### PR TITLE
fix(mcp): land PRs #5 and #6 content into next

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,13 +110,15 @@ noema events backfill [--dry-run] [--yes]
 noema resolve <divergence-id> --accept <origin> | --custom <body>
                                           Resolve a divergence (concurrent edit conflict)
 
-noema federation status                   Show federation config, peer sync state, and vector clock
+noema federation status                   Show federation config, MCP access posture, peer sync state, and vector clock
 noema federation peers                    List configured federation peers
 noema federation add-peer <name> <endpoint>
                                           Add a federation peer to cortex.md
 noema federation reset-peer <name>...     Clear stored state for a peer (forces a fresh handshake; use after a peer
                                           ran `noema migrate cortex-id --reset` and the syncer is now reporting an
                                           identity mismatch)
+noema federation key fingerprint          Print the SHA-256 fingerprint of the active MCP shared key (safe to
+                                          say aloud over an out-of-band channel to confirm a pairing)
 
 noema serve [--transport stdio|http] [--host <addr>] [--tls-cert <file> --tls-key <file>]
                                           Start the MCP server (http requires --host; endpoint is /mcp)

--- a/internal/cli/cmd_federation.go
+++ b/internal/cli/cmd_federation.go
@@ -23,8 +23,77 @@ func federationCmd() *cobra.Command {
 		federationPeersCmd(),
 		federationAddPeerCmd(),
 		federationResetPeerCmd(),
+		federationKeyCmd(),
 	)
 	return cmd
+}
+
+// federationKeyCmd groups subcommands that inspect or manage the MCP shared
+// access key. `fingerprint` is the only subcommand for now; rotate / path /
+// show-source are natural follow-ons that live under the same umbrella.
+func federationKeyCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "key",
+		Short: "Inspect or manage the MCP shared access key",
+	}
+	cmd.AddCommand(federationKeyFingerprintCmd())
+	return cmd
+}
+
+// federationKeyFingerprintCmd prints the SHA-256 fingerprint of the
+// currently-active shared key, resolved via the same env > file > open
+// priority chain `noema serve` uses. It exists so two operators can
+// confirm they're holding the same key over an out-of-band channel
+// (Signal, phone) without speaking the secret itself — the fingerprint
+// is safe to say aloud.
+func federationKeyFingerprintCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "fingerprint",
+		Short: "Print the SHA-256 fingerprint of the active MCP shared key",
+		Long: `Resolves the active MCP shared key using the same priority chain as ` + "`noema serve`" + `:
+NOEMA_MCP_KEY > access.shared_key_file > open mode. Prints the SHA-256
+fingerprint of the key (SSH-style format, safe to say aloud) so two
+operators can confirm over an out-of-band channel that they're holding
+the same secret.
+
+In open mode (no key configured), prints a message and exits successfully.`,
+		Example: "  noema federation key fingerprint\n  NOEMA_MCP_KEY=... noema federation key fingerprint",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cx, err := resolveCortex()
+			if err != nil {
+				return err
+			}
+			defer cx.Close()
+
+			m, err := cortex.ReadManifest(cx.Dir)
+			if err != nil {
+				return fmt.Errorf("reading cortex.md: %w", err)
+			}
+
+			key, err := cortex.LoadAccessKey(cx.Dir, m.Access)
+			if err != nil {
+				return fmt.Errorf("loading access key: %w", err)
+			}
+
+			out := cmd.OutOrStdout()
+			if !key.Keyed() {
+				fmt.Fprintf(out, "Cortex:      %s\n", cx.Name)
+				fmt.Fprintln(out, "Access:      open mode (no key configured)")
+				return nil
+			}
+
+			fmt.Fprintf(out, "Cortex:      %s\n", cx.Name)
+			fmt.Fprintf(out, "Source:      %s\n", key.Source)
+			if key.Path != "" {
+				fmt.Fprintf(out, "Path:        %s\n", key.Path)
+			}
+			fmt.Fprintf(out, "Fingerprint: %s\n", key.Fingerprint)
+			if key.EnvOverride() {
+				fmt.Fprintf(out, "Note:        %s is overriding access.shared_key_file\n", cortex.AccessKeyEnvVar)
+			}
+			return nil
+		},
+	}
 }
 
 func federationStatusCmd() *cobra.Command {
@@ -43,7 +112,22 @@ func federationStatusCmd() *cobra.Command {
 				m = cortex.Manifest{Name: cx.Name}
 			}
 
-			fmt.Printf("Cortex: %s\n\n", m.Name)
+			fmt.Printf("Cortex: %s\n", m.Name)
+
+			// Surface the active MCP access posture regardless of whether
+			// federation is configured. An operator inspecting status on a
+			// stdio-only cortex still wants to know whether the same cortex
+			// would come up keyed or open if they flipped it to http.
+			// Resolution errors here are non-fatal: print a warning line
+			// and keep going so the rest of the status output still lands.
+			if key, err := cortex.LoadAccessKey(cx.Dir, m.Access); err != nil {
+				fmt.Printf("Access: error loading key: %v\n", err)
+			} else if key.Keyed() {
+				fmt.Printf("Access: keyed (source=%s, fingerprint=%s)\n", key.Source, key.Fingerprint)
+			} else {
+				fmt.Println("Access: open")
+			}
+			fmt.Println()
 
 			if m.Federation == nil || len(m.Federation.Peers) == 0 {
 				fmt.Println("Federation: not configured (no peers in cortex.md)")

--- a/internal/cli/cmd_federation_test.go
+++ b/internal/cli/cmd_federation_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -317,5 +318,258 @@ func withConfigForCortex(t *testing.T, cx *cortex.Cortex) {
 	}
 	if err := cfg.Save(); err != nil {
 		t.Fatalf("cfg.Save: %v", err)
+	}
+}
+
+// writeSidecarKeyFile drops a sidecar key file at <cortexDir>/<rel> with
+// mode 0o600 and rewrites cortex.md so access.shared_key_file points at
+// it. Tests use this to exercise the file-source branch of the
+// fingerprint command without plumbing a whole file-loader fake.
+func writeSidecarKeyFile(t *testing.T, cx *cortex.Cortex, rel, key string) {
+	t.Helper()
+	path := filepath.Join(cx.Dir, rel)
+	if err := os.WriteFile(path, []byte(key+"\n"), 0o600); err != nil {
+		t.Fatalf("write sidecar %s: %v", path, err)
+	}
+	m, err := cortex.ReadManifest(cx.Dir)
+	if err != nil {
+		t.Fatalf("ReadManifest: %v", err)
+	}
+	m.Access = &cortex.AccessConfig{SharedKeyFile: rel}
+	if err := cortex.WriteManifest(cx.Dir, m); err != nil {
+		t.Fatalf("WriteManifest: %v", err)
+	}
+}
+
+// ---- federation status (access line) ----
+
+// TestFederationStatus_ShowsAccessLineOpenMode pins that `noema
+// federation status` surfaces the active MCP access posture on every
+// run, even on a cortex with no peers. The access line has to come
+// before the "Federation: not configured" message so an operator
+// inspecting a fresh cortex can tell keyed vs open at a glance.
+func TestFederationStatus_ShowsAccessLineOpenMode(t *testing.T) {
+	cx := newCortexWithPeers(t, "solo") // no peers variadic arg
+	withConfigForCortex(t, cx)
+	t.Setenv(cortex.AccessKeyEnvVar, "")
+
+	// Capture os.Stdout. federationStatusCmd prints through fmt.Printf
+	// directly rather than cmd.OutOrStdout, so we have to redirect
+	// os.Stdout. The alternative (plumbing an io.Writer through the
+	// RunE) is out of scope for PR (c).
+	out := captureStdout(t, func() {
+		cmd := federationStatusCmd()
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "Access: open") {
+		t.Errorf("output missing 'Access: open' line:\n%s", out)
+	}
+	// Ordering matters: Access line must come before the federation
+	// block so the top-of-output summary is always consistent.
+	accessIdx := strings.Index(out, "Access:")
+	fedIdx := strings.Index(out, "Federation:")
+	if accessIdx < 0 || fedIdx < 0 || accessIdx > fedIdx {
+		t.Errorf("Access line must appear before Federation line:\n%s", out)
+	}
+}
+
+// TestFederationStatus_ShowsAccessLineKeyedMode pins that env-sourced
+// keyed mode is surfaced with source + fingerprint and, critically,
+// that the raw key does not leak into status output. `noema
+// federation status` is the thing operators are likely to paste into
+// a bug report or support channel, so the "no raw key" invariant
+// matters more here than anywhere else in the codebase.
+func TestFederationStatus_ShowsAccessLineKeyedMode(t *testing.T) {
+	cx := newCortexWithPeers(t, "solo")
+	withConfigForCortex(t, cx)
+	const key = "not-a-real-key-for-tests"
+	t.Setenv(cortex.AccessKeyEnvVar, key)
+
+	out := captureStdout(t, func() {
+		cmd := federationStatusCmd()
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "Access: keyed") {
+		t.Errorf("output missing 'Access: keyed' line:\n%s", out)
+	}
+	if !strings.Contains(out, "source=env") {
+		t.Errorf("output missing source=env:\n%s", out)
+	}
+	if !strings.Contains(out, cortex.KeyFingerprint(key)) {
+		t.Errorf("output missing fingerprint:\n%s", out)
+	}
+	if strings.Contains(out, key) {
+		t.Errorf("SECURITY: raw key leaked in status output:\n%s", out)
+	}
+}
+
+// captureStdout redirects os.Stdout for the duration of f and returns
+// everything written to it. federationStatusCmd bypasses cmd.OutOrStdout
+// in favor of fmt.Printf, so this indirection is the only way to
+// assert on its output without rewriting the command.
+func captureStdout(t *testing.T, f func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		var buf bytes.Buffer
+		_, _ = buf.ReadFrom(r)
+		done <- buf.String()
+	}()
+	f()
+	_ = w.Close()
+	os.Stdout = orig
+	return <-done
+}
+
+// ---- federation key fingerprint ----
+
+// TestFederationKeyFingerprint_OpenMode pins that a cortex with no access
+// config and no NOEMA_MCP_KEY reports open mode rather than erroring.
+// This is the "query whether I'm keyed" use case — the command must be
+// callable on any cortex and must answer truthfully without tripping on
+// the absence of a key.
+func TestFederationKeyFingerprint_OpenMode(t *testing.T) {
+	cx := newCortexWithPeers(t, "alpha")
+	withConfigForCortex(t, cx)
+	t.Setenv(cortex.AccessKeyEnvVar, "")
+
+	var out bytes.Buffer
+	cmd := federationKeyFingerprintCmd()
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v\noutput:\n%s", err, out.String())
+	}
+	s := out.String()
+	if !strings.Contains(s, "open mode") {
+		t.Errorf("output does not report open mode:\n%s", s)
+	}
+	if strings.Contains(s, "Fingerprint:") {
+		t.Errorf("open mode output must not print a Fingerprint line:\n%s", s)
+	}
+}
+
+// TestFederationKeyFingerprint_EnvKey pins the env-sourced path: when
+// NOEMA_MCP_KEY is set, the command reports Source: env and the
+// fingerprint. The exact fingerprint is derived from cortex.KeyFingerprint
+// so we can assert on it byte-for-byte without duplicating the SHA-256
+// logic in the test.
+func TestFederationKeyFingerprint_EnvKey(t *testing.T) {
+	cx := newCortexWithPeers(t, "alpha")
+	withConfigForCortex(t, cx)
+	const key = "test-shared-key-123"
+	t.Setenv(cortex.AccessKeyEnvVar, key)
+
+	var out bytes.Buffer
+	cmd := federationKeyFingerprintCmd()
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v\noutput:\n%s", err, out.String())
+	}
+	s := out.String()
+
+	for _, want := range []string{
+		"Source:      env",
+		"Fingerprint: " + cortex.KeyFingerprint(key),
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("output missing %q:\n%s", want, s)
+		}
+	}
+	// Critical: the raw key must never appear in output. This is the
+	// whole point of the fingerprint — it's the thing you can say over
+	// Signal without compromising the secret.
+	if strings.Contains(s, key) {
+		t.Errorf("SECURITY: raw key leaked in fingerprint output:\n%s", s)
+	}
+}
+
+// TestFederationKeyFingerprint_FileKey pins the sidecar-file path: a
+// cortex with access.shared_key_file pointing at a valid sidecar resolves
+// to Source: file and the correct fingerprint, and also surfaces the
+// absolute Path so an operator can see which file is in play.
+func TestFederationKeyFingerprint_FileKey(t *testing.T) {
+	cx := newCortexWithPeers(t, "alpha")
+	withConfigForCortex(t, cx)
+	t.Setenv(cortex.AccessKeyEnvVar, "")
+
+	const key = "file-sourced-key-abc"
+	writeSidecarKeyFile(t, cx, ".access.secret", key)
+
+	var out bytes.Buffer
+	cmd := federationKeyFingerprintCmd()
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v\noutput:\n%s", err, out.String())
+	}
+	s := out.String()
+
+	for _, want := range []string{
+		"Source:      file",
+		"Fingerprint: " + cortex.KeyFingerprint(key),
+		".access.secret", // Path line includes the filename
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("output missing %q:\n%s", want, s)
+		}
+	}
+	if strings.Contains(s, key) {
+		t.Errorf("SECURITY: raw key leaked in fingerprint output:\n%s", s)
+	}
+}
+
+// TestFederationKeyFingerprint_EnvOverridesFile pins the override-warning
+// branch: when both a sidecar file AND NOEMA_MCP_KEY are present, the
+// env wins (that's the design) but the command must surface the
+// override so the operator knows why the sidecar file they thought
+// was active isn't. Without this the override is silent and the next
+// operator inherits a confusing "why is my fingerprint wrong" puzzle.
+func TestFederationKeyFingerprint_EnvOverridesFile(t *testing.T) {
+	cx := newCortexWithPeers(t, "alpha")
+	withConfigForCortex(t, cx)
+
+	const fileKey = "from-file"
+	const envKey = "from-env-wins"
+	writeSidecarKeyFile(t, cx, ".access.secret", fileKey)
+	t.Setenv(cortex.AccessKeyEnvVar, envKey)
+
+	var out bytes.Buffer
+	cmd := federationKeyFingerprintCmd()
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute: %v\noutput:\n%s", err, out.String())
+	}
+	s := out.String()
+
+	if !strings.Contains(s, "Source:      env") {
+		t.Errorf("expected env source:\n%s", s)
+	}
+	// The reported fingerprint must match the env key, not the file
+	// key — the whole point of this test is that env wins.
+	if !strings.Contains(s, cortex.KeyFingerprint(envKey)) {
+		t.Errorf("fingerprint does not match env key:\n%s", s)
+	}
+	if strings.Contains(s, cortex.KeyFingerprint(fileKey)) {
+		t.Errorf("fingerprint unexpectedly matches overridden file key:\n%s", s)
+	}
+	// The override note is the "loud failure" — without it the
+	// operator can't tell why their sidecar file isn't being used.
+	if !strings.Contains(s, "NOEMA_MCP_KEY is overriding") {
+		t.Errorf("output missing env-override warning:\n%s", s)
 	}
 }

--- a/internal/cli/cmd_serve.go
+++ b/internal/cli/cmd_serve.go
@@ -40,7 +40,7 @@ func serveCmd() *cobra.Command {
 		Aliases: []string{"server"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if printConfig {
-				return runPrintMCPConfig()
+				return runPrintMCPConfig(cmd.OutOrStdout(), transport, host, port, tlsCert, tlsKey)
 			}
 			if printSystemdUnit {
 				return runPrintSystemdUnit(cmd.OutOrStdout(), transport, host, port, tlsCert, tlsKey)
@@ -376,15 +376,28 @@ func runPrintLaunchdPlist(out io.Writer, transport, host string, port int, tlsCe
 	// Install hint to stderr so `--print-launchd-plist > foo.plist`
 	// writes only the plist to the file while the operator still sees
 	// the install commands in their terminal.
+	plistPath := fmt.Sprintf("~/Library/LaunchAgents/%s.plist", label)
 	fmt.Fprintf(os.Stderr, "# Generated LaunchAgent plist for Noema cortex %q.\n", cortexFlag)
 	fmt.Fprintln(os.Stderr, "# Install with:")
 	fmt.Fprintln(os.Stderr, "#")
 	fmt.Fprintf(os.Stderr, "#   noema serve %s --print-launchd-plist \\\n", strings.Join(serveArgs[1:], " "))
-	fmt.Fprintf(os.Stderr, "#     > ~/Library/LaunchAgents/%s.plist\n", label)
-	fmt.Fprintf(os.Stderr, "#   launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/%s.plist\n", label)
+	fmt.Fprintf(os.Stderr, "#     > %s\n", plistPath)
+	fmt.Fprintf(os.Stderr, "#   launchctl bootstrap gui/$(id -u) %s\n", plistPath)
+	fmt.Fprintln(os.Stderr, "#")
+	fmt.Fprintln(os.Stderr, "# KEYED MODE (MCP shared-key auth):")
+	fmt.Fprintf(os.Stderr, "#   The plist contains an EnvironmentVariables block with NOEMA_MCP_KEY=%s\n", launchdKeyPlaceholder)
+	fmt.Fprintln(os.Stderr, "#   launchd has no EnvironmentFile= equivalent, so the key must live inside")
+	fmt.Fprintln(os.Stderr, "#   the plist itself. Before loading, edit the plist and replace the")
+	fmt.Fprintln(os.Stderr, "#   placeholder with your real bearer token, then tighten permissions:")
+	fmt.Fprintln(os.Stderr, "#")
+	fmt.Fprintf(os.Stderr, "#     chmod 600 %s\n", plistPath)
+	fmt.Fprintln(os.Stderr, "#")
+	fmt.Fprintln(os.Stderr, "# OPEN MODE (no auth):")
+	fmt.Fprintln(os.Stderr, "#   Delete the entire <key>EnvironmentVariables</key>...</dict> block")
+	fmt.Fprintln(os.Stderr, "#   before loading. The server will come up in open mode.")
 	fmt.Fprintln(os.Stderr, "#")
 	fmt.Fprintf(os.Stderr, "# Tail logs: tail -f ~/Library/Logs/noema-%s.log\n", cortexFlag)
-	fmt.Fprintf(os.Stderr, "# Stop:      launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/%s.plist\n", label)
+	fmt.Fprintf(os.Stderr, "# Stop:      launchctl bootout gui/$(id -u) %s\n", plistPath)
 	fmt.Fprintln(os.Stderr)
 
 	plist := buildLaunchdPlist(launchdPlistParams{
@@ -413,7 +426,18 @@ type systemdUnitParams struct {
 // directory and can break legitimate setups where the cortex lives
 // outside ~/.noema. Operators who want hardening can add it manually;
 // the generated unit works out of the box, which is the goal.
+//
+// The generator is pure-flag and emits the same unit whether the target
+// cortex is keyed or open: the EnvironmentFile= line uses a leading "-"
+// so systemd treats it as optional, which means open-mode cortexes
+// simply ignore the missing file, and keyed-mode cortexes get their
+// NOEMA_MCP_KEY injected when the operator drops the env file in place.
+// That keeps the print path testable without loading a live cortex and
+// lets operators flip between open and keyed mode without regenerating
+// the unit.
 func buildSystemdUnit(p systemdUnitParams) string {
+	envFile := "%h/.config/noema/" + p.Cortex + ".env"
+
 	var b strings.Builder
 	fmt.Fprintf(&b, "# Noema memory server (%s)\n", p.Cortex)
 	fmt.Fprintln(&b, "#")
@@ -423,6 +447,15 @@ func buildSystemdUnit(p systemdUnitParams) string {
 	fmt.Fprintf(&b, "#     | sudo tee /etc/systemd/system/noema-%s.service\n", p.Cortex)
 	fmt.Fprintln(&b, "#   sudo systemctl daemon-reload")
 	fmt.Fprintf(&b, "#   sudo systemctl enable --now noema-%s\n", p.Cortex)
+	fmt.Fprintln(&b, "#")
+	fmt.Fprintln(&b, "# For keyed-mode MCP auth, create the env file before first start:")
+	fmt.Fprintln(&b, "#")
+	fmt.Fprintf(&b, "#   install -d -m 700 ~/.config/noema\n")
+	fmt.Fprintf(&b, "#   umask 077 && printf 'NOEMA_MCP_KEY=<paste-key>\\n' > %s\n", envFile)
+	fmt.Fprintf(&b, "#   chmod 600 %s\n", envFile)
+	fmt.Fprintln(&b, "#")
+	fmt.Fprintln(&b, "# The EnvironmentFile= line below is prefixed with `-` so the unit")
+	fmt.Fprintln(&b, "# still starts in open mode when the env file is absent.")
 	fmt.Fprintln(&b, "#")
 	fmt.Fprintf(&b, "# Tail logs: sudo journalctl -u noema-%s -f\n", p.Cortex)
 	fmt.Fprintf(&b, "# Restart:   sudo systemctl restart noema-%s\n", p.Cortex)
@@ -437,6 +470,7 @@ func buildSystemdUnit(p systemdUnitParams) string {
 	fmt.Fprintln(&b, "[Service]")
 	fmt.Fprintln(&b, "Type=simple")
 	fmt.Fprintf(&b, "User=%s\n", p.User)
+	fmt.Fprintf(&b, "EnvironmentFile=-%s\n", envFile)
 	fmt.Fprintf(&b, "ExecStart=%s %s\n", p.Exe, strings.Join(p.ServeArgs, " "))
 	fmt.Fprintln(&b, "Restart=on-failure")
 	fmt.Fprintln(&b, "RestartSec=5s")
@@ -455,6 +489,19 @@ type launchdPlistParams struct {
 	HomeDir   string   // user home dir (from os.UserHomeDir) for log path
 	ServeArgs []string // argv after the binary path, starting with "serve"
 }
+
+// launchdKeyPlaceholder is the literal value emitted in the plist's
+// EnvironmentVariables dict for NOEMA_MCP_KEY. Operators must replace
+// it with the real key before loading the plist, OR delete the whole
+// EnvironmentVariables block for open mode. The stderr install hints
+// printed by runPrintLaunchdPlist call this out explicitly.
+//
+// launchd has no equivalent of systemd's EnvironmentFile= directive, so
+// unlike the systemd unit we cannot reference an external secret file:
+// the plist itself becomes secret-bearing in keyed mode. The placeholder
+// makes that requirement visible in the generated file rather than
+// leaving it buried in documentation.
+const launchdKeyPlaceholder = "REPLACE_WITH_BEARER_KEY_OR_DELETE_THIS_DICT"
 
 // buildLaunchdPlist renders a per-user LaunchAgent plist. Every text value
 // that could come from user input (cortex name, paths) is run through
@@ -481,6 +528,11 @@ func buildLaunchdPlist(p launchdPlistParams) string {
 		fmt.Fprintf(&b, "        <string>%s</string>\n", xmlEscape(arg))
 	}
 	fmt.Fprintln(&b, "    </array>")
+	fmt.Fprintln(&b, "    <key>EnvironmentVariables</key>")
+	fmt.Fprintln(&b, "    <dict>")
+	fmt.Fprintln(&b, "        <key>NOEMA_MCP_KEY</key>")
+	fmt.Fprintf(&b, "        <string>%s</string>\n", xmlEscape(launchdKeyPlaceholder))
+	fmt.Fprintln(&b, "    </dict>")
 	fmt.Fprintln(&b, "    <key>RunAtLoad</key>")
 	fmt.Fprintln(&b, "    <true/>")
 	fmt.Fprintln(&b, "    <key>KeepAlive</key>")
@@ -508,9 +560,27 @@ func xmlEscape(s string) string {
 }
 
 // runPrintMCPConfig writes a ready-to-use .mcp.json snippet to stdout.
-// It resolves the binary path via os.Executable and the cortex name via the
-// same priority chain used by resolveCortex (flag > env > config default).
-func runPrintMCPConfig() error {
+// For stdio transport (the default), it emits a `command` + `args` entry
+// that Claude Code and other stdio-based MCP clients expect. For http
+// transport, it emits a `url` + `headers` entry pointing at the
+// /mcp Streamable HTTP endpoint with an Authorization header literal
+// of "Bearer ${NOEMA_MCP_KEY}". That placeholder is emitted verbatim
+// rather than pulling the live key for two reasons:
+//
+//  1. the file is typically committed to source control alongside the
+//     rest of the repo's .mcp.json, and
+//  2. MCP clients that support env interpolation in headers (Claude
+//     Code does) will resolve it at runtime, while clients that do not
+//     will produce an obvious 401 with a bearer string they can search
+//     for and edit, rather than a silent "wrong key" failure.
+//
+// The cortex name is resolved via the same priority chain as resolveCortex
+// (flag > env > config default). Transport-specific flags are plumbed
+// through from RunE so a single `noema serve --print-config --transport
+// http --host 10.0.0.1 ...` invocation produces the exact config a
+// remote client would need, including the URL scheme that matches the
+// --tls-cert/--tls-key pair.
+func runPrintMCPConfig(out io.Writer, transport, host string, port int, tlsCert, tlsKey string) error {
 	exe, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("resolving executable path: %w", err)
@@ -528,20 +598,60 @@ func runPrintMCPConfig() error {
 		name = cfg.Default
 	}
 
-	serveArgs := []string{"serve"}
-	if name != "" {
-		serveArgs = append(serveArgs, "--cortex", name)
+	var entry map[string]any
+	switch transport {
+	case "http":
+		// For the http entry we must be able to form a URL, so --host
+		// and --port are required. --tls-cert/--tls-key are optional;
+		// their presence determines https vs. http. We reuse
+		// validateHTTPServe's sub-checks (host required, not 0.0.0.0,
+		// tls pair coherent) but don't gate on cortexExplicit here —
+		// the .mcp.json snippet is emitted for a client that's talking
+		// TO a server, not launching one, so there's no network-
+		// exposure risk in printing an http config without --cortex.
+		if host == "" {
+			return fmt.Errorf("--print-config --transport http requires --host (the address a client will dial, e.g. 10.0.0.1 or my.lan)")
+		}
+		if ip := net.ParseIP(host); ip != nil && ip.IsUnspecified() {
+			return fmt.Errorf("--host %s is a wildcard bind address; pass the address clients should dial instead", host)
+		}
+		if (tlsCert == "") != (tlsKey == "") {
+			return fmt.Errorf("--tls-cert and --tls-key must be provided together")
+		}
+		scheme := "http"
+		if tlsCert != "" && tlsKey != "" {
+			scheme = "https"
+		}
+		// IPv6 addresses need brackets in URLs.
+		hostForURL := host
+		if ip := net.ParseIP(host); ip != nil && ip.To4() == nil {
+			hostForURL = "[" + host + "]"
+		}
+		entry = map[string]any{
+			"url": fmt.Sprintf("%s://%s:%d/mcp", scheme, hostForURL, port),
+			"headers": map[string]any{
+				"Authorization": "Bearer ${NOEMA_MCP_KEY}",
+			},
+		}
+	case "stdio", "":
+		serveArgs := []string{"serve"}
+		if name != "" {
+			serveArgs = append(serveArgs, "--cortex", name)
+		}
+		entry = map[string]any{
+			"command": exe,
+			"args":    serveArgs,
+		}
+	default:
+		return fmt.Errorf("--print-config does not support --transport %q (use stdio or http)", transport)
 	}
 
-	out := map[string]any{
+	payload := map[string]any{
 		"mcpServers": map[string]any{
-			"noema": map[string]any{
-				"command": exe,
-				"args":    serveArgs,
-			},
+			"noema": entry,
 		},
 	}
-	enc := json.NewEncoder(os.Stdout)
+	enc := json.NewEncoder(out)
 	enc.SetIndent("", "  ")
-	return enc.Encode(out)
+	return enc.Encode(payload)
 }

--- a/internal/cli/cmd_serve.go
+++ b/internal/cli/cmd_serve.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"net/http"
 	"os"
 	"os/user"
 	"strings"
@@ -68,18 +69,56 @@ func serveCmd() *cobra.Command {
 			case "stdio", "":
 				err = mcpgo.ServeStdio(s)
 			case "http":
+				// Read the manifest BEFORE validateHTTPServe so the
+				// access-key resolution and the keyed-TLS check below
+				// share the same view of cortex.md with everything
+				// downstream (syncer, middleware).
+				m, manifestErr := cortex.ReadManifest(cx.Dir)
+				if manifestErr != nil {
+					return fmt.Errorf("reading cortex.md: %w", manifestErr)
+				}
+
+				// Resolve the shared MCP access key: NOEMA_MCP_KEY env
+				// var > sidecar file > open mode. Errors here are hard
+				// stops — misconfigured auth must not silently downgrade
+				// to open mode.
+				accessKey, accessErr := cortex.LoadAccessKey(cx.Dir, m.Access)
+				if accessErr != nil {
+					return fmt.Errorf("loading MCP access key: %w", accessErr)
+				}
+				if accessKey.EnvOverride() {
+					fmt.Printf("[serve] %s overrides access.shared_key_file at %s\n",
+						cortex.AccessKeyEnvVar, accessKey.Path)
+				}
+
 				if err := validateHTTPServe(host, tlsCert, tlsKey, cx.Name, cortexFlag != ""); err != nil {
 					return err
 				}
 				useTLS := tlsCert != "" && tlsKey != ""
 
-				// Federation only runs over the HTTP transport (peers need
-				// an HTTP endpoint to call sync_events on). Start the
-				// syncer only when the bound cortex actually has peers
-				// configured.
-				m, manifestErr := cortex.ReadManifest(cx.Dir)
-				if manifestErr == nil && m.Federation != nil && len(m.Federation.Peers) > 0 {
-					syncer = startSyncer(cx)
+				if err := requireTLSForKeyedMode(accessKey, useTLS); err != nil {
+					return err
+				}
+
+				// Federation only runs over the HTTP transport (peers
+				// need an HTTP endpoint to call sync_events on). Start
+				// the syncer only when the bound cortex actually has
+				// peers configured. Pass the shared key so outbound
+				// sync calls carry the same Authorization header the
+				// middleware enforces on inbound calls (ring model).
+				if m.Federation != nil && len(m.Federation.Peers) > 0 {
+					syncer = startSyncer(cx, accessKey.Value)
+				}
+
+				// Surface the access posture on startup. The
+				// fingerprint lets two operators confirm they're
+				// running the same key without speaking the secret
+				// itself.
+				if accessKey.Keyed() {
+					fmt.Printf("[serve] access=keyed source=%s fingerprint=%s\n",
+						accessKey.Source, accessKey.Fingerprint)
+				} else {
+					fmt.Printf("[serve] access=open\n")
 				}
 
 				// IPv6 addresses need brackets in listen addresses.
@@ -89,20 +128,42 @@ func serveCmd() *cobra.Command {
 				}
 				addr := fmt.Sprintf("%s:%d", hostForAddr, port)
 
-				httpOpts := []mcpgo.StreamableHTTPOption{
-					mcpgo.WithEndpointPath("/mcp"),
+				// Build the MCP handler. No WithEndpointPath — our
+				// own mux routes /mcp. No WithTLSCert — we drive
+				// ListenAndServeTLS ourselves so the middleware chain
+				// wraps the handler cleanly. NewStreamableHTTPServer
+				// still starts mcp-go's session sweeper, which is the
+				// only side effect of that call we care about.
+				mcpHandler := mcpgo.NewStreamableHTTPServer(s)
+
+				// Middleware chain: CORS (outermost) → Auth → mcpHandler.
+				// CORS is outermost because preflight (OPTIONS) cannot
+				// carry credentials by spec and must not be 401'd.
+				// AuthMiddleware("") is a pass-through in open mode.
+				wrapped := mcpserver.CORSMiddleware(
+					mcpserver.AuthMiddleware(accessKey.Value)(mcpHandler),
+				)
+
+				// Our own mux so non-/mcp paths return 404 cleanly
+				// instead of being dispatched through the MCP handler.
+				mux := http.NewServeMux()
+				mux.Handle("/mcp", wrapped)
+
+				httpSrv := &http.Server{
+					Addr:    addr,
+					Handler: mux,
 				}
-				if useTLS {
-					httpOpts = append(httpOpts, mcpgo.WithTLSCert(tlsCert, tlsKey))
-				}
-				httpServer := mcpgo.NewStreamableHTTPServer(s, httpOpts...)
 
 				scheme := "http"
 				if useTLS {
 					scheme = "https"
 				}
 				fmt.Printf("Starting Streamable HTTP server on %s://%s/mcp\n", scheme, addr)
-				err = httpServer.Start(addr)
+				if useTLS {
+					err = httpSrv.ListenAndServeTLS(tlsCert, tlsKey)
+				} else {
+					err = httpSrv.ListenAndServe()
+				}
 			case "sse":
 				err = fmt.Errorf(
 					"the legacy `sse` transport was removed in this release: noema now speaks Streamable HTTP (MCP 2025-03-26).\n" +
@@ -132,8 +193,10 @@ func serveCmd() *cobra.Command {
 
 // startSyncer reads the cortex manifest and, if federation peers are configured,
 // starts a background syncer that polls remote peers for new events.
-// Returns nil if federation is not configured.
-func startSyncer(cx *cortex.Cortex) *federation.Syncer {
+// Returns nil if federation is not configured. sharedKey is attached as an
+// Authorization: Bearer header on every outbound sync when non-empty; pass ""
+// for open-mode peers.
+func startSyncer(cx *cortex.Cortex, sharedKey string) *federation.Syncer {
 	m, err := cortex.ReadManifest(cx.Dir)
 	if err != nil || m.Federation == nil || len(m.Federation.Peers) == 0 {
 		return nil
@@ -150,13 +213,32 @@ func startSyncer(cx *cortex.Cortex) *federation.Syncer {
 	}
 
 	state := federation.NewState(cx.DB.DB)
-	cfg := federation.Config{Peers: peers, Interval: interval}
+	cfg := federation.Config{Peers: peers, Interval: interval, SharedKey: sharedKey}
 
 	syncer := federation.NewSyncer(cx, state, cfg)
 	syncer.Start()
 
 	fmt.Printf("Federation syncer started (%d peers, interval %s)\n", len(peers), cfg.EffectiveInterval())
 	return syncer
+}
+
+// requireTLSForKeyedMode returns a startup error when shared-key auth is
+// active but TLS is not configured. A bearer token sent over plaintext HTTP
+// is stolen by the first adversary on the network path, so the combination
+// is worse than open mode: it creates the appearance of security while
+// leaking the key on every request. Making this a hard error — not a
+// warning — is consistent with the --host guardrail's fail-fast posture.
+// See docs/design/mcp-auth-plan.md §4.
+func requireTLSForKeyedMode(access cortex.AccessKey, useTLS bool) error {
+	if !access.Keyed() || useTLS {
+		return nil
+	}
+	return fmt.Errorf(
+		"refusing to serve MCP auth over plaintext HTTP: access.shared_key_file is set (source=%s) but --tls-cert/--tls-key are not configured.\n"+
+			"  A bearer token sent without TLS is stolen by the first adversary on the network path.\n"+
+			"  Provide --tls-cert and --tls-key, or remove access.shared_key_file from cortex.md to run in open mode.",
+		access.Source,
+	)
 }
 
 // validateHTTPServe enforces the flag invariants for `noema serve --transport

--- a/internal/cli/cmd_serve_test.go
+++ b/internal/cli/cmd_serve_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"encoding/xml"
 	"strings"
 	"testing"
@@ -552,6 +553,275 @@ func TestRequireTLSForKeyedMode(t *testing.T) {
 				t.Errorf("error %q does not contain %q", err.Error(), tc.wantErrSubstr)
 			}
 		})
+	}
+}
+
+// --------- buildSystemdUnit auth plumbing ---------
+
+// TestBuildSystemdUnit_EmitsOptionalEnvironmentFile pins the shared-key
+// plumbing in the generated unit. The line must be present, use a
+// leading "-" so open-mode cortexes are not broken by a missing file,
+// and live inside the [Service] section (not [Unit]) — a misplaced
+// EnvironmentFile= is silently ignored by systemd and produces a unit
+// that looks fine but never injects NOEMA_MCP_KEY.
+func TestBuildSystemdUnit_EmitsOptionalEnvironmentFile(t *testing.T) {
+	out := buildSystemdUnit(systemdUnitParams{
+		Cortex:    "agentbrain",
+		User:      "mark",
+		Exe:       "/usr/local/bin/noema",
+		ServeArgs: []string{"serve", "--cortex", "agentbrain", "--transport", "http", "--host", "127.0.0.1"},
+	})
+
+	// The "-" prefix is load-bearing: without it, systemd refuses to
+	// start the unit when the env file does not exist, which is the
+	// default state for open-mode cortexes. The test pins the exact
+	// path form so a refactor that changes ~/.config to /etc (or
+	// drops the "-") is caught here.
+	const wantLine = "EnvironmentFile=-%h/.config/noema/agentbrain.env"
+	if !strings.Contains(out, wantLine) {
+		t.Errorf("unit missing optional EnvironmentFile line %q\nfull:\n%s", wantLine, out)
+	}
+
+	// Structurally verify the directive lives in [Service]. We look
+	// at the substring between [Service] and [Install] to make sure
+	// EnvironmentFile= isn't sitting in [Unit] where systemd would
+	// silently ignore it.
+	svcIdx := strings.Index(out, "[Service]")
+	instIdx := strings.Index(out, "[Install]")
+	if svcIdx < 0 || instIdx < 0 || svcIdx >= instIdx {
+		t.Fatalf("unit is missing [Service] or [Install] section:\n%s", out)
+	}
+	serviceBlock := out[svcIdx:instIdx]
+	if !strings.Contains(serviceBlock, "EnvironmentFile=-") {
+		t.Errorf("EnvironmentFile is not inside [Service] section:\n%s", out)
+	}
+}
+
+// TestBuildSystemdUnit_IncludesKeyedModeInstallInstructions pins that
+// the header comment explains how to populate the env file for keyed
+// mode. If the instructions regress, operators will install the unit
+// expecting keyed mode to "just work" and hit a 401 on first peer
+// sync instead of getting the env file checklist up front.
+func TestBuildSystemdUnit_IncludesKeyedModeInstallInstructions(t *testing.T) {
+	out := buildSystemdUnit(systemdUnitParams{
+		Cortex:    "agentbrain",
+		User:      "mark",
+		Exe:       "/usr/local/bin/noema",
+		ServeArgs: []string{"serve", "--cortex", "agentbrain", "--transport", "http", "--host", "127.0.0.1"},
+	})
+	for _, want := range []string{
+		"keyed-mode MCP auth",
+		"NOEMA_MCP_KEY=<paste-key>",
+		"chmod 600",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("install comment missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// --------- buildLaunchdPlist auth plumbing ---------
+
+// TestBuildLaunchdPlist_EmitsEnvironmentVariablesBlock pins the shape
+// of the EnvironmentVariables dict: one key named NOEMA_MCP_KEY, with
+// a placeholder value operators must replace before loading the plist.
+// launchd has no EnvironmentFile= equivalent, so the key lives in the
+// plist itself — this test exists so a refactor can't silently drop
+// the dict (which would downgrade every keyed-mode Mac to open mode).
+func TestBuildLaunchdPlist_EmitsEnvironmentVariablesBlock(t *testing.T) {
+	out := buildLaunchdPlist(launchdPlistParams{
+		Cortex:    "agentbrain",
+		Exe:       "/usr/local/bin/noema",
+		HomeDir:   "/Users/mark",
+		ServeArgs: []string{"serve", "--cortex", "agentbrain", "--transport", "http", "--host", "127.0.0.1"},
+	})
+	for _, want := range []string{
+		"<key>EnvironmentVariables</key>",
+		"<key>NOEMA_MCP_KEY</key>",
+		"<string>" + launchdKeyPlaceholder + "</string>",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("plist missing fragment %q\nfull:\n%s", want, out)
+		}
+	}
+
+	// The placeholder must NOT look like a real key. If someone ever
+	// changes it to a short, plausible-looking string an operator
+	// could skip the install warning and load the plist with a
+	// literal "s3cret" as NOEMA_MCP_KEY. The "REPLACE" marker is the
+	// anti-footgun: it's ugly on purpose so `launchd load` surfaces
+	// the 401 immediately.
+	if !strings.Contains(launchdKeyPlaceholder, "REPLACE") {
+		t.Errorf("placeholder %q does not obviously require replacement", launchdKeyPlaceholder)
+	}
+
+	// The emitted plist must still be valid XML — adding a nested
+	// dict is easy to get wrong (unclosed <dict>), and if it does we
+	// want to catch it in CI, not when an operator runs launchctl
+	// bootstrap. Re-run the full parse to be sure.
+	dec := xml.NewDecoder(bytes.NewBufferString(out))
+	for {
+		_, err := dec.Token()
+		if err != nil {
+			if err.Error() == "EOF" {
+				break
+			}
+			t.Fatalf("plist with EnvironmentVariables is not valid XML: %v\nfull:\n%s", err, out)
+		}
+	}
+}
+
+// --------- runPrintMCPConfig ---------
+
+// TestRunPrintMCPConfig_StdioShape pins the stdio output: a single
+// mcpServers.noema entry with command/args, no url/headers. This is
+// the shape Claude Code and every other stdio-based MCP client
+// expects; regressing to the http form here would silently break
+// local-only workflows.
+func TestRunPrintMCPConfig_StdioShape(t *testing.T) {
+	prev := cortexFlag
+	cortexFlag = "agentbrain"
+	t.Cleanup(func() { cortexFlag = prev })
+
+	var buf bytes.Buffer
+	if err := runPrintMCPConfig(&buf, "stdio", "", 0, "", ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var parsed struct {
+		McpServers map[string]struct {
+			Command string   `json:"command"`
+			Args    []string `json:"args"`
+			URL     string   `json:"url"`
+			Headers map[string]string
+		} `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput:\n%s", err, buf.String())
+	}
+	entry, ok := parsed.McpServers["noema"]
+	if !ok {
+		t.Fatalf("output missing mcpServers.noema:\n%s", buf.String())
+	}
+	if entry.Command == "" {
+		t.Errorf("stdio entry missing command:\n%s", buf.String())
+	}
+	if entry.URL != "" {
+		t.Errorf("stdio entry must not include url:\n%s", buf.String())
+	}
+	if entry.Headers != nil {
+		t.Errorf("stdio entry must not include headers:\n%s", buf.String())
+	}
+	// The --cortex flag must be part of args so the generated config
+	// pins exactly the cortex the operator was viewing at print time.
+	found := false
+	for _, a := range entry.Args {
+		if a == "agentbrain" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("stdio entry args do not pin --cortex agentbrain: %v", entry.Args)
+	}
+}
+
+// TestRunPrintMCPConfig_HTTPShape pins the http output: url + headers
+// with the Authorization placeholder literal. This is the whole point
+// of the PR (c) work — a Claude Code client pointing at a keyed
+// remote peer needs the bearer header in the config, and the
+// placeholder form lets operators commit the file to source control
+// without leaking the key.
+func TestRunPrintMCPConfig_HTTPShape(t *testing.T) {
+	var buf bytes.Buffer
+	if err := runPrintMCPConfig(&buf, "http", "10.0.0.1", 3443, "/tls.crt", "/tls.key"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var parsed struct {
+		McpServers map[string]struct {
+			URL     string            `json:"url"`
+			Headers map[string]string `json:"headers"`
+			Command string            `json:"command"`
+		} `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &parsed); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput:\n%s", err, buf.String())
+	}
+	entry := parsed.McpServers["noema"]
+
+	if entry.Command != "" {
+		t.Errorf("http entry must not include command:\n%s", buf.String())
+	}
+	// TLS flags present → https scheme; port included; /mcp path.
+	wantURL := "https://10.0.0.1:3443/mcp"
+	if entry.URL != wantURL {
+		t.Errorf("url = %q, want %q", entry.URL, wantURL)
+	}
+	// The Authorization header must be the literal placeholder. We
+	// DO NOT expand env vars here — the whole point is that the
+	// client (Claude Code) performs the expansion at runtime, and
+	// the file is safe to commit.
+	wantAuth := "Bearer ${NOEMA_MCP_KEY}"
+	if got := entry.Headers["Authorization"]; got != wantAuth {
+		t.Errorf("Authorization header = %q, want %q", got, wantAuth)
+	}
+}
+
+// TestRunPrintMCPConfig_HTTPNoTLS pins that http (without --tls-cert)
+// produces an http:// URL, not https://. Getting this wrong would
+// point the generated client config at the wrong scheme and every
+// request would fail on TLS handshake before the 401 even runs.
+func TestRunPrintMCPConfig_HTTPNoTLS(t *testing.T) {
+	var buf bytes.Buffer
+	if err := runPrintMCPConfig(&buf, "http", "127.0.0.1", 3000, "", ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "http://127.0.0.1:3000/mcp") {
+		t.Errorf("no-TLS http mode should emit http:// URL:\n%s", buf.String())
+	}
+	if strings.Contains(buf.String(), "https://") {
+		t.Errorf("no-TLS http mode must not emit https:// URL:\n%s", buf.String())
+	}
+}
+
+// TestRunPrintMCPConfig_HTTPRejectsMissingHost pins the guard that
+// refuses to print an http config without --host. A missing host
+// would silently produce a ":3000/mcp" URL that's meaningless.
+func TestRunPrintMCPConfig_HTTPRejectsMissingHost(t *testing.T) {
+	var buf bytes.Buffer
+	err := runPrintMCPConfig(&buf, "http", "", 3000, "", "")
+	if err == nil {
+		t.Fatal("expected error for http without --host, got nil")
+	}
+	if !strings.Contains(err.Error(), "--host") {
+		t.Errorf("error does not mention --host: %v", err)
+	}
+}
+
+// TestRunPrintMCPConfig_HTTPRejectsWildcardHost pins that 0.0.0.0
+// is rejected here for the same reason serve rejects it on the
+// listen side: a wildcard is not a dialable address for a client.
+// This guard exists so an operator who copy-pastes their serve
+// args into --print-config doesn't get a useless config file.
+func TestRunPrintMCPConfig_HTTPRejectsWildcardHost(t *testing.T) {
+	var buf bytes.Buffer
+	err := runPrintMCPConfig(&buf, "http", "0.0.0.0", 3000, "", "")
+	if err == nil {
+		t.Fatal("expected error for 0.0.0.0 host, got nil")
+	}
+}
+
+// TestRunPrintMCPConfig_HTTPIPv6Brackets pins the URL formatting for
+// IPv6 literals. An IPv6 host without brackets produces a URL that
+// url.Parse rejects, so MCP clients would fail at config load.
+func TestRunPrintMCPConfig_HTTPIPv6Brackets(t *testing.T) {
+	var buf bytes.Buffer
+	if err := runPrintMCPConfig(&buf, "http", "fe80::1", 3000, "", ""); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(buf.String(), "http://[fe80::1]:3000/mcp") {
+		t.Errorf("IPv6 host not bracketed:\n%s", buf.String())
 	}
 }
 

--- a/internal/cli/cmd_serve_test.go
+++ b/internal/cli/cmd_serve_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/xml"
 	"strings"
 	"testing"
+
+	"github.com/Fail-Safe/Noema/internal/cortex"
 )
 
 // TestValidateHTTPServe pins the flag invariants for `noema serve --transport
@@ -478,6 +480,78 @@ func TestRunPrintLaunchdPlist_HappyPath(t *testing.T) {
 	}
 	if !strings.Contains(s, "com.fail-safe.noema.agentbrain") {
 		t.Errorf("plist label does not include cortex name:\n%s", s)
+	}
+}
+
+// TestRequireTLSForKeyedMode pins the auth-requires-TLS guard: shared-key
+// mode over plaintext HTTP is a worse security posture than open mode (it
+// leaks the key on every request while creating the appearance of security),
+// so the combination is a hard startup error. The guard must fire for both
+// "file" and "env" sources, must be a no-op in open mode, and must be a
+// no-op when TLS is configured.
+func TestRequireTLSForKeyedMode(t *testing.T) {
+	cases := []struct {
+		name          string
+		access        cortex.AccessKey
+		useTLS        bool
+		wantErrSubstr string // empty = expect nil
+	}{
+		{
+			name:   "open mode no TLS — fine",
+			access: cortex.AccessKey{}, // Keyed() == false
+			useTLS: false,
+		},
+		{
+			name:   "open mode with TLS — fine",
+			access: cortex.AccessKey{},
+			useTLS: true,
+		},
+		{
+			name:   "keyed mode with TLS — fine",
+			access: cortex.AccessKey{Value: "k", Source: "file", Fingerprint: "SHA256:aa"},
+			useTLS: true,
+		},
+		{
+			name:          "keyed mode from file, no TLS — reject",
+			access:        cortex.AccessKey{Value: "k", Source: "file", Path: ".access.secret"},
+			useTLS:        false,
+			wantErrSubstr: "source=file",
+		},
+		{
+			name:          "keyed mode from env, no TLS — reject",
+			access:        cortex.AccessKey{Value: "k", Source: "env"},
+			useTLS:        false,
+			wantErrSubstr: "source=env",
+		},
+		{
+			name:          "keyed mode error mentions plaintext",
+			access:        cortex.AccessKey{Value: "k", Source: "file"},
+			useTLS:        false,
+			wantErrSubstr: "plaintext HTTP",
+		},
+		{
+			name:          "keyed mode error suggests remediation",
+			access:        cortex.AccessKey{Value: "k", Source: "file"},
+			useTLS:        false,
+			wantErrSubstr: "--tls-cert and --tls-key",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := requireTLSForKeyedMode(tc.access, tc.useTLS)
+			if tc.wantErrSubstr == "" {
+				if err != nil {
+					t.Fatalf("expected nil, got: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tc.wantErrSubstr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErrSubstr) {
+				t.Errorf("error %q does not contain %q", err.Error(), tc.wantErrSubstr)
+			}
+		})
 	}
 }
 

--- a/internal/federation/federation.go
+++ b/internal/federation/federation.go
@@ -15,6 +15,12 @@ type PeerConfig struct {
 type Config struct {
 	Peers    []PeerConfig  `yaml:"peers,omitempty"`
 	Interval time.Duration // parsed from string
+
+	// SharedKey is the MCP bearer token this syncer attaches to every
+	// outbound request as "Authorization: Bearer <SharedKey>". Empty
+	// means open mode (no header sent). Populated at startup from
+	// cortex.LoadAccessKey; never surfaced in YAML, logs, or events.
+	SharedKey string `yaml:"-"`
 }
 
 // EffectiveInterval returns the configured interval or the default.

--- a/internal/federation/syncer.go
+++ b/internal/federation/syncer.go
@@ -202,6 +202,15 @@ func (s *Syncer) syncPeer(peer PeerConfig) error {
 		}
 		clientOpts = append(clientOpts, transport.WithHTTPBasicClient(httpClient))
 	}
+	if s.config.SharedKey != "" {
+		// Ring-model auth: the same key the middleware enforces on
+		// incoming requests is attached to every outbound sync. Peers
+		// in mismatched modes (one keyed, one open) will 401 each
+		// other — by design; see docs/design/mcp-auth-plan.md.
+		clientOpts = append(clientOpts, transport.WithHTTPHeaders(map[string]string{
+			"Authorization": "Bearer " + s.config.SharedKey,
+		}))
+	}
 	mcpClient, err := client.NewStreamableHttpClient(mcpURL, clientOpts...)
 	if err != nil {
 		return fmt.Errorf("creating Streamable HTTP client: %w", err)

--- a/internal/mcp/middleware.go
+++ b/internal/mcp/middleware.go
@@ -1,0 +1,71 @@
+package mcp
+
+import (
+	"crypto/sha256"
+	"crypto/subtle"
+	"net/http"
+)
+
+// CORSMiddleware adds permissive CORS headers to every response and
+// short-circuits OPTIONS preflight requests with 204 No Content.
+//
+// mcp-go's StreamableHTTPServer returns 404 for any method other than
+// POST/GET/DELETE (streamable_http.go:254-255), so without this layer
+// browser-based MCP clients (Zed, custom dashboards, anything running
+// in a WebView) fail their preflight and never get to the real request.
+// The CORS layer sits OUTSIDE AuthMiddleware because the CORS spec
+// forbids sending credentials on preflight — a browser that can't
+// complete preflight can't authenticate in the first place.
+func CORSMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// These headers are safe to set on every response. CORS-aware
+		// clients use them; non-browser callers ignore them.
+		w.Header().Set("Access-Control-Allow-Origin", "*")
+		w.Header().Set("Access-Control-Allow-Methods", "POST, GET, DELETE, OPTIONS")
+		w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, Mcp-Session-Id")
+		w.Header().Set("Access-Control-Expose-Headers", "Mcp-Session-Id")
+
+		if r.Method == http.MethodOptions {
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// AuthMiddleware returns a middleware that gates the wrapped handler
+// behind a shared bearer key. When sharedKey is empty, the returned
+// middleware is a pass-through (open mode): no header is required and
+// no comparison runs.
+//
+// When keyed, the middleware computes a SHA-256 prehash of the
+// expected "Bearer <key>" string once at construction, and hashes the
+// incoming Authorization header on every request. The two 32-byte
+// digests are compared with subtle.ConstantTimeCompare. Prehashing
+// both sides closes a subtle timing leak: ConstantTimeCompare returns
+// 0 immediately when its inputs differ in length, which would let a
+// probing attacker recover the expected-key length bit by bit. After
+// prehashing, both sides are always 32 bytes regardless of the
+// attacker's guess, so length is never observable.
+//
+// There are zero MCP-method carve-outs. initialize, tools/list,
+// tools/call for every tool, resources/list, ping — all gated. See
+// Design Decision #3 in docs/design/mcp-auth-plan.md for why.
+func AuthMiddleware(sharedKey string) func(http.Handler) http.Handler {
+	if sharedKey == "" {
+		return func(next http.Handler) http.Handler { return next }
+	}
+	expected := sha256.Sum256([]byte("Bearer " + sharedKey))
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			got := sha256.Sum256([]byte(r.Header.Get("Authorization")))
+			if subtle.ConstantTimeCompare(got[:], expected[:]) != 1 {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusUnauthorized)
+				_, _ = w.Write([]byte(`{"error":"unauthorized: NOEMA_MCP_KEY / access.shared_key_file required"}`))
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/internal/mcp/middleware_test.go
+++ b/internal/mcp/middleware_test.go
@@ -1,0 +1,286 @@
+package mcp_test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	mcpserver "github.com/Fail-Safe/Noema/internal/mcp"
+)
+
+// okHandler is a sentinel downstream handler that records whether it
+// was called and returns 200 with a fixed body.
+func okHandler(called *bool) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if called != nil {
+			*called = true
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+}
+
+// ---- AuthMiddleware ----
+
+func TestAuthMiddleware_OpenMode_PassesRequestsThrough(t *testing.T) {
+	called := false
+	h := mcpserver.AuthMiddleware("")(okHandler(&called))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader("{}"))
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rr.Code)
+	}
+	if !called {
+		t.Error("downstream handler was not called in open mode")
+	}
+}
+
+func TestAuthMiddleware_OpenMode_IgnoresHeaderPresence(t *testing.T) {
+	// A random Authorization header should not trip anything in open mode.
+	called := false
+	h := mcpserver.AuthMiddleware("")(okHandler(&called))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer totally-wrong")
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (open mode ignores header content)", rr.Code)
+	}
+	if !called {
+		t.Error("downstream handler was not called")
+	}
+}
+
+func TestAuthMiddleware_Keyed_MissingHeader(t *testing.T) {
+	called := false
+	h := mcpserver.AuthMiddleware("s3cret")(okHandler(&called))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rr.Code)
+	}
+	if called {
+		t.Error("downstream handler must not be called on 401")
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json", ct)
+	}
+	body, _ := io.ReadAll(rr.Body)
+	if !strings.Contains(string(body), "unauthorized") {
+		t.Errorf("body does not mention unauthorized: %q", string(body))
+	}
+}
+
+func TestAuthMiddleware_Keyed_WrongBearerValue(t *testing.T) {
+	called := false
+	h := mcpserver.AuthMiddleware("s3cret")(okHandler(&called))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer not-the-right-one")
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rr.Code)
+	}
+	if called {
+		t.Error("downstream handler must not be called on 401")
+	}
+}
+
+func TestAuthMiddleware_Keyed_WrongScheme(t *testing.T) {
+	// Basic auth, Digest, or a raw token without a scheme must all 401.
+	h := mcpserver.AuthMiddleware("s3cret")(okHandler(nil))
+
+	cases := []string{
+		"Basic czNjcmV0",   // base64("s3cret") under Basic
+		"s3cret",           // raw value, no scheme
+		"bearer s3cret",    // lowercase scheme (bearer != Bearer byte-for-byte)
+		"Bearer  s3cret",   // extra space
+		"Bearer s3cret\r\n", // trailing junk
+	}
+	for _, h3 := range cases {
+		t.Run(h3, func(t *testing.T) {
+			rr := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+			req.Header.Set("Authorization", h3)
+			h.ServeHTTP(rr, req)
+			if rr.Code != http.StatusUnauthorized {
+				t.Errorf("Authorization=%q → status %d, want 401", h3, rr.Code)
+			}
+		})
+	}
+}
+
+func TestAuthMiddleware_Keyed_CorrectBearer(t *testing.T) {
+	called := false
+	h := mcpserver.AuthMiddleware("s3cret")(okHandler(&called))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer s3cret")
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rr.Code)
+	}
+	if !called {
+		t.Error("downstream handler was not called on valid auth")
+	}
+}
+
+func TestAuthMiddleware_Keyed_LongKeyStillWorks(t *testing.T) {
+	// A 256-char key must still compare correctly after prehash.
+	longKey := strings.Repeat("a", 256)
+	h := mcpserver.AuthMiddleware(longKey)(okHandler(nil))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer "+longKey)
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 for long key", rr.Code)
+	}
+}
+
+func TestAuthMiddleware_Keyed_EmptyHeaderRejectedButNotCrashing(t *testing.T) {
+	// Empty Authorization header (set to "") must be rejected — and
+	// must not crash the prehash path with a zero-length input.
+	h := mcpserver.AuthMiddleware("s3cret")(okHandler(nil))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set("Authorization", "")
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401 for empty header", rr.Code)
+	}
+}
+
+// ---- CORSMiddleware ----
+
+func TestCORSMiddleware_SetsHeadersOnRegularRequest(t *testing.T) {
+	called := false
+	h := mcpserver.CORSMiddleware(okHandler(&called))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	h.ServeHTTP(rr, req)
+
+	if !called {
+		t.Error("downstream handler was not called")
+	}
+	if rr.Header().Get("Access-Control-Allow-Origin") != "*" {
+		t.Error("Access-Control-Allow-Origin missing")
+	}
+	if !strings.Contains(rr.Header().Get("Access-Control-Allow-Methods"), "POST") {
+		t.Error("Access-Control-Allow-Methods missing POST")
+	}
+	if !strings.Contains(rr.Header().Get("Access-Control-Allow-Headers"), "Authorization") {
+		t.Error("Access-Control-Allow-Headers must include Authorization (browsers need it to send Bearer)")
+	}
+	if !strings.Contains(rr.Header().Get("Access-Control-Allow-Headers"), "Mcp-Session-Id") {
+		t.Error("Access-Control-Allow-Headers must include Mcp-Session-Id (MCP session tracking)")
+	}
+}
+
+func TestCORSMiddleware_OptionsShortCircuits(t *testing.T) {
+	// The whole point: OPTIONS must never reach mcp-go (which returns 404)
+	// and must succeed with 204 No Content.
+	called := false
+	h := mcpserver.CORSMiddleware(okHandler(&called))
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodOptions, "/mcp", nil)
+	req.Header.Set("Origin", "https://example.com")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	req.Header.Set("Access-Control-Request-Headers", "authorization, content-type")
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Errorf("status = %d, want 204", rr.Code)
+	}
+	if called {
+		t.Error("downstream handler must not be called for OPTIONS")
+	}
+	if rr.Header().Get("Access-Control-Allow-Origin") != "*" {
+		t.Error("preflight response missing Access-Control-Allow-Origin")
+	}
+}
+
+// ---- CORS + Auth chain ----
+
+func TestCORSAuthChain_OptionsBypassesAuthEvenInKeyedMode(t *testing.T) {
+	// CORS preflight has no Authorization header by spec. If the chain
+	// ordering is wrong (auth outside CORS), preflight would 401 and
+	// the browser would never send the real request.
+	called := false
+	inner := mcpserver.AuthMiddleware("s3cret")(okHandler(&called))
+	h := mcpserver.CORSMiddleware(inner)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodOptions, "/mcp", nil)
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Errorf("preflight status = %d, want 204 (auth must not reject OPTIONS)", rr.Code)
+	}
+	if called {
+		t.Error("downstream handler must not run for preflight")
+	}
+}
+
+func TestCORSAuthChain_PostStillRequiresAuth(t *testing.T) {
+	called := false
+	inner := mcpserver.AuthMiddleware("s3cret")(okHandler(&called))
+	h := mcpserver.CORSMiddleware(inner)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("POST without auth: status = %d, want 401", rr.Code)
+	}
+	if called {
+		t.Error("downstream handler must not be called without auth")
+	}
+	// CORS headers should still be present on the 401 so browser
+	// clients see a useful error (not a CORS-blocked opaque failure).
+	if rr.Header().Get("Access-Control-Allow-Origin") != "*" {
+		t.Error("401 response missing CORS header — browser will show an opaque error")
+	}
+}
+
+func TestCORSAuthChain_PostWithAuthSucceeds(t *testing.T) {
+	called := false
+	inner := mcpserver.AuthMiddleware("s3cret")(okHandler(&called))
+	h := mcpserver.CORSMiddleware(inner)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	req.Header.Set("Authorization", "Bearer s3cret")
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("authenticated POST status = %d, want 200", rr.Code)
+	}
+	if !called {
+		t.Error("downstream handler was not called on authenticated POST")
+	}
+	if rr.Header().Get("Access-Control-Allow-Origin") != "*" {
+		t.Error("200 response missing CORS header")
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -409,7 +409,20 @@ func NewServer(cx *cortex.Cortex, noemaVersion string) *server.MCPServer {
 		}
 
 		var sb strings.Builder
-		sb.WriteString(fmt.Sprintf("Cortex: %s\n\n", m.Name))
+		sb.WriteString(fmt.Sprintf("Cortex: %s\n", m.Name))
+
+		// Surface the MCP access posture alongside federation state so a
+		// peer calling this tool sees exactly what the middleware is
+		// enforcing locally. Resolution errors are non-fatal: print them
+		// and keep going rather than blanking the rest of the status.
+		if key, kerr := cortex.LoadAccessKey(cx.Dir, m.Access); kerr != nil {
+			sb.WriteString(fmt.Sprintf("Access: error loading key: %v\n", kerr))
+		} else if key.Keyed() {
+			sb.WriteString(fmt.Sprintf("Access: keyed (source=%s, fingerprint=%s)\n", key.Source, key.Fingerprint))
+		} else {
+			sb.WriteString("Access: open\n")
+		}
+		sb.WriteByte('\n')
 
 		if m.Federation == nil || len(m.Federation.Peers) == 0 {
 			sb.WriteString("Federation: not configured (no peers in cortex.md)\n")
@@ -615,7 +628,8 @@ Choose the type that best reflects the intent of the memory:
                                    manifest version (used by federation peers
                                    to verify identity on every sync)
   sync_events [since] [limit]    → pull events for federation (JSON array)
-  federation_status              → federation config, peer states, vector clock
+  federation_status              → MCP access posture, federation config,
+                                   peer states, vector clock
   announce_peer name endpoint    → accept a peer announcement for discovery
 
 ## Filtering


### PR DESCRIPTION
## Summary

Restores the two commits from #5 and #6 that never reached `next` due to a stacked-PR merge misfire.

### What happened

#4, #5, and #6 were set up as a stacked chain:
- #4: `feat/mcp-auth-a` → `next`
- #5: `feat/mcp-auth-b` → `feat/mcp-auth-a`
- #6: `feat/mcp-auth-c` → `feat/mcp-auth-b`

When merged rapidly through the GitHub UI, each PR landed in the branch it was pointed at — #4 into `next`, but #5 into `feat/mcp-auth-a` and #6 into `feat/mcp-auth-b`. GitHub marks all three as MERGED, but only #4's content actually reached `next`.

Because #4 is pure plumbing (the loader has no call sites until #5 wires it in), `next` has been compiling and running cleanly in open-mode — it just silently doesn't have the auth feature.

### This PR

Cherry-picks the two missing commits directly onto `next`:

- `36be8d4` — "Enforce MCP shared-key auth with CORS-aware middleware" (originally #5)
- `3a199cc` — "Surface access posture and plumb keys into config generators" (originally #6)

Both are unmodified from the originals and cherry-picked cleanly (no conflicts, no content drift).

## What this brings to `next`

From #5:
- `internal/mcp/middleware.go` — `CORSMiddleware` + `AuthMiddleware` (prehashed constant-time compare, no per-method carve-outs)
- `internal/federation/{federation,syncer}.go` — outbound `Authorization` header injection via `transport.WithHTTPHeaders`
- `internal/cli/cmd_serve.go` — access-key load path, startup fingerprint log, `requireTLSForKeyedMode` guard, custom `ServeMux` mounting
- 14 middleware tests + 7 TLS-guard tests

From #6:
- `noema federation key fingerprint` CLI subcommand
- `Access:` line on `federation_status` (CLI + MCP tool)
- `--print-systemd-unit` / `--print-launchd-plist` / `--print-config` keyed-mode support
- `get_instructions` mentions the new `Access:` line
- 15 new tests across generators, fingerprint, and Access-line rendering

## Review guidance

For substantive review of the code changes, see the original PRs:
- #5 — middleware, wiring, TLS guard (MERGED, but content didn't reach `next`)
- #6 — fingerprint CLI, access posture, config generators (MERGED, but content didn't reach `next`)

This PR's diff should be byte-identical to the cumulative diff of #5 + #6.

## Test plan

- [x] `git cherry-pick 36be8d4 3a199cc` — clean, no conflicts
- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all packages pass (internal/cli, internal/mcp, internal/federation, internal/cortex, internal/db, internal/event, internal/trace, internal/tui, internal/config)
- [x] **Production drill already validated** — this exact code shape (as `feat/mcp-auth-c`) ran through the 9-phase rollout/rollback plan across three federated hosts (ai-1, ai-2, ai-3). All gates passed. See #5 and #6 for the per-phase breakdown.

## Follow-up for reviewers

Stacked PRs targeting each other is a foot-gun on GitHub — the pattern only survives merges if you do them one at a time and let GitHub auto-rebase the next base in between. For future multi-commit rollouts I'll point all PRs at `next` directly with cumulative diffs, or use a single PR with a reviewer-friendly commit series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)