### PR TITLE
Strip leading date prefixes from titles in trace.NewID

### DIFF
--- a/internal/cortex/cortex.go
+++ b/internal/cortex/cortex.go
@@ -237,6 +237,11 @@ Choose the type that best reflects the **intent** of the memory:
 
 1. Pick a type and write your content.
 2. Generate an ID: today's date + slugified title, e.g. ` + "`20260330-decision-to-use-sqlite`" + `.
+   **Do not include the date in the title** — the ID generator adds today's date
+   automatically. A leading ` + "`YYYYMMDD-`" + ` or ` + "`YYYY-MM-DD-`" + ` in the title
+   is stripped before the ID is built so you don't end up with two date prefixes.
+   If a trace is *about* a specific date, put that information in the body or in
+   a tag (e.g. ` + "`tags: [event-2026-04-02]`" + `) instead of the title.
 3. Write the file to ` + "`traces/<id>.md`" + ` with the frontmatter shown above.
 4. Run ` + "`noema sync`" + ` (if available) to update the database index.
 

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -112,13 +112,54 @@ func (t *Trace) Write(path string) error {
 }
 
 // NewID generates a trace ID from a title: YYYYMMDD-slugified-title.
+//
+// If the slugified title already begins with a date prefix (either
+// `YYYYMMDD-` or `YYYY-MM-DD-`), the leading date is stripped before
+// today's date is prepended. This is a defensive measure: agents
+// commonly include dates in titles to mark when an event occurred
+// (e.g., "20260402 dadbot heartbeat check"), and without the strip
+// the resulting ID would carry two date prefixes
+// (`20260402-20260402-dadbot-heartbeat-check`). The strip does not
+// validate that the digits form a real calendar date — its only job
+// is to prevent visual prefix duplication in the final ID.
 func NewID(title string) string {
 	date := time.Now().UTC().Format("20060102")
-	s := slug(title)
+	s := stripLeadingDatePrefix(slug(title))
 	if len(s) > 60 {
 		s = strings.TrimRight(s[:60], "-")
 	}
 	return date + "-" + s
+}
+
+// stripLeadingDatePrefix removes a leading date prefix from s if one is
+// present. It recognises two forms:
+//
+//	YYYYMMDD-     (8 digits + hyphen)         e.g. "20260402-foo" -> "foo"
+//	YYYY-MM-DD-   (4-2-2 digits with hyphens) e.g. "2026-04-02-foo" -> "foo"
+//
+// Anything else — including titles where digits appear later in the
+// string ("divergence-20260402-foo", "2026-was-a-year") — is returned
+// unchanged.
+func stripLeadingDatePrefix(s string) string {
+	// YYYYMMDD- form (9 chars).
+	if len(s) >= 9 && s[8] == '-' && allDigits(s[:8]) {
+		return s[9:]
+	}
+	// YYYY-MM-DD- form (11 chars).
+	if len(s) >= 11 && s[4] == '-' && s[7] == '-' && s[10] == '-' &&
+		allDigits(s[:4]) && allDigits(s[5:7]) && allDigits(s[8:10]) {
+		return s[11:]
+	}
+	return s
+}
+
+func allDigits(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 func slug(s string) string {

--- a/internal/trace/trace_test.go
+++ b/internal/trace/trace_test.go
@@ -168,6 +168,66 @@ func TestNewID_Unicode(t *testing.T) {
 	}
 }
 
+func TestNewID_StripsLeadingDatePrefix(t *testing.T) {
+	date := time.Now().UTC().Format("20060102")
+
+	cases := []struct {
+		name     string
+		title    string
+		wantSlug string
+	}{
+		{
+			name:     "YYYYMMDD prefix with space separator",
+			title:    "20260402 dadbot autonomous infrastructure access",
+			wantSlug: "dadbot-autonomous-infrastructure-access",
+		},
+		{
+			name:     "YYYYMMDD prefix already slug-shaped",
+			title:    "20260402-dadbot-autonomous-infrastructure-access",
+			wantSlug: "dadbot-autonomous-infrastructure-access",
+		},
+		{
+			name:     "YYYY-MM-DD prefix with space separator",
+			title:    "2026-04-02 ai news digest",
+			wantSlug: "ai-news-digest",
+		},
+		{
+			name:     "YYYY-MM-DD prefix already slug-shaped",
+			title:    "2026-04-02-ai-news-digest",
+			wantSlug: "ai-news-digest",
+		},
+		{
+			name:     "embedded date is not stripped",
+			title:    "divergence-20260402-original-trace",
+			wantSlug: "divergence-20260402-original-trace",
+		},
+		{
+			name:     "four-digit year alone is not stripped",
+			title:    "2026 was a year",
+			wantSlug: "2026-was-a-year",
+		},
+		{
+			name:     "eight digits without trailing hyphen are not stripped",
+			title:    "20260402dadbot",
+			wantSlug: "20260402dadbot",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			id := trace.NewID(tc.title)
+			wantPrefix := date + "-"
+			if !strings.HasPrefix(id, wantPrefix) {
+				t.Fatalf("ID %q does not start with today's date %q", id, wantPrefix)
+			}
+			gotSlug := strings.TrimPrefix(id, wantPrefix)
+			if gotSlug != tc.wantSlug {
+				t.Errorf("slug = %q, want %q (full id: %q)", gotSlug, tc.wantSlug, id)
+			}
+		})
+	}
+}
+
 // ---- IsValidType ----
 
 func TestIsValidType(t *testing.T) {


### PR DESCRIPTION
## Summary

- `trace.NewID` now strips a leading `YYYYMMDD-` or `YYYY-MM-DD-` from the slugified title before prepending today's date, eliminating the `20260402-20260402-dadbot-heartbeat-check` doubled-prefix bug that has been silently producing ugly IDs in production cortexes for at least the last week.
- `get_instructions` (the live reference guide returned by the MCP `get_instructions` tool) now tells agents not to include dates in titles and explains that the ID generator adds today's date automatically.
- Adds a table-driven `TestNewID_StripsLeadingDatePrefix` covering both date forms, both separator styles (space vs already-slug-shaped), and three negative cases to lock in what is *not* stripped.

## Why

A Hermes agent reported that `list_traces` on `agentbrain` was returning IDs like `20260402-20260402-dadbot-autonomous-infrastructure-access`, and `get_trace` only worked with the duplicated form because the duplicated form was the literal stored ID. Inspection of `~/.noema/agentbrain/traces/` on `ai-1` turned up ~30 traces with the same pattern, going back to 2026-03-30. Root cause: agents are using the leading date in titles as a "this is *about* date X" semantic marker (one trace was even submitted on April 2 about an April 1 heartbeat — `20260402-20260401-dadbot-heartbeat-check-8-36pm.md`), and `NewID` had no defense against the duplication.

The agent intent — putting context in the title — is reasonable. The fix accommodates it: titles can contain whatever the agent finds descriptive, the ID stays clean. The instructions update tells future agents the cleaner pattern (date in body or tag, not title) so the underlying habit shifts over time too.

## What's *not* in this PR

Existing traces with the doubled prefix in production cortexes are **left as-is**. A rename migration would have to:

- Rename the on-disk filename (`traces/<old>.md` → `traces/<new>.md`)
- Update every DB foreign key (`traces`, `trace_tags`, `trace_lineage`, `traces_fts`, `events`)
- Emit new create+delete events that the federation event log on every peer can replay coherently

That last requirement is the blocker — events are immutable by design, and there's currently no `rename` action in the federation protocol. Designing one is a separate piece of work that deserves its own conversation. The duplicated IDs function correctly today; only their visual form is bad. This PR stops the bleeding; an optional follow-up `noema migrate trace-ids` command can clean up historical data if and when the ugly IDs become operationally annoying.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` all packages green
- [x] `go test -v -run TestNewID ./internal/trace/...` — all 7 new subtests pass:
  - `YYYYMMDD prefix with space separator` → date stripped
  - `YYYYMMDD prefix already slug-shaped` → date stripped
  - `YYYY-MM-DD prefix with space separator` → date stripped
  - `YYYY-MM-DD prefix already slug-shaped` → date stripped
  - `embedded date is not stripped` (`divergence-20260402-foo`) → preserved (this protects the divergence ID generation at `cortex.go:1754`)
  - `four-digit year alone is not stripped` (`2026 was a year`) → preserved
  - `eight digits without trailing hyphen are not stripped` (`20260402dadbot`) → preserved
- [x] After merge + binary push: create a fresh trace via MCP `create_trace` with title `"20260407 verification trace"` and confirm the resulting ID is `20260407-verification-trace`, not `20260407-20260407-verification-trace`

## Breaking changes

None. The fix only changes how *new* trace IDs are generated. Existing traces, federation events, vector clocks, lineage edges, and on-disk filenames are all unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)