### PR TITLE
feat(mcp): enforce shared-key auth with CORS-aware middleware

### DIFF
--- a/internal/cli/cmd_serve.go
+++ b/internal/cli/cmd_serve.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http"
 	"os"
 	"os/user"
 	"strings"
@@ -68,18 +69,56 @@ func serveCmd() *cobra.Command {
 			case "stdio", "":
 				err = mcpgo.ServeStdio(s)
 			case "http":
+				// Read the manifest BEFORE validateHTTPServe so the
+				// access-key resolution and the keyed-TLS check below
+				// share the same view of cortex.md with everything
+				// downstream (syncer, middleware).
+				m, manifestErr := cortex.ReadManifest(cx.Dir)
+				if manifestErr != nil {
+					return fmt.Errorf("reading cortex.md: %w", manifestErr)
+				}
+
+				// Resolve the shared MCP access key: NOEMA_MCP_KEY env
+				// var > sidecar file > open mode. Errors here are hard
+				// stops — misconfigured auth must not silently downgrade
+				// to open mode.
+				accessKey, accessErr := cortex.LoadAccessKey(cx.Dir, m.Access)
+				if accessErr != nil {
+					return fmt.Errorf("loading MCP access key: %w", accessErr)
+				}
+				if accessKey.EnvOverride() {
+					fmt.Printf("[serve] %s overrides access.shared_key_file at %s\n",
+						cortex.AccessKeyEnvVar, accessKey.Path)
+				}
+
 				if err := validateHTTPServe(host, tlsCert, tlsKey, cx.Name, cortexFlag != ""); err != nil {
 					return err
 				}
 				useTLS := tlsCert != "" && tlsKey != ""
 
-				// Federation only runs over the HTTP transport (peers need
-				// an HTTP endpoint to call sync_events on). Start the
-				// syncer only when the bound cortex actually has peers
-				// configured.
-				m, manifestErr := cortex.ReadManifest(cx.Dir)
-				if manifestErr == nil && m.Federation != nil && len(m.Federation.Peers) > 0 {
-					syncer = startSyncer(cx)
+				if err := requireTLSForKeyedMode(accessKey, useTLS); err != nil {
+					return err
+				}
+
+				// Federation only runs over the HTTP transport (peers
+				// need an HTTP endpoint to call sync_events on). Start
+				// the syncer only when the bound cortex actually has
+				// peers configured. Pass the shared key so outbound
+				// sync calls carry the same Authorization header the
+				// middleware enforces on inbound calls (ring model).
+				if m.Federation != nil && len(m.Federation.Peers) > 0 {
+					syncer = startSyncer(cx, accessKey.Value)
+				}
+
+				// Surface the access posture on startup. The
+				// fingerprint lets two operators confirm they're
+				// running the same key without speaking the secret
+				// itself.
+				if accessKey.Keyed() {
+					fmt.Printf("[serve] access=keyed source=%s fingerprint=%s\n",
+						accessKey.Source, accessKey.Fingerprint)
+				} else {
+					fmt.Printf("[serve] access=open\n")
 				}
 
 				// IPv6 addresses need brackets in listen addresses.
@@ -89,20 +128,42 @@ func serveCmd() *cobra.Command {
 				}
 				addr := fmt.Sprintf("%s:%d", hostForAddr, port)
 
-				httpOpts := []mcpgo.StreamableHTTPOption{
-					mcpgo.WithEndpointPath("/mcp"),
+				// Build the MCP handler. No WithEndpointPath — our
+				// own mux routes /mcp. No WithTLSCert — we drive
+				// ListenAndServeTLS ourselves so the middleware chain
+				// wraps the handler cleanly. NewStreamableHTTPServer
+				// still starts mcp-go's session sweeper, which is the
+				// only side effect of that call we care about.
+				mcpHandler := mcpgo.NewStreamableHTTPServer(s)
+
+				// Middleware chain: CORS (outermost) → Auth → mcpHandler.
+				// CORS is outermost because preflight (OPTIONS) cannot
+				// carry credentials by spec and must not be 401'd.
+				// AuthMiddleware("") is a pass-through in open mode.
+				wrapped := mcpserver.CORSMiddleware(
+					mcpserver.AuthMiddleware(accessKey.Value)(mcpHandler),
+				)
+
+				// Our own mux so non-/mcp paths return 404 cleanly
+				// instead of being dispatched through the MCP handler.
+				mux := http.NewServeMux()
+				mux.Handle("/mcp", wrapped)
+
+				httpSrv := &http.Server{
+					Addr:    addr,
+					Handler: mux,
 				}
-				if useTLS {
-					httpOpts = append(httpOpts, mcpgo.WithTLSCert(tlsCert, tlsKey))
-				}
-				httpServer := mcpgo.NewStreamableHTTPServer(s, httpOpts...)
 
 				scheme := "http"
 				if useTLS {
 					scheme = "https"
 				}
 				fmt.Printf("Starting Streamable HTTP server on %s://%s/mcp\n", scheme, addr)
-				err = httpServer.Start(addr)
+				if useTLS {
+					err = httpSrv.ListenAndServeTLS(tlsCert, tlsKey)
+				} else {
+					err = httpSrv.ListenAndServe()
+				}
 			case "sse":
 				err = fmt.Errorf(
 					"the legacy `sse` transport was removed in this release: noema now speaks Streamable HTTP (MCP 2025-03-26).\n" +
@@ -132,8 +193,10 @@ func serveCmd() *cobra.Command {
 
 // startSyncer reads the cortex manifest and, if federation peers are configured,
 // starts a background syncer that polls remote peers for new events.
-// Returns nil if federation is not configured.
-func startSyncer(cx *cortex.Cortex) *federation.Syncer {
+// Returns nil if federation is not configured. sharedKey is attached as an
+// Authorization: Bearer header on every outbound sync when non-empty; pass ""
+// for open-mode peers.
+func startSyncer(cx *cortex.Cortex, sharedKey string) *federation.Syncer {
 	m, err := cortex.ReadManifest(cx.Dir)
 	if err != nil || m.Federation == nil || len(m.Federation.Peers) == 0 {
 		return nil
@@ -150,13 +213,32 @@ func startSyncer(cx *cortex.Cortex) *federation.Syncer {
 	}
 
 	state := federation.NewState(cx.DB.DB)
-	cfg := federation.Config{Peers: peers, Interval: interval}
+	cfg := federation.Config{Peers: peers, Interval: interval, SharedKey: sharedKey}
 
 	syncer := federation.NewSyncer(cx, state, cfg)
 	syncer.Start()
 
 	fmt.Printf("Federation syncer started (%d peers, interval %s)\n", len(peers), cfg.EffectiveInterval())
 	return syncer
+}
+
+// requireTLSForKeyedMode returns a startup error when shared-key auth is
+// active but TLS is not configured. A bearer token sent over plaintext HTTP
+// is stolen by the first adversary on the network path, so the combination
+// is worse than open mode: it creates the appearance of security while
+// leaking the key on every request. Making this a hard error — not a
+// warning — is consistent with the --host guardrail's fail-fast posture.
+// See docs/design/mcp-auth-plan.md §4.
+func requireTLSForKeyedMode(access cortex.AccessKey, useTLS bool) error {
+	if !access.Keyed() || useTLS {
+		return nil
+	}
+	return fmt.Errorf(
+		"refusing to serve MCP auth over plaintext HTTP: access.shared_key_file is set (source=%s) but --tls-cert/--tls-key are not configured.\n"+
+			"  A bearer token sent without TLS is stolen by the first adversary on the network path.\n"+
+			"  Provide --tls-cert and --tls-key, or remove access.shared_key_file from cortex.md to run in open mode.",
+		access.Source,
+	)
 }
 
 // validateHTTPServe enforces the flag invariants for `noema serve --transport

--- a/internal/cli/cmd_serve_test.go
+++ b/internal/cli/cmd_serve_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/xml"
 	"strings"
 	"testing"
+
+	"github.com/Fail-Safe/Noema/internal/cortex"
 )
 
 // TestValidateHTTPServe pins the flag invariants for `noema serve --transport
@@ -478,6 +480,78 @@ func TestRunPrintLaunchdPlist_HappyPath(t *testing.T) {
 	}
 	if !strings.Contains(s, "com.fail-safe.noema.agentbrain") {
 		t.Errorf("plist label does not include cortex name:\n%s", s)
+	}
+}
+
+// TestRequireTLSForKeyedMode pins the auth-requires-TLS guard: shared-key
+// mode over plaintext HTTP is a worse security posture than open mode (it
+// leaks the key on every request while creating the appearance of security),
+// so the combination is a hard startup error. The guard must fire for both
+// "file" and "env" sources, must be a no-op in open mode, and must be a
+// no-op when TLS is configured.
+func TestRequireTLSForKeyedMode(t *testing.T) {
+	cases := []struct {
+		name          string
+		access        cortex.AccessKey
+		useTLS        bool
+		wantErrSubstr string // empty = expect nil
+	}{
+		{
+			name:   "open mode no TLS — fine",
+			access: cortex.AccessKey{}, // Keyed() == false
+			useTLS: false,
+		},
+		{
+			name:   "open mode with TLS — fine",
+			access: cortex.AccessKey{},
+			useTLS: true,
+		},
+		{
+			name:   "keyed mode with TLS — fine",
+			access: cortex.AccessKey{Value: "k", Source: "file", Fingerprint: "SHA256:aa"},
+			useTLS: true,
+		},
+		{
+			name:          "keyed mode from file, no TLS — reject",
+			access:        cortex.AccessKey{Value: "k", Source: "file", Path: ".access.secret"},
+			useTLS:        false,
+			wantErrSubstr: "source=file",
+		},
+		{
+			name:          "keyed mode from env, no TLS — reject",
+			access:        cortex.AccessKey{Value: "k", Source: "env"},
+			useTLS:        false,
+			wantErrSubstr: "source=env",
+		},
+		{
+			name:          "keyed mode error mentions plaintext",
+			access:        cortex.AccessKey{Value: "k", Source: "file"},
+			useTLS:        false,
+			wantErrSubstr: "plaintext HTTP",
+		},
+		{
+			name:          "keyed mode error suggests remediation",
+			access:        cortex.AccessKey{Value: "k", Source: "file"},
+			useTLS:        false,
+			wantErrSubstr: "--tls-cert and --tls-key",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := requireTLSForKeyedMode(tc.access, tc.useTLS)
+			if tc.wantErrSubstr == "" {
+				if err != nil {
+					t.Fatalf("expected nil, got: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErrSubstr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErrSubstr) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.wantErrSubstr)
+			}
+		})
 	}
 }
 

--- a/internal/federation/federation.go
+++ b/internal/federation/federation.go
@@ -15,6 +15,12 @@ type PeerConfig struct {
 type Config struct {
 	Peers    []PeerConfig  `yaml:"peers,omitempty"`
 	Interval time.Duration // parsed from string
+
+	// SharedKey is the MCP bearer token this syncer attaches to every
+	// outbound request as "Authorization: Bearer <SharedKey>". Empty
+	// means open mode (no header sent). Populated at startup from
+	// cortex.LoadAccessKey; never surfaced in YAML, logs, or events.
+	SharedKey string `yaml:"-"`
 }
 
 // EffectiveInterval returns the configured interval or the default.

--- a/internal/federation/syncer.go
+++ b/internal/federation/syncer.go
@@ -202,6 +202,15 @@ func (s *Syncer) syncPeer(peer PeerConfig) error {
 		}
 		clientOpts = append(clientOpts, transport.WithHTTPBasicClient(httpClient))
 	}
+	if s.config.SharedKey != "" {
+		// Ring-model auth: the same key the middleware enforces on
+		// incoming requests is attached to every outbound sync. Peers
+		// in mismatched modes (one keyed, one open) will 401 each
+		// other — by design; see docs/design/mcp-auth-plan.md.
+		clientOpts = append(clientOpts, transport.WithHTTPHeaders(map[string]string{
+			"Authorization": "Bearer " + s.config.SharedKey,
+		}))
+	}
 	mcpClient, err := client.NewStreamableHttpClient(mcpURL, clientOpts...)
 	if err != nil {
 		return fmt.Errorf("creating Streamable HTTP client: %w", err)

--- a/internal/mcp/middleware.go
+++ b/internal/mcp/middleware.go
@@ -1,0 +1,71 @@
+package mcp
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"net/http"
+)
+
+// CORSMiddleware adds permissive CORS headers to every response and
+// short-circuits OPTIONS preflight requests with 204 No Content.
+//
+// mcp-go's StreamableHTTPServer returns 404 for any method other than
+// POST/GET/DELETE (streamable_http.go:254-255), so without this layer
+// browser-based MCP clients (Zed, custom dashboards, anything running
+// in a WebView) fail their preflight and never get to the real request.
+// The CORS layer sits OUTSIDE AuthMiddleware because the CORS spec
+// forbids sending credentials on preflight — a browser that can't
+// complete preflight can't authenticate in the first place.
+func CORSMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// These headers are safe to set on every response. CORS-aware
+		// clients use them; non-browser callers ignore them.
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "POST, GET, DELETE, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, Mcp-Session-Id")
+		w.Header().Set("Access-Control-Expose-Headers", "Mcp-Session-Id")
+
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// AuthMiddleware returns a middleware that gates the wrapped handler
+// behind a shared bearer key. When sharedKey is empty, the returned
+// middleware is a pass-through (open mode): no header is required and
+// no comparison runs.
+//
+// When keyed, the middleware computes a SHA-256 prehash of the
+// expected "Bearer <key>" string once at construction, and hashes the
+// incoming Authorization header on every request. The two 32-byte
+// digests are compared with subtle.ConstantTimeCompare. Prehashing
+// both sides closes a subtle timing leak: ConstantTimeCompare returns
+// 0 immediately when its inputs differ in length, which would let a
+// probing attacker recover the expected-key length bit by bit. After
+// prehashing, both sides are always 32 bytes regardless of the
+// attacker's guess, so length is never observable.
+//
+// There are zero MCP-method carve-outs. initialize, tools/list,
+// tools/call for every tool, resources/list, ping — all gated. See
+// Design Decision #3 in docs/design/mcp-auth-plan.md for why.
+func AuthMiddleware(sharedKey string) func(http.Handler) http.Handler {
+	if sharedKey == "" {
+		return func(next http.Handler) http.Handler { return next }
+	}
+	expected := sha256.Sum256([]byte("Bearer " + sharedKey))
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			got := sha256.Sum256([]byte(r.Header.Get("Authorization")))
+			if subtle.ConstantTimeCompare(got[:], expected[:]) != 1 {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"error":"unauthorized: NOEMA_MCP_KEY / access.shared_key_file required"}`))
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/mcp/middleware_test.go
+++ b/internal/mcp/middleware_test.go
@@ -1,0 +1,286 @@
+package mcp_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	mcpserver "github.com/Fail-Safe/Noema/internal/mcp"
+)
+
+// okHandler is a sentinel downstream handler that records whether it
+// was called and returns 200 with a fixed body.
+func okHandler(called *bool) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if called != nil {
+			*called = true
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+}
+
+// ---- AuthMiddleware ----
+
+func TestAuthMiddleware_OpenMode_PassesRequestsThrough(t *testing.T) {
+	called := false
+	h := mcpserver.AuthMiddleware("")(okHandler(&called))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader("{}"))
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rr.Code)
+	}
+	if !called {
+		t.Error("downstream handler was not called in open mode")
+	}
+}
+
+func TestAuthMiddleware_OpenMode_IgnoresHeaderPresence(t *testing.T) {
+	// A random Authorization header should not trip anything in open mode.
+	called := false
+	h := mcpserver.AuthMiddleware("")(okHandler(&called))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer totally-wrong")
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (open mode ignores header content)", rr.Code)
+	}
+	if !called {
+		t.Error("downstream handler was not called")
+	}
+}
+
+func TestAuthMiddleware_Keyed_MissingHeader(t *testing.T) {
+	called := false
+	h := mcpserver.AuthMiddleware("s3cret")(okHandler(&called))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rr.Code)
+	}
+	if called {
+		t.Error("downstream handler must not be called on 401")
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	body, _ := io.ReadAll(rr.Body)
+	if !strings.Contains(string(body), "unauthorized") {
+		t.Errorf("body does not mention unauthorized: %q", string(body))
+	}
+}
+
+func TestAuthMiddleware_Keyed_WrongBearerValue(t *testing.T) {
+	called := false
+	h := mcpserver.AuthMiddleware("s3cret")(okHandler(&called))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer not-the-right-one")
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rr.Code)
+	}
+	if called {
+		t.Error("downstream handler must not be called on 401")
+	}
+}
+
+func TestAuthMiddleware_Keyed_WrongScheme(t *testing.T) {
+	// Basic auth, Digest, or a raw token without a scheme must all 401.
+	h := mcpserver.AuthMiddleware("s3cret")(okHandler(nil))
+
+	cases := []string{
+		"Basic czNjcmV0",   // base64("s3cret") under Basic
+		"s3cret",           // raw value, no scheme
+		"bearer s3cret",    // lowercase scheme (bearer != Bearer byte-for-byte)
+		"Bearer  s3cret",   // extra space
+		"Bearer s3cret\r\n", // trailing junk
+	}
+	for _, h3 := range cases {
+		t.Run(h3, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+			req.Header.Set("Authorization", h3)
+			h.ServeHTTP(rr, req)
+			if rr.Code != http.StatusUnauthorized {
+				t.Errorf("Authorization=%q → status %d, want 401", h3, rr.Code)
+			}
+		})
+	}
+}
+
+func TestAuthMiddleware_Keyed_CorrectBearer(t *testing.T) {
+	called := false
+	h := mcpserver.AuthMiddleware("s3cret")(okHandler(&called))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer s3cret")
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rr.Code)
+	}
+	if !called {
+		t.Error("downstream handler was not called on valid auth")
+	}
+}
+
+func TestAuthMiddleware_Keyed_LongKeyStillWorks(t *testing.T) {
+	// A 256-char key must still compare correctly after prehash.
+	longKey := strings.Repeat("a", 256)
+	h := mcpserver.AuthMiddleware(longKey)(okHandler(nil))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer "+longKey)
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 for long key", rr.Code)
+	}
+}
+
+func TestAuthMiddleware_Keyed_EmptyHeaderRejectedButNotCrashing(t *testing.T) {
+	// Empty Authorization header (set to "") must be rejected — and
+	// must not crash the prehash path with a zero-length input.
+	h := mcpserver.AuthMiddleware("s3cret")(okHandler(nil))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set("Authorization", "")
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401 for empty header", rr.Code)
+	}
+}
+
+// ---- CORSMiddleware ----
+
+func TestCORSMiddleware_SetsHeadersOnRegularRequest(t *testing.T) {
+	called := false
+	h := mcpserver.CORSMiddleware(okHandler(&called))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	h.ServeHTTP(rr, req)
+
+	if !called {
+		t.Error("downstream handler was not called")
+	}
+	if rr.Header().Get("Access-Control-Allow-Origin") != "*" {
+		t.Error("Access-Control-Allow-Origin missing")
+	}
+	if !strings.Contains(rr.Header().Get("Access-Control-Allow-Methods"), "POST") {
+		t.Error("Access-Control-Allow-Methods missing POST")
+	}
+	if !strings.Contains(rr.Header().Get("Access-Control-Allow-Headers"), "Authorization") {
+		t.Error("Access-Control-Allow-Headers must include Authorization (browsers need it to send Bearer)")
+	}
+	if !strings.Contains(rr.Header().Get("Access-Control-Allow-Headers"), "Mcp-Session-Id") {
+		t.Error("Access-Control-Allow-Headers must include Mcp-Session-Id (MCP session tracking)")
+	}
+}
+
+func TestCORSMiddleware_OptionsShortCircuits(t *testing.T) {
+	// The whole point: OPTIONS must never reach mcp-go (which returns 404)
+	// and must succeed with 204 No Content.
+	called := false
+	h := mcpserver.CORSMiddleware(okHandler(&called))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodOptions, "/mcp", nil)
+	req.Header.Set("Origin", "https://example.com")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	req.Header.Set("Access-Control-Request-Headers", "authorization, content-type")
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Errorf("status = %d, want 204", rr.Code)
+	}
+	if called {
+		t.Error("downstream handler must not be called for OPTIONS")
+	}
+	if rr.Header().Get("Access-Control-Allow-Origin") != "*" {
+		t.Error("preflight response missing Access-Control-Allow-Origin")
+	}
+}
+
+// ---- CORS + Auth chain ----
+
+func TestCORSAuthChain_OptionsBypassesAuthEvenInKeyedMode(t *testing.T) {
+	// CORS preflight has no Authorization header by spec. If the chain
+	// ordering is wrong (auth outside CORS), preflight would 401 and
+	// the browser would never send the real request.
+	called := false
+	inner := mcpserver.AuthMiddleware("s3cret")(okHandler(&called))
+	h := mcpserver.CORSMiddleware(inner)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodOptions, "/mcp", nil)
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Errorf("preflight status = %d, want 204 (auth must not reject OPTIONS)", rr.Code)
+	}
+	if called {
+		t.Error("downstream handler must not run for preflight")
+	}
+}
+
+func TestCORSAuthChain_PostStillRequiresAuth(t *testing.T) {
+	called := false
+	inner := mcpserver.AuthMiddleware("s3cret")(okHandler(&called))
+	h := mcpserver.CORSMiddleware(inner)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("POST without auth: status = %d, want 401", rr.Code)
+	}
+	if called {
+		t.Error("downstream handler must not be called without auth")
+	}
+	// CORS headers should still be present on the 401 so browser
+	// clients see a useful error (not a CORS-blocked opaque failure).
+	if rr.Header().Get("Access-Control-Allow-Origin") != "*" {
+		t.Error("401 response missing CORS header — browser will show an opaque error")
+	}
+}
+
+func TestCORSAuthChain_PostWithAuthSucceeds(t *testing.T) {
+	called := false
+	inner := mcpserver.AuthMiddleware("s3cret")(okHandler(&called))
+	h := mcpserver.CORSMiddleware(inner)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer s3cret")
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("authenticated POST status = %d, want 200", rr.Code)
+	}
+	if !called {
+		t.Error("downstream handler was not called on authenticated POST")
+	}
+	if rr.Header().Get("Access-Control-Allow-Origin") != "*" {
+		t.Error("200 response missing CORS header")
+	}
+}


### PR DESCRIPTION
## Summary

Wires the `AccessKey` plumbing from #4 into the HTTP serve path. New middleware package, custom `http.Server` wrapping mcp-go's `StreamableHTTPServer` as a plain `http.Handler`, and matching outbound header injection in the federation syncer.

**This is the PR that actually turns auth on.** Without it, #4 is a dormant loader.

- **`internal/mcp/middleware.go`** — `CORSMiddleware` + `AuthMiddleware`.
  - CORS is the **outermost** layer so preflight `OPTIONS` never hits auth (browsers can't send credentials on preflight per spec). Without this layer, browser-based MCP clients (Zed, dashboards) fail preflight and never get to the real request.
  - `AuthMiddleware` prehashes `"Bearer <key>"` once at construction and compares with `subtle.ConstantTimeCompare`. Prehashing closes a length-leak: `ConstantTimeCompare` returns 0 immediately when its inputs differ in length, which would let a probing attacker recover the expected-key length bit by bit. After prehashing, both sides are always 32 bytes.
  - Open mode (empty key) returns a pass-through. No per-method carve-outs — `initialize`, `tools/list`, every tool call, `ping` — all gated.
- **`internal/federation/{federation,syncer}.go`** — `Config.SharedKey` (`yaml:"-"`, never serialized) is populated at startup and attached via `transport.WithHTTPHeaders` on every outbound sync. Peers in mismatched modes 401 each other by design.
- **`internal/cli/cmd_serve.go`** — loads the access key before building the mcp-go handler, logs the mode + SHA256 fingerprint, and refuses to start keyed-mode HTTP without TLS (`requireTLSForKeyedMode`). Mounts our own `ServeMux` at `/mcp` so we control the middleware chain; the old `WithEndpointPath`/`WithTLSCert` shortcuts are gone.

Threat model: `docs/design/mcp-auth-plan.md`.

## Files

- `internal/mcp/middleware.go` — 71 lines, two middlewares
- `internal/mcp/middleware_test.go` — 286 lines, 14 cases
- `internal/cli/cmd_serve.go` — 116 lines changed (chain wiring + TLS guard)
- `internal/cli/cmd_serve_test.go` — 74 lines added (7 TLS-guard cases)
- `internal/federation/federation.go` + `syncer.go` — 15 lines, outbound header injection

## Test plan

- [x] `go test ./internal/mcp/... ./internal/cli/... ./internal/federation/...` — all 14 middleware + 7 TLS-guard cases pass locally
- [x] `go build ./...` — clean
- [x] **Production drill** executed across three federated hosts (ai-1, ai-2, ai-3). 9-phase rollout/rollback plan, all gates passed:
  - Phase 1 (deploy + open-mode compat): ✓ (after diagnosing a zombie process on ai-1 and deleted-inode mmap on ai-2/ai-3 — binary replacement without restart is a real operator footgun worth documenting separately)
  - Phase 2 (env-var keyed rollout, asymmetric states): ✓ Half-duplex 401s at expected transitions; ring self-heals once all three peers match
  - Phase 3 (negative test — wrong key on one peer): ✓ Selective isolation, retroactive self-heal on key fix
  - Phase 5 (0600 permissions guard): ✓ 0640/0644 rejected with clear error; the error message tells operators exactly what to chmod
  - Phase 7 (TLS guard): ✓ Keyed-mode HTTP without `--tls-cert`/`--tls-key` refused at startup with a three-line operator-grade error (what's wrong, why it matters, two fix paths)
  - Phase 9 (full rollback): ✓ Ring returns to fully-open federation with unattended recovery, canary round-trip in <60s
- [x] CORS preflight bypasses auth: verified with `curl -X OPTIONS` against production endpoints
- [x] `subtle.ConstantTimeCompare` length-leak closed: prehashing produces constant 32-byte inputs regardless of attacker guess

Stacked on #4; blocks #(c).

🤖 Generated with [Claude Code](https://claude.com/claude-code)