### PR TITLE
docs(readme): bump Go version requirement to 1.25+

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A Trace has a **type** that describes its intent:
 
 ## Installation
 
-Requires Go 1.21+.
+Requires Go 1.25+.
 
 ```bash
 go install github.com/Fail-Safe/Noema/cmd/noema@latest


### PR DESCRIPTION
## Summary
- \`go.mod\` has declared \`go 1.25.0\` for some time, but the README still said \`Requires Go 1.21+.\`
- A user on Go 1.21 running \`go install github.com/Fail-Safe/Noema/cmd/noema@latest\` would hit Go's auto-toolchain download silently, or fail outright with \`GOTOOLCHAIN=local\`.
- Correct the claim to \`Requires Go 1.25+.\` so the README matches what the build actually needs.

Found while fact-checking the landing page copy on noemacortex.com — the site was copying the stale claim from here. Site is now corrected to match.

## Test plan
- [x] \`grep 1\.21 README.md CLAUDE.md\` — no other stale references
- [x] \`head -5 go.mod\` — confirms \`go 1.25.0\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)