### PR TITLE
feat(tui): live-refresh, pane focus, body scroll, brand wordmark

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/mark3labs/mcp-go v0.46.0
+	github.com/muesli/termenv v0.16.0
 	github.com/spf13/cobra v1.10.2
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.48.0
@@ -33,7 +34,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.19 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
@@ -16,10 +17,48 @@ import (
 
 // ---- styles ----------------------------------------------------------------
 
+// Brand palette — mirrors the Noema website (src/styles/global.css).
+// We use CompleteColor rather than bare hex so 256-color terminals get
+// hand-picked palette indices instead of termenv's automatic downmatch
+// (which picks color 232 — near-black — for the brand red, rendering
+// the wordmark period invisible on dark backgrounds).
+//
+// Kept as package-level vars so a future light/dark toggle only has to
+// swap these assignments without touching the style definitions below.
 var (
+	// brandFg — cream "Noema" wordmark.
+	//   TrueColor: #ece4d4 (website --fg)
+	//   ANSI256:   223      (#ffd7af — warm beige, closest to cream)
+	//   ANSI:      7        (white)
+	brandFg = lipgloss.CompleteColor{
+		TrueColor: "#ece4d4",
+		ANSI256:   "223",
+		ANSI:      "7",
+	}
+
+	// brandRed — accent period in "Noema."
+	//   TrueColor: #e10032 (website --red)
+	//   ANSI256:   161      (#d7005f — closest saturated red)
+	//   ANSI:      1        (red)
+	brandRed = lipgloss.CompleteColor{
+		TrueColor: "#e10032",
+		ANSI256:   "161",
+		ANSI:      "1",
+	}
+)
+
+var (
+	// styleHeader renders the "Noema" portion of the wordmark in the
+	// brand cream. styleHeaderAccent renders the trailing period in
+	// brand red — matching the website's wordmark. Splitting them
+	// keeps the two colors independent for theming.
 	styleHeader = lipgloss.NewStyle().
 			Bold(true).
-			Foreground(lipgloss.Color("99"))
+			Foreground(brandFg)
+
+	styleHeaderAccent = lipgloss.NewStyle().
+				Bold(true).
+				Foreground(brandRed)
 
 	styleSelected = lipgloss.NewStyle().
 			Bold(true).
@@ -49,7 +88,46 @@ var (
 
 	styleStatus = lipgloss.NewStyle().
 			Foreground(lipgloss.Color("71"))
+
+	// styleNewRow tints rows that arrived on the most recent refresh —
+	// the visible "pop in" effect when watching live updates.
+	styleNewRow = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("71"))
+
+	// styleLive is the header badge shown while follow mode is active.
+	styleLive = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("71")).
+			Bold(true)
+
+	// When the detail pane owns focus, the list pane gets a "modal
+	// backdrop" treatment — every row renders through a dim palette
+	// so it visibly recedes. The selected row stays a notch brighter
+	// than the rest so the cursor position is still legible.
+	//
+	// Brightness ladder (dim mode):
+	//   styleRowDim        238  very faint   — unselected rows
+	//   styleNewRowDim      65  muted green  — highlighted arrivals
+	//   styleSelectedDim   244  soft gray    — current selection
+	styleSelectedDim = lipgloss.NewStyle().
+				Foreground(lipgloss.Color("244"))
+
+	styleRowDim = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("238"))
+
+	styleNewRowDim = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("65"))
 )
+
+// followInterval is how often the TUI polls the cortex when follow mode
+// is on. 1s is fast enough to feel live when an agent is writing into
+// the cortex in the background, but slow enough to be invisible CPU load
+// (List is sub-millisecond on a local SQLite file).
+const followInterval = 1 * time.Second
+
+// newRowHighlightTicks is how many consecutive refresh ticks a newly-
+// arrived trace stays highlighted. With followInterval=1s this gives
+// ~2 seconds of green tint before the row fades back to normal.
+const newRowHighlightTicks = 2
 
 // ---- state machine ---------------------------------------------------------
 
@@ -59,6 +137,16 @@ const (
 	stateList    viewState = iota
 	stateSearch
 	stateConfirm
+)
+
+// focusPane tracks which pane (list or detail) receives navigation keys.
+// Only the list/detail split is focus-aware — modal states like search
+// and confirm pre-empt focus while active.
+type focusPane int
+
+const (
+	focusList focusPane = iota
+	focusDetail
 )
 
 // ---- messages --------------------------------------------------------------
@@ -73,6 +161,12 @@ type editorDoneMsg struct {
 }
 
 type errMsg struct{ err error }
+
+// tickMsg drives the follow-mode polling loop. `gen` is a generation
+// counter used to discard stale ticks left over from a previous
+// follow-mode session — without it, rapid f-on → f-off → f-on toggling
+// could leave multiple tick chains running in parallel.
+type tickMsg struct{ gen int }
 
 // ---- model -----------------------------------------------------------------
 
@@ -96,6 +190,28 @@ type model struct {
 	confirm     confirmAction
 	err         error
 	status      string
+
+	// Follow-mode state (auto-refresh).
+	follow    bool           // true when auto-refresh is on
+	followGen int            // bumped each time follow turns on; stale ticks discarded
+	newRowTTL map[string]int // trace ID → ticks of highlight remaining
+
+	// Pane focus + detail-pane scroll position (body lines only —
+	// metadata always stays pinned). detailScroll is reset whenever the
+	// trace under the cursor changes, but preserved across tab toggles
+	// so you can glance at the list and come back to where you were.
+	focus        focusPane
+	detailScroll int
+
+	// Snapshot of the filter context at the time of the last accepted
+	// rowsLoadedMsg. Used to detect when a refresh crosses a context
+	// boundary (e.g. user toggled `a`/`t`/`/`) — in that case the new
+	// rowset isn't comparable to the previous one, so we skip the
+	// new-row diff and the sticky-cursor reseat.
+	prevSeen        bool
+	lastShowAll     bool
+	lastShowTrashed bool
+	lastQuery       string
 }
 
 func initialModel(cx *cortex.Cortex) model {
@@ -104,9 +220,10 @@ func initialModel(cx *cortex.Cortex) model {
 	ti.CharLimit = 120
 
 	return model{
-		cx:     cx,
-		search: ti,
-		state:  stateList,
+		cx:        cx,
+		search:    ti,
+		state:     stateList,
+		newRowTTL: map[string]int{},
 	}
 }
 
@@ -129,6 +246,15 @@ func loadRows(cx *cortex.Cortex, query string, all, trashed bool) tea.Cmd {
 		}
 		return rowsLoadedMsg(rows)
 	}
+}
+
+// tickCmd schedules the next follow-mode poll. The generation is
+// carried inside the message so that Update can reject ticks left over
+// from a stopped-and-restarted follow session.
+func tickCmd(gen int) tea.Cmd {
+	return tea.Tick(followInterval, func(_ time.Time) tea.Msg {
+		return tickMsg{gen: gen}
+	})
 }
 
 func editorCmd(path, id string, isNew bool) tea.Cmd {
@@ -159,12 +285,22 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case rowsLoadedMsg:
-		m.rows = []cortex.Row(msg)
-		if m.cursor >= len(m.rows) {
-			m.cursor = max(0, len(m.rows)-1)
+		return m.handleRowsLoaded([]cortex.Row(msg)), nil
+
+	case tickMsg:
+		// Discard stale ticks from a prior follow-mode session.
+		if !m.follow || msg.gen != m.followGen {
+			return m, nil
 		}
-		m.current = m.loadCurrent()
-		return m, nil
+		// Always re-queue the next tick — we want the chain to keep
+		// spinning even when we suppress the actual refresh (search
+		// focus, confirm modal), so the loop resumes automatically
+		// when the user returns to the list.
+		cmds := []tea.Cmd{tickCmd(msg.gen)}
+		if m.state == stateList {
+			cmds = append(cmds, loadRows(m.cx, m.searchQuery, m.showAll, m.showTrashed))
+		}
+		return m, tea.Batch(cmds...)
 
 	case editorDoneMsg:
 		return m.handleEditorDone(msg)
@@ -194,26 +330,80 @@ func (m model) updateList(msg tea.KeyMsg) (model, tea.Cmd) {
 	case "q", "ctrl+c":
 		return m, tea.Quit
 
+	case "tab":
+		// Cycle focus between the list and detail panes. Modal states
+		// (search/confirm) can't be reached from here, so there are
+		// only two stops.
+		if m.focus == focusList {
+			m.focus = focusDetail
+		} else {
+			m.focus = focusList
+		}
+		return m, nil
+
+	case "left":
+		// Absolute focus: left arrow always lands on the list pane,
+		// regardless of current focus. Pairs with "right" for
+		// one-handed browsing — you can scroll a trace with j/k on the
+		// right side and jump back to the list without thinking about
+		// which pane you're currently in.
+		m.focus = focusList
+		return m, nil
+
+	case "right":
+		m.focus = focusDetail
+		return m, nil
+
 	case "j", "down":
+		if m.focus == focusDetail {
+			return m.scrollDetail(1), nil
+		}
 		if m.cursor < len(m.rows)-1 {
-			m.cursor++
-			m.current = m.loadCurrent()
+			m = m.selectCursor(m.cursor + 1)
 		}
 
 	case "k", "up":
+		if m.focus == focusDetail {
+			return m.scrollDetail(-1), nil
+		}
 		if m.cursor > 0 {
-			m.cursor--
-			m.current = m.loadCurrent()
+			m = m.selectCursor(m.cursor - 1)
 		}
 
 	case "g":
-		m.cursor = 0
-		m.current = m.loadCurrent()
+		if m.focus == focusDetail {
+			m.detailScroll = 0
+			return m, nil
+		}
+		m = m.selectCursor(0)
 
 	case "G":
+		if m.focus == focusDetail {
+			m.detailScroll = m.detailMaxScroll()
+			return m, nil
+		}
 		if len(m.rows) > 0 {
-			m.cursor = len(m.rows) - 1
-			m.current = m.loadCurrent()
+			m = m.selectCursor(len(m.rows) - 1)
+		}
+
+	case "pgdown", "ctrl+d":
+		// Half-page scroll is detail-only. In list focus these keys
+		// are no-ops (existing behavior).
+		if m.focus == focusDetail {
+			step := m.detailVisibleBodyH() / 2
+			if step < 1 {
+				step = 1
+			}
+			return m.scrollDetail(step), nil
+		}
+
+	case "pgup", "ctrl+u":
+		if m.focus == focusDetail {
+			step := m.detailVisibleBodyH() / 2
+			if step < 1 {
+				step = 1
+			}
+			return m.scrollDetail(-step), nil
 		}
 
 	case "n":
@@ -302,7 +492,31 @@ func (m model) updateList(msg tea.KeyMsg) (model, tea.Cmd) {
 		m.search, cmd = m.search.Update(nil)
 		return m, cmd
 
+	case "f":
+		// Toggle follow (auto-refresh) mode. A fresh generation is
+		// minted on every on-transition so stale ticks from a prior
+		// on→off→on cycle are discarded on arrival.
+		m.follow = !m.follow
+		if m.follow {
+			m.followGen++
+			m.status = "Live mode on"
+			return m, tickCmd(m.followGen)
+		}
+		m.status = "Live mode off"
+		return m, nil
+
+	case "R":
+		// Manual refresh — useful when follow is off, or as a
+		// "refresh now, don't wait for the next tick" escape hatch.
+		return m, loadRows(m.cx, m.searchQuery, m.showAll, m.showTrashed)
+
 	case "esc":
+		// First esc pops detail focus back to the list; second esc
+		// (or esc with list already focused) clears any active search.
+		if m.focus == focusDetail {
+			m.focus = focusList
+			return m, nil
+		}
 		if m.searchQuery != "" {
 			m.searchQuery = ""
 			m.cursor = 0
@@ -408,6 +622,90 @@ func (m model) handleEditorDone(msg editorDoneMsg) (model, tea.Cmd) {
 	return m, loadRows(m.cx, m.searchQuery, m.showAll, m.showTrashed)
 }
 
+// handleRowsLoaded folds a fresh rowset into the model, preserving the
+// cursor's trace ID across the refresh and tracking which rows arrived
+// on this tick so they can be highlighted briefly. Context changes
+// (user toggled a/t/search) skip the sticky + diff logic because the
+// new rowset isn't comparable to the previous one. Detail scroll is
+// reset if the refresh lands on a different trace than before.
+func (m model) handleRowsLoaded(newRows []cortex.Row) model {
+	var prevCurrentID string
+	if m.current != nil {
+		prevCurrentID = m.current.ID
+	}
+	sameContext := m.prevSeen &&
+		m.lastShowAll == m.showAll &&
+		m.lastShowTrashed == m.showTrashed &&
+		m.lastQuery == m.searchQuery
+
+	if sameContext {
+		// Fade the highlight on rows that were flagged previously.
+		// Delete-during-iterate is safe for Go maps.
+		for id, ttl := range m.newRowTTL {
+			if ttl-1 <= 0 {
+				delete(m.newRowTTL, id)
+			} else {
+				m.newRowTTL[id] = ttl - 1
+			}
+		}
+		// Flag rows that weren't in the previous snapshot as new.
+		prev := make(map[string]bool, len(m.rows))
+		for _, r := range m.rows {
+			prev[r.ID] = true
+		}
+		for _, r := range newRows {
+			if !prev[r.ID] {
+				m.newRowTTL[r.ID] = newRowHighlightTicks
+			}
+		}
+	} else {
+		// Context change — the old highlights belong to a different
+		// view. Drop them to avoid a misleading green flash.
+		m.newRowTTL = map[string]int{}
+	}
+
+	// Sticky cursor by trace ID. Capture what's selected *before*
+	// swapping the rows out.
+	var selectedID string
+	if m.cursor >= 0 && m.cursor < len(m.rows) {
+		selectedID = m.rows[m.cursor].ID
+	}
+	m.rows = newRows
+
+	if sameContext && selectedID != "" {
+		for i, r := range m.rows {
+			if r.ID == selectedID {
+				m.cursor = i
+				break
+			}
+		}
+	}
+	if m.cursor >= len(m.rows) {
+		m.cursor = max(0, len(m.rows)-1)
+	}
+
+	m.prevSeen = true
+	m.lastShowAll = m.showAll
+	m.lastShowTrashed = m.showTrashed
+	m.lastQuery = m.searchQuery
+
+	m.current = m.loadCurrent()
+
+	// If the refresh landed on a different trace (sticky-cursor
+	// failed because the row was archived/deleted, or context
+	// changed), reset the detail scroll — the old offset belongs
+	// to a different body.
+	var newCurrentID string
+	if m.current != nil {
+		newCurrentID = m.current.ID
+	}
+	if newCurrentID != prevCurrentID {
+		m.detailScroll = 0
+	}
+
+	return m
+}
+
 func (m model) loadCurrent() *trace.Trace {
 	if len(m.rows) == 0 {
 		return nil
@@ -421,6 +719,115 @@ func (m model) loadCurrent() *trace.Trace {
 	}
 	t, _ := trace.ParseFile(path)
 	return t
+}
+
+// paneWidths returns the widths of the list pane and the detail pane
+// given the current terminal width. Single source of truth so the
+// scroll math stays consistent with what View() actually renders.
+func (m model) paneWidths() (listW, detailW int) {
+	listW = m.width * listPct / 100
+	detailW = m.width - listW - 1 // -1 for the divider column
+	return
+}
+
+// bodyHeight returns the height of the body region between the header
+// and footer rows.
+func (m model) bodyHeight() int {
+	return m.height - 2
+}
+
+// detailMetaLineCount returns how many metadata rows the detail pane
+// will render for the current trace (excluding the separator). This
+// matches the append order in renderDetail — keep them in sync.
+func (m model) detailMetaLineCount() int {
+	if m.current == nil {
+		return 0
+	}
+	// id, title, type, created are always present.
+	n := 4
+	if m.current.Author != "" {
+		n++
+	}
+	if len(m.current.Tags) > 0 {
+		n++
+	}
+	return n
+}
+
+// detailBodyLines returns the body of the current trace, pre-wrapped
+// to the detail pane's body width. Returns an empty slice if there is
+// no current trace or no body.
+func (m model) detailBodyLines() []string {
+	if m.current == nil || m.current.Body == "" {
+		return nil
+	}
+	_, detailW := m.paneWidths()
+	bodyW := detailW - 4
+	if bodyW < 10 {
+		bodyW = 10
+	}
+	var out []string
+	for _, raw := range strings.Split(m.current.Body, "\n") {
+		for _, wrapped := range wrapLine(raw, bodyW) {
+			out = append(out, "  "+wrapped)
+		}
+	}
+	return out
+}
+
+// detailVisibleBodyH returns how many body rows fit in the detail pane
+// after the metadata block and separator.
+func (m model) detailVisibleBodyH() int {
+	h := m.bodyHeight() - m.detailMetaLineCount() - 1 // -1 for the separator
+	if h < 0 {
+		return 0
+	}
+	return h
+}
+
+// detailMaxScroll returns the largest valid detailScroll offset — i.e.
+// the offset where the last body line sits on the last visible row.
+func (m model) detailMaxScroll() int {
+	total := len(m.detailBodyLines())
+	visible := m.detailVisibleBodyH()
+	if total <= visible {
+		return 0
+	}
+	return total - visible
+}
+
+// scrollDetail advances (or rewinds) detailScroll by delta lines,
+// clamped to the valid range for the current trace and pane size.
+func (m model) scrollDetail(delta int) model {
+	m.detailScroll += delta
+	if m.detailScroll < 0 {
+		m.detailScroll = 0
+	}
+	if max := m.detailMaxScroll(); m.detailScroll > max {
+		m.detailScroll = max
+	}
+	return m
+}
+
+// selectCursor moves the row cursor, reloads the current trace, and
+// resets the detail scroll only if the trace actually changed. Used
+// by every list-focus navigation handler so we don't drop scroll state
+// on no-op moves (e.g. pressing `k` at the top of the list).
+func (m model) selectCursor(idx int) model {
+	var prevID string
+	if m.current != nil {
+		prevID = m.current.ID
+	}
+	m.cursor = idx
+	m.current = m.loadCurrent()
+	var newID string
+	if m.current != nil {
+		newID = m.current.ID
+	}
+	if newID != prevID {
+		m.detailScroll = 0
+	}
+	return m
 }
 
 // newTraceTempFile writes a blank trace template to a temp file.
@@ -443,9 +850,8 @@ func (m model) View() string {
 		return "Loading…\n"
 	}
 
-	listW := m.width * listPct / 100
-	detailW := m.width - listW - 1 // -1 for divider column
-	bodyH := m.height - 2          // header + footer
+	listW, detailW := m.paneWidths()
+	bodyH := m.bodyHeight()
 
 	list := m.renderList(listW, bodyH)
 	detail := m.renderDetail(detailW, bodyH)
@@ -467,7 +873,7 @@ func (m model) View() string {
 }
 
 func (m model) renderHeader() string {
-	left := styleHeader.Render("Noema") + styleDim.Render("  "+m.cx.Name)
+	left := styleHeader.Render("Noema") + styleHeaderAccent.Render(".") + styleDim.Render("  "+m.cx.Name)
 	if m.searchQuery != "" {
 		left += styleDim.Render(`  search:"` + m.searchQuery + `"`)
 	}
@@ -476,6 +882,9 @@ func (m model) renderHeader() string {
 		left += styleDim.Render("  [trash]")
 	case m.showAll:
 		left += styleDim.Render("  [all]")
+	}
+	if m.follow {
+		left += styleLive.Render("  ● live")
 	}
 	right := styleDim.Render(fmt.Sprintf("%d traces", len(m.rows)))
 	gap := m.width - lipgloss.Width(left) - lipgloss.Width(right)
@@ -525,10 +934,17 @@ func (m model) renderList(width, height int) string {
 		}
 		title = truncRune(title, titleW)
 
-		// Build plain-text line with rune-padding for alignment
+		// Build plain-text line with rune-padding for alignment.
+		// Cursor glyph is "▸" when the list pane owns focus, "·" when the
+		// detail pane owns it — visible feedback that arrow keys will
+		// drive the other side.
 		cursor := " "
 		if i == m.cursor {
-			cursor = ">"
+			if m.focus == focusList {
+				cursor = "▸"
+			} else {
+				cursor = "·"
+			}
 		}
 		line := fmt.Sprintf("%s %-*s %-*s %s",
 			cursor,
@@ -537,10 +953,31 @@ func (m model) renderList(width, height int) string {
 			date,
 		)
 
-		if i == m.cursor {
-			sb.WriteString(styleSelected.Width(width).Render(line))
-		} else {
-			sb.WriteString(lipgloss.NewStyle().Width(width).Render(line))
+		// When the detail pane owns focus, every row in the list is
+		// rendered through a dim palette — the entire pane fades like
+		// a modal backdrop, not just the selected row. The cursor row
+		// still sits one brightness step above the rest so the
+		// selection is findable at a glance when tabbing back.
+		dim := m.focus == focusDetail
+		switch {
+		case i == m.cursor:
+			if dim {
+				sb.WriteString(styleSelectedDim.Width(width).Render(line))
+			} else {
+				sb.WriteString(styleSelected.Width(width).Render(line))
+			}
+		case m.newRowTTL[r.ID] > 0:
+			if dim {
+				sb.WriteString(styleNewRowDim.Width(width).Render(line))
+			} else {
+				sb.WriteString(styleNewRow.Width(width).Render(line))
+			}
+		default:
+			if dim {
+				sb.WriteString(styleRowDim.Width(width).Render(line))
+			} else {
+				sb.WriteString(lipgloss.NewStyle().Width(width).Render(line))
+			}
 		}
 		if i < end-1 {
 			sb.WriteByte('\n')
@@ -567,15 +1004,23 @@ func (m model) renderDetail(width, height int) string {
 
 	labelW := 10 // "  created:" is 10 chars
 
+	// Every metadata value gets truncated to fit the pane. Without
+	// this, lipgloss soft-wraps an overlong id/author/tags row into
+	// 2 visible rows, the internal line count underestimates the
+	// true render height, and the whole UI scrolls up by one row.
+	metaValW := width - labelW - 2
+	if metaValW < 4 {
+		metaValW = 4
+	}
 	metaLine := func(label, val string) string {
 		l := styleLabel.Render(fmt.Sprintf("  %-*s", labelW, label+":"))
-		v := styleValue.Render(val)
+		v := styleValue.Render(truncRune(val, metaValW))
 		return l + v
 	}
 
 	var lines []string
 	lines = append(lines, metaLine("id", t.ID))
-	lines = append(lines, metaLine("title", truncRune(t.Title, width-labelW-4)))
+	lines = append(lines, metaLine("title", t.Title))
 	lines = append(lines, metaLine("type", t.Type))
 	if t.Author != "" {
 		lines = append(lines, metaLine("author", t.Author))
@@ -588,23 +1033,82 @@ func (m model) renderDetail(width, height int) string {
 		created = created[:10]
 	}
 	lines = append(lines, metaLine("created", created))
-	lines = append(lines, styleDivider.Render("  "+strings.Repeat("─", width-4)))
 
-	bodyW := width - 4
-	if bodyW < 10 {
-		bodyW = 10
+	// Pre-wrap the body so we can scroll line-by-line and compute an
+	// accurate scroll indicator.
+	bodyLines := m.detailBodyLines()
+	totalBody := len(bodyLines)
+
+	// Visible body region sits below the metadata + separator.
+	visibleBodyH := height - len(lines) - 1 // -1 for the separator line
+	if visibleBodyH < 0 {
+		visibleBodyH = 0
 	}
-	if t.Body == "" {
-		lines = append(lines, styleDim.Render("  (no body)"))
-	} else {
-		for _, raw := range strings.Split(t.Body, "\n") {
-			for _, wrapped := range wrapLine(raw, bodyW) {
-				lines = append(lines, "  "+wrapped)
-			}
+
+	// Clamp the stored scroll offset for this render. The clamp in
+	// scrollDetail handles the common case; this catches the edge
+	// where width changed (and therefore the wrap width, and therefore
+	// total body line count) without a scroll key being pressed.
+	scroll := m.detailScroll
+	maxScroll := 0
+	if totalBody > visibleBodyH {
+		maxScroll = totalBody - visibleBodyH
+	}
+	if scroll > maxScroll {
+		scroll = maxScroll
+	}
+	if scroll < 0 {
+		scroll = 0
+	}
+
+	// Separator line — decorated with a scroll indicator on the right
+	// when there's more body than fits, so users always know whether
+	// there's content above/below regardless of focus.
+	sepRule := width - 4
+	if sepRule < 1 {
+		sepRule = 1
+	}
+	if totalBody > visibleBodyH {
+		// Glyph shows scroll direction: ▴ above, ▾ below, ▴▾ both.
+		var glyph string
+		switch {
+		case scroll > 0 && scroll < maxScroll:
+			glyph = "▴▾"
+		case scroll > 0:
+			glyph = "▴"
+		default:
+			glyph = "▾"
 		}
+		upper := scroll + visibleBodyH
+		if upper > totalBody {
+			upper = totalBody
+		}
+		indicator := fmt.Sprintf("%s %d/%d", glyph, upper, totalBody)
+		indW := lipgloss.Width(indicator)
+		if sepRule > indW+2 {
+			dashW := sepRule - indW - 1
+			lines = append(lines,
+				"  "+styleDivider.Render(strings.Repeat("─", dashW))+" "+styleDim.Render(indicator))
+		} else {
+			lines = append(lines, styleDivider.Render("  "+strings.Repeat("─", sepRule)))
+		}
+	} else {
+		lines = append(lines, styleDivider.Render("  "+strings.Repeat("─", sepRule)))
 	}
 
-	// Clip to height
+	// Body slice with scroll offset applied.
+	switch {
+	case totalBody == 0:
+		lines = append(lines, styleDim.Render("  (no body)"))
+	default:
+		end := scroll + visibleBodyH
+		if end > totalBody {
+			end = totalBody
+		}
+		lines = append(lines, bodyLines[scroll:end]...)
+	}
+
+	// Clip to height as a belt-and-braces safety net.
 	if len(lines) > height {
 		lines = lines[:height]
 	}
@@ -630,15 +1134,31 @@ func (m model) renderFooter() string {
 			return styleStatus.Render("  " + m.status)
 		}
 		var hint string
-		if m.showTrashed {
-			hint = "j/k:nav  r:recover  D:purge  t:back  /:search  q:quit"
-		} else {
-			hint = "j/k:nav  n:new  e:edit  d:archive  u:unarchive  D:trash  t:trash-view  a:all  /:search  q:quit"
+		switch {
+		case m.focus == focusDetail:
+			// Detail-pane focus: arrow keys scroll the body, everything
+			// else is either reach-through (quit) or tab back to list.
+			hint = "j/k:scroll  g/G:top/bot  PgUp/PgDn:half  ←/tab:list  esc:list  q:quit"
+		case m.showTrashed:
+			hint = "j/k:nav  r:recover  D:purge  t:back  /:search  →/tab:body  f:live  R:refresh  q:quit"
+		default:
+			hint = "j/k:nav  n:new  e:edit  d:archive  u:unarchive  D:trash  t:trash-view  a:all  /:search  →/tab:body  f:live  R:refresh  q:quit"
 		}
-		if m.searchQuery != "" {
+		if m.focus == focusList && m.searchQuery != "" {
 			hint = "esc:clear  " + hint
 		}
-		return styleFooter.Render("  " + hint)
+		styled := styleFooter.Render(hint)
+		// Right-align the hint when the detail pane owns focus — a
+		// secondary visual cue (on top of the pane-dim backdrop and
+		// cursor glyph swap) that attention has moved to the right.
+		if m.focus == focusDetail {
+			pad := m.width - lipgloss.Width(styled) - 2
+			if pad < 0 {
+				pad = 0
+			}
+			return strings.Repeat(" ", pad) + styled + "  "
+		}
+		return "  " + styled
 	}
 }
 

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -7,10 +7,21 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/muesli/termenv"
 
 	"github.com/Fail-Safe/Noema/internal/cortex"
 	"github.com/Fail-Safe/Noema/internal/trace"
 )
+
+// TestMain forces lipgloss into a known color profile for the whole
+// test binary. Without this, lipgloss detects the go-test environment
+// as non-TTY and strips every escape sequence, so style-assertion
+// tests can't distinguish `styleSelected` from `styleSelectedDim`.
+func TestMain(m *testing.M) {
+	lipgloss.SetColorProfile(termenv.ANSI256)
+	os.Exit(m.Run())
+}
 
 // ---- test helpers ----------------------------------------------------------
 
@@ -556,5 +567,794 @@ func TestView_ConfirmFooter(t *testing.T) {
 	view := m.View()
 	if !strings.Contains(view, "archive") {
 		t.Errorf("expected 'archive' in confirm footer, view:\n%s", view)
+	}
+}
+
+// ---- follow mode (live auto-refresh) ---------------------------------------
+
+func TestFollow_ToggleStartsAndStopsTickChain(t *testing.T) {
+	cx := setupCortex(t)
+	m := loadedModel(t, cx)
+
+	if m.follow {
+		t.Fatalf("follow should default to false")
+	}
+
+	// Press f to enable follow mode.
+	m2, cmd := m.updateList(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("f")})
+	if !m2.follow {
+		t.Errorf("after f: follow = false, want true")
+	}
+	if m2.followGen != 1 {
+		t.Errorf("after first f: followGen = %d, want 1", m2.followGen)
+	}
+	if cmd == nil {
+		t.Fatal("enabling follow should return a tickCmd")
+	}
+
+	// Press f again to disable. No new command should be scheduled.
+	m3, cmd := m2.updateList(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("f")})
+	if m3.follow {
+		t.Errorf("after second f: follow = true, want false")
+	}
+	if cmd != nil {
+		t.Error("disabling follow should not return a command")
+	}
+
+	// Re-enable: generation must bump so any stale tick from the first
+	// session would be discarded.
+	m4, _ := m3.updateList(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("f")})
+	if m4.followGen != 2 {
+		t.Errorf("after re-enable: followGen = %d, want 2", m4.followGen)
+	}
+}
+
+func TestFollow_TickMsgRefreshesWhenOn(t *testing.T) {
+	cx := setupCortex(t)
+	addTrace(t, cx, "only", "note")
+	m := loadedModel(t, cx)
+	m.follow = true
+	m.followGen = 1
+
+	result, cmd := m.Update(tickMsg{gen: 1})
+	m2 := result.(model)
+
+	if !m2.follow {
+		t.Error("tick should not clear follow")
+	}
+	if cmd == nil {
+		t.Fatal("active tick should return a batch (next tick + loadRows)")
+	}
+}
+
+func TestFollow_StaleTickIsDiscarded(t *testing.T) {
+	cx := setupCortex(t)
+	m := loadedModel(t, cx)
+	m.follow = true
+	m.followGen = 5
+
+	// A tickMsg from generation 3 (e.g. left over from a prior session)
+	// must be ignored — no reschedule, no refresh.
+	_, cmd := m.Update(tickMsg{gen: 3})
+	if cmd != nil {
+		t.Error("stale tick should not schedule anything")
+	}
+}
+
+func TestFollow_TickWhileFollowOffIsDiscarded(t *testing.T) {
+	cx := setupCortex(t)
+	m := loadedModel(t, cx)
+	// follow is false (default)
+
+	_, cmd := m.Update(tickMsg{gen: 0})
+	if cmd != nil {
+		t.Error("tick while follow is off should not schedule anything")
+	}
+}
+
+func TestFollow_TickSuppressesRefreshInSearchState(t *testing.T) {
+	cx := setupCortex(t)
+	m := loadedModel(t, cx)
+	m.follow = true
+	m.followGen = 1
+	m.state = stateSearch
+
+	// In search state the refresh is suppressed but the tick chain
+	// must keep spinning so polling resumes once search closes.
+	_, cmd := m.Update(tickMsg{gen: 1})
+	if cmd == nil {
+		t.Fatal("tick should still reschedule even when refresh is suppressed")
+	}
+}
+
+func TestFollow_ManualRefreshKey(t *testing.T) {
+	cx := setupCortex(t)
+	addTrace(t, cx, "one", "note")
+	m := loadedModel(t, cx)
+
+	// Press R to trigger a manual reload (works regardless of follow state).
+	_, cmd := m.updateList(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("R")})
+	if cmd == nil {
+		t.Error("R should return a load command")
+	}
+}
+
+func TestFollow_HeaderShowsLiveBadge(t *testing.T) {
+	cx := setupCortex(t)
+	m := loadedModel(t, cx)
+
+	// The distinctive badge is "● live" — plain "live" is also in the
+	// footer hint ("f:live  R:refresh") so we can't use that as the
+	// needle without false-positives.
+	const badge = "● live"
+
+	if strings.Contains(m.View(), badge) {
+		t.Error("live badge should not appear when follow is off")
+	}
+
+	m.follow = true
+	if !strings.Contains(m.View(), badge) {
+		t.Errorf("live badge should appear when follow is on, view:\n%s", m.View())
+	}
+}
+
+// ---- sticky cursor ---------------------------------------------------------
+
+func TestStickyCursor_PreservesSelectionWhenNewRowArrivesAtTop(t *testing.T) {
+	cx := setupCortex(t)
+	a := addTrace(t, cx, "alpha", "note")
+	b := addTrace(t, cx, "beta", "note")
+	m := loadedModel(t, cx)
+
+	// Traces are ordered created_at DESC, so "beta" is at index 0 and
+	// "alpha" is at index 1. Put the cursor on alpha.
+	var alphaIdx int
+	for i, r := range m.rows {
+		if r.ID == a.ID {
+			alphaIdx = i
+		}
+	}
+	m.cursor = alphaIdx
+
+	// Simulate a new trace arriving at the top (what an agent writing
+	// in the background would produce).
+	c := addTrace(t, cx, "gamma", "note")
+	_ = c
+	_ = b
+
+	msg := loadRows(cx, "", false, false)()
+	result, _ := m.Update(msg)
+	m2 := result.(model)
+
+	if len(m2.rows) != 3 {
+		t.Fatalf("expected 3 rows, got %d", len(m2.rows))
+	}
+	// Cursor should still be pointing at alpha, even though its index
+	// shifted down by one when gamma was inserted at the top.
+	if m2.rows[m2.cursor].ID != a.ID {
+		t.Errorf("cursor drifted: now on %q, want alpha (%q)",
+			m2.rows[m2.cursor].ID, a.ID)
+	}
+}
+
+func TestStickyCursor_ClampsWhenSelectedRowDisappears(t *testing.T) {
+	cx := setupCortex(t)
+	addTrace(t, cx, "keep-1", "note")
+	gone := addTrace(t, cx, "gone", "note")
+	addTrace(t, cx, "keep-2", "note")
+	m := loadedModel(t, cx)
+
+	for i, r := range m.rows {
+		if r.ID == gone.ID {
+			m.cursor = i
+		}
+	}
+
+	// Archive the selected trace so it leaves the active view.
+	if err := cx.Archive(gone.ID); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+
+	msg := loadRows(cx, "", false, false)()
+	result, _ := m.Update(msg)
+	m2 := result.(model)
+
+	if len(m2.rows) != 2 {
+		t.Fatalf("expected 2 rows after archive, got %d", len(m2.rows))
+	}
+	if m2.cursor < 0 || m2.cursor >= len(m2.rows) {
+		t.Errorf("cursor out of bounds after sticky fallback: %d", m2.cursor)
+	}
+}
+
+// ---- new-row highlight -----------------------------------------------------
+
+func TestNewRowHighlight_MarksArrivalsOnRefresh(t *testing.T) {
+	cx := setupCortex(t)
+	addTrace(t, cx, "first", "note")
+	m := loadedModel(t, cx)
+
+	// Initial load should not highlight anything — there's no
+	// "previous" snapshot to diff against.
+	if len(m.newRowTTL) != 0 {
+		t.Errorf("initial load should not mark any rows as new, got %d",
+			len(m.newRowTTL))
+	}
+
+	// Now add a new trace and refresh. The new trace ID should be
+	// flagged, but the pre-existing one should not.
+	second := addTrace(t, cx, "second", "note")
+
+	msg := loadRows(cx, "", false, false)()
+	result, _ := m.Update(msg)
+	m2 := result.(model)
+
+	if m2.newRowTTL[second.ID] != newRowHighlightTicks {
+		t.Errorf("new row TTL = %d, want %d",
+			m2.newRowTTL[second.ID], newRowHighlightTicks)
+	}
+	// Sanity: only the new row is flagged.
+	if len(m2.newRowTTL) != 1 {
+		t.Errorf("expected 1 highlighted row, got %d", len(m2.newRowTTL))
+	}
+}
+
+func TestNewRowHighlight_FadesAcrossConsecutiveRefreshes(t *testing.T) {
+	cx := setupCortex(t)
+	addTrace(t, cx, "first", "note")
+	m := loadedModel(t, cx)
+
+	// Add a new trace — refresh #1 flags it with a fresh TTL.
+	fresh := addTrace(t, cx, "fresh", "note")
+	msg := loadRows(cx, "", false, false)()
+	result, _ := m.Update(msg)
+	m1 := result.(model)
+
+	if m1.newRowTTL[fresh.ID] != newRowHighlightTicks {
+		t.Fatalf("after first refresh: ttl = %d, want %d",
+			m1.newRowTTL[fresh.ID], newRowHighlightTicks)
+	}
+
+	// Refresh #2 — no new arrivals, existing TTL should decrement.
+	msg = loadRows(cx, "", false, false)()
+	result, _ = m1.Update(msg)
+	m2 := result.(model)
+
+	if m2.newRowTTL[fresh.ID] != newRowHighlightTicks-1 {
+		t.Errorf("after second refresh: ttl = %d, want %d",
+			m2.newRowTTL[fresh.ID], newRowHighlightTicks-1)
+	}
+
+	// Refresh #3 — TTL expires and the row is removed from the map.
+	msg = loadRows(cx, "", false, false)()
+	result, _ = m2.Update(msg)
+	m3 := result.(model)
+
+	if _, still := m3.newRowTTL[fresh.ID]; still {
+		t.Errorf("after third refresh: row still highlighted, want expired")
+	}
+}
+
+func TestNewRowHighlight_ContextChangeWipesHighlights(t *testing.T) {
+	cx := setupCortex(t)
+	addTrace(t, cx, "active", "note")
+	m := loadedModel(t, cx)
+
+	// Create a highlighted state by adding a trace and refreshing.
+	added := addTrace(t, cx, "added", "note")
+	msg := loadRows(cx, "", false, false)()
+	result, _ := m.Update(msg)
+	m1 := result.(model)
+
+	if _, ok := m1.newRowTTL[added.ID]; !ok {
+		t.Fatalf("setup failed: expected highlight on added trace")
+	}
+
+	// User toggles `a` (show all) — a context change. The next
+	// rowsLoadedMsg should wipe the old highlight map, not pretend the
+	// toggled-in rows are "new arrivals".
+	m1.showAll = true
+	msg = loadRows(cx, "", true, false)()
+	result, _ = m1.Update(msg)
+	m2 := result.(model)
+
+	if len(m2.newRowTTL) != 0 {
+		t.Errorf("context change should wipe highlights, got %d entries",
+			len(m2.newRowTTL))
+	}
+}
+
+// TestHeader_BrandWordmark verifies the TUI header renders "Noema."
+// split into two styled runs: "Noema" in brand cream and "." in brand
+// red — matching the website wordmark. Locks in the CompleteColor
+// fallbacks (223 for cream, 161 for red) so a future style refactor
+// can't regress to termenv's broken auto-downconversion, which maps
+// #e10032 to color 232 (near-black).
+func TestHeader_BrandWordmark(t *testing.T) {
+	cx := setupCortex(t)
+	m := loadedModel(t, cx)
+
+	header := m.renderHeader()
+
+	// Both the wordmark and the accent period must appear.
+	if !strings.Contains(header, "Noema") {
+		t.Errorf("header missing 'Noema':\n%q", header)
+	}
+	if !strings.Contains(header, ".") {
+		t.Errorf("header missing brand period '.':\n%q", header)
+	}
+
+	// Brand cream resolves to 256-color 223 on the ANSI256 profile
+	// pinned by TestMain. Bold + fg 223.
+	if !strings.Contains(header, "\x1b[1;38;5;223m") {
+		t.Errorf("header missing brand cream SGR (1;38;5;223):\n%q", header)
+	}
+
+	// Brand red resolves to 256-color 161 on the ANSI256 profile.
+	// Bold + fg 161. The old bug downconverted to 232 (near-black);
+	// guard against any regression that reintroduces it.
+	if !strings.Contains(header, "\x1b[1;38;5;161m") {
+		t.Errorf("header missing brand red SGR (1;38;5;161):\n%q", header)
+	}
+	if strings.Contains(header, "\x1b[1;38;5;232m") {
+		t.Error("header period downconverted to near-black (232) — " +
+			"CompleteColor ANSI256 fallback is broken")
+	}
+	if strings.Contains(header, "\x1b[38;5;99m") {
+		t.Error("header still uses old purple (xterm-256 color 99)")
+	}
+}
+
+// ---- pane focus + detail scroll --------------------------------------------
+
+// longBody builds a body with n lines so the detail pane definitely
+// overflows. Each line is short enough to avoid wrap concerns at width=120.
+func longBody(n int) string {
+	var sb strings.Builder
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			sb.WriteByte('\n')
+		}
+		sb.WriteString("line ")
+		// left-pad digit so every line has the same byte count and we
+		// don't accidentally wrap later.
+		sb.WriteString(strings.Repeat("0", 3))
+	}
+	return sb.String()
+}
+
+// addTraceWithBody inserts a trace with a custom body — the default
+// addTrace helper uses "body of <title>" which is too short for scroll
+// tests.
+func addTraceWithBody(t *testing.T, cx *cortex.Cortex, title, body string) *trace.Trace {
+	t.Helper()
+	tr := trace.New(title, "note", "", nil, body)
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	return tr
+}
+
+func TestTab_TogglesFocus(t *testing.T) {
+	cx := setupCortex(t)
+	addTrace(t, cx, "first", "note")
+	m := loadedModel(t, cx)
+
+	if m.focus != focusList {
+		t.Fatalf("initial focus = %v, want focusList", m.focus)
+	}
+
+	m2, _ := m.updateList(tea.KeyMsg{Type: tea.KeyTab})
+	if m2.focus != focusDetail {
+		t.Errorf("after tab: focus = %v, want focusDetail", m2.focus)
+	}
+
+	m3, _ := m2.updateList(tea.KeyMsg{Type: tea.KeyTab})
+	if m3.focus != focusList {
+		t.Errorf("after 2nd tab: focus = %v, want focusList", m3.focus)
+	}
+}
+
+func TestArrowKeys_SetFocusAbsolutely(t *testing.T) {
+	cx := setupCortex(t)
+	addTrace(t, cx, "first", "note")
+	m := loadedModel(t, cx)
+
+	// From list focus: right moves to detail.
+	m2, _ := m.updateList(tea.KeyMsg{Type: tea.KeyRight})
+	if m2.focus != focusDetail {
+		t.Errorf("after right from list: focus = %v, want focusDetail", m2.focus)
+	}
+
+	// From detail focus: left moves back to list.
+	m3, _ := m2.updateList(tea.KeyMsg{Type: tea.KeyLeft})
+	if m3.focus != focusList {
+		t.Errorf("after left from detail: focus = %v, want focusList", m3.focus)
+	}
+
+	// Right is idempotent — pressing it while detail-focused is a no-op.
+	m4, _ := m2.updateList(tea.KeyMsg{Type: tea.KeyRight})
+	if m4.focus != focusDetail {
+		t.Errorf("right on detail-focus: focus = %v, want focusDetail", m4.focus)
+	}
+
+	// Left is idempotent too — pressing it while list-focused stays put.
+	m5, _ := m.updateList(tea.KeyMsg{Type: tea.KeyLeft})
+	if m5.focus != focusList {
+		t.Errorf("left on list-focus: focus = %v, want focusList", m5.focus)
+	}
+}
+
+func TestArrowKeys_DoNotMoveCursor(t *testing.T) {
+	// Left/right arrow keys are for pane switching only — they must
+	// not advance or rewind the list cursor. Regression guard against
+	// accidentally aliasing them to j/k.
+	cx := setupCortex(t)
+	addTrace(t, cx, "a", "note")
+	addTrace(t, cx, "b", "note")
+	addTrace(t, cx, "c", "note")
+	m := loadedModel(t, cx)
+	m.cursor = 1 // start mid-list
+
+	m2, _ := m.updateList(tea.KeyMsg{Type: tea.KeyRight})
+	if m2.cursor != 1 {
+		t.Errorf("right moved cursor: %d -> %d", 1, m2.cursor)
+	}
+
+	m3, _ := m2.updateList(tea.KeyMsg{Type: tea.KeyLeft})
+	if m3.cursor != 1 {
+		t.Errorf("left moved cursor: %d -> %d", 1, m3.cursor)
+	}
+}
+
+func TestTab_EscFromDetailReturnsToList(t *testing.T) {
+	cx := setupCortex(t)
+	addTrace(t, cx, "first", "note")
+	m := loadedModel(t, cx)
+
+	m2, _ := m.updateList(tea.KeyMsg{Type: tea.KeyTab})
+	if m2.focus != focusDetail {
+		t.Fatalf("setup: focus = %v, want focusDetail", m2.focus)
+	}
+
+	m3, _ := m2.updateList(tea.KeyMsg{Type: tea.KeyEsc})
+	if m3.focus != focusList {
+		t.Errorf("after esc: focus = %v, want focusList", m3.focus)
+	}
+}
+
+func TestDetailScroll_JKScrollsBody(t *testing.T) {
+	cx := setupCortex(t)
+	addTraceWithBody(t, cx, "long", longBody(200))
+	m := loadedModel(t, cx)
+	m.focus = focusDetail
+
+	if m.detailScroll != 0 {
+		t.Fatalf("initial detailScroll = %d, want 0", m.detailScroll)
+	}
+
+	m2, _ := m.updateList(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	if m2.detailScroll != 1 {
+		t.Errorf("after j: detailScroll = %d, want 1", m2.detailScroll)
+	}
+	// List cursor must NOT have moved.
+	if m2.cursor != m.cursor {
+		t.Errorf("j in detail focus moved list cursor: %d -> %d", m.cursor, m2.cursor)
+	}
+
+	m3, _ := m2.updateList(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")})
+	if m3.detailScroll != 0 {
+		t.Errorf("after k: detailScroll = %d, want 0", m3.detailScroll)
+	}
+}
+
+func TestDetailScroll_Bounds(t *testing.T) {
+	cx := setupCortex(t)
+	addTraceWithBody(t, cx, "long", longBody(200))
+	m := loadedModel(t, cx)
+	m.focus = focusDetail
+
+	// k at top stays at 0.
+	m2, _ := m.updateList(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("k")})
+	if m2.detailScroll != 0 {
+		t.Errorf("k at top: detailScroll = %d, want 0", m2.detailScroll)
+	}
+
+	// G jumps to bottom = max.
+	m3, _ := m2.updateList(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("G")})
+	max := m3.detailMaxScroll()
+	if max == 0 {
+		t.Fatalf("test setup broken: max scroll = 0 — body too short")
+	}
+	if m3.detailScroll != max {
+		t.Errorf("after G: detailScroll = %d, want %d (max)", m3.detailScroll, max)
+	}
+
+	// j at bottom stays at max.
+	m4, _ := m3.updateList(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	if m4.detailScroll != max {
+		t.Errorf("j at bottom: detailScroll = %d, want %d (max)", m4.detailScroll, max)
+	}
+}
+
+func TestDetailScroll_GJumpsToTopBottom(t *testing.T) {
+	cx := setupCortex(t)
+	addTraceWithBody(t, cx, "long", longBody(200))
+	m := loadedModel(t, cx)
+	m.focus = focusDetail
+
+	// G bottom, then g top.
+	mEnd, _ := m.updateList(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("G")})
+	if mEnd.detailScroll == 0 {
+		t.Fatalf("G in detail focus should advance past 0")
+	}
+
+	mTop, _ := mEnd.updateList(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("g")})
+	if mTop.detailScroll != 0 {
+		t.Errorf("g in detail focus: detailScroll = %d, want 0", mTop.detailScroll)
+	}
+
+	// And cursor never moved during any of this.
+	if mTop.cursor != m.cursor {
+		t.Errorf("G/g in detail focus moved list cursor: %d -> %d", m.cursor, mTop.cursor)
+	}
+}
+
+func TestDetailScroll_HalfPage(t *testing.T) {
+	cx := setupCortex(t)
+	addTraceWithBody(t, cx, "long", longBody(200))
+	m := loadedModel(t, cx)
+	m.focus = focusDetail
+
+	step := m.detailVisibleBodyH() / 2
+	if step < 1 {
+		t.Fatalf("test setup broken: half-page step = %d", step)
+	}
+
+	// Ctrl+D scrolls down a half page.
+	m2, _ := m.updateList(tea.KeyMsg{Type: tea.KeyCtrlD})
+	if m2.detailScroll != step {
+		t.Errorf("after ctrl+d: detailScroll = %d, want %d", m2.detailScroll, step)
+	}
+
+	// Ctrl+U scrolls back up a half page.
+	m3, _ := m2.updateList(tea.KeyMsg{Type: tea.KeyCtrlU})
+	if m3.detailScroll != 0 {
+		t.Errorf("after ctrl+u: detailScroll = %d, want 0", m3.detailScroll)
+	}
+
+	// PgDown is an alias for ctrl+d.
+	m4, _ := m.updateList(tea.KeyMsg{Type: tea.KeyPgDown})
+	if m4.detailScroll != step {
+		t.Errorf("after pgdown: detailScroll = %d, want %d", m4.detailScroll, step)
+	}
+
+	// PgUp is an alias for ctrl+u.
+	m5, _ := m4.updateList(tea.KeyMsg{Type: tea.KeyPgUp})
+	if m5.detailScroll != 0 {
+		t.Errorf("after pgup: detailScroll = %d, want 0", m5.detailScroll)
+	}
+}
+
+func TestDetailScroll_ResetsOnTraceChange(t *testing.T) {
+	cx := setupCortex(t)
+	addTraceWithBody(t, cx, "first", longBody(200))
+	addTraceWithBody(t, cx, "second", longBody(200))
+	m := loadedModel(t, cx)
+	m.focus = focusDetail
+
+	// Scroll the first trace.
+	m2, _ := m.updateList(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("G")})
+	if m2.detailScroll == 0 {
+		t.Fatalf("setup: G should have scrolled first trace")
+	}
+
+	// Switch back to list focus and move cursor to second trace.
+	m3, _ := m2.updateList(tea.KeyMsg{Type: tea.KeyTab})
+	m4, _ := m3.updateList(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+
+	if m4.detailScroll != 0 {
+		t.Errorf("trace change should reset detailScroll, got %d", m4.detailScroll)
+	}
+}
+
+func TestDetailScroll_PreservedOnTabToggle(t *testing.T) {
+	cx := setupCortex(t)
+	addTraceWithBody(t, cx, "long", longBody(200))
+	m := loadedModel(t, cx)
+	m.focus = focusDetail
+
+	// Scroll down 5 lines.
+	cur := m
+	for i := 0; i < 5; i++ {
+		cur, _ = cur.updateList(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	}
+	if cur.detailScroll != 5 {
+		t.Fatalf("setup: detailScroll = %d, want 5", cur.detailScroll)
+	}
+
+	// Tab to list, tab back to detail — same trace, scroll should persist.
+	back, _ := cur.updateList(tea.KeyMsg{Type: tea.KeyTab})
+	forth, _ := back.updateList(tea.KeyMsg{Type: tea.KeyTab})
+	if forth.detailScroll != 5 {
+		t.Errorf("tab-toggle dropped scroll: got %d, want 5", forth.detailScroll)
+	}
+}
+
+func TestDetailScroll_NoOpWhenBodyFitsInPane(t *testing.T) {
+	cx := setupCortex(t)
+	addTrace(t, cx, "short", "note") // default body is tiny
+	m := loadedModel(t, cx)
+	m.focus = focusDetail
+
+	if m.detailMaxScroll() != 0 {
+		t.Fatalf("setup: short body shouldn't overflow")
+	}
+
+	m2, _ := m.updateList(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("j")})
+	if m2.detailScroll != 0 {
+		t.Errorf("j with body-fits-in-pane: detailScroll = %d, want 0", m2.detailScroll)
+	}
+}
+
+// ---- metadata truncation (UI-shift bug fix) --------------------------------
+
+func TestMetadataOverflow_LongIDsTruncated(t *testing.T) {
+	cx := setupCortex(t)
+	addTrace(t, cx, "x", "note")
+	m := loadedModel(t, cx)
+
+	// Blast the current trace with overlong metadata. Without
+	// per-field truncation these would soft-wrap and push the metadata
+	// block past its expected line count.
+	m.current.ID = strings.Repeat("A", 500)
+	m.current.Author = strings.Repeat("B", 500)
+	m.current.Tags = []string{strings.Repeat("c", 500)}
+
+	_, detailW := m.paneWidths()
+	rendered := m.renderDetail(detailW, m.bodyHeight())
+
+	// The raw 500-char strings must never appear verbatim in the
+	// rendered output — every metadata value passes through truncRune.
+	if strings.Contains(rendered, strings.Repeat("A", 500)) {
+		t.Error("id was rendered without truncation")
+	}
+	if strings.Contains(rendered, strings.Repeat("B", 500)) {
+		t.Error("author was rendered without truncation")
+	}
+	if strings.Contains(rendered, strings.Repeat("c", 500)) {
+		t.Error("tags were rendered without truncation")
+	}
+	// And the truncation glyph should be present somewhere.
+	if !strings.Contains(rendered, "…") {
+		t.Error("expected truncation glyph '…' in metadata row")
+	}
+}
+
+// ---- focus-aware rendering -------------------------------------------------
+
+func TestFooter_HintChangesOnFocus(t *testing.T) {
+	cx := setupCortex(t)
+	addTrace(t, cx, "first", "note")
+	m := loadedModel(t, cx)
+
+	listHint := m.renderFooter()
+	if !strings.Contains(listHint, "tab:body") {
+		t.Errorf("list-focus footer missing 'tab:body' hint:\n%s", listHint)
+	}
+	if !strings.Contains(listHint, "n:new") {
+		t.Errorf("list-focus footer missing 'n:new' hint:\n%s", listHint)
+	}
+
+	m.focus = focusDetail
+	detailHint := m.renderFooter()
+	if !strings.Contains(detailHint, "scroll") {
+		t.Errorf("detail-focus footer missing 'scroll' hint:\n%s", detailHint)
+	}
+	if !strings.Contains(detailHint, "tab:list") {
+		t.Errorf("detail-focus footer missing 'tab:list' hint:\n%s", detailHint)
+	}
+	if strings.Contains(detailHint, "n:new") {
+		t.Errorf("detail-focus footer should not advertise n:new:\n%s", detailHint)
+	}
+}
+
+// TestFooter_AlignmentTracksFocus locks in the "footer flips sides with
+// focus" behavior: list focus keeps the hint on the left (2-space
+// gutter), detail focus pushes it to the right edge (2-space right
+// gutter). This is a secondary focus cue on top of the pane-dim and
+// cursor-glyph swap.
+func TestFooter_AlignmentTracksFocus(t *testing.T) {
+	cx := setupCortex(t)
+	addTrace(t, cx, "first", "note")
+	m := loadedModel(t, cx)
+
+	// List focus: leading gutter, no trailing pad run.
+	listHint := m.renderFooter()
+	if !strings.HasPrefix(listHint, "  ") {
+		t.Errorf("list-focus footer missing leading 2-space gutter:\n%q", listHint)
+	}
+
+	// Detail focus: trailing gutter, and the visible width of the
+	// footer (leading pad + styled hint + trailing pad) should equal
+	// the model width — i.e. the hint is pinned to the right edge.
+	m.focus = focusDetail
+	detailHint := m.renderFooter()
+	if !strings.HasSuffix(detailHint, "  ") {
+		t.Errorf("detail-focus footer missing trailing 2-space gutter:\n%q", detailHint)
+	}
+	if lipgloss.Width(detailHint) != m.width {
+		t.Errorf("detail-focus footer width = %d, want %d (full pane width)",
+			lipgloss.Width(detailHint), m.width)
+	}
+	// Spot-check: a lot of leading spaces, meaning the hint was pushed
+	// right — it should start with at least a dozen blanks.
+	leading := len(detailHint) - len(strings.TrimLeft(detailHint, " "))
+	if leading < 12 {
+		t.Errorf("detail-focus footer leading pad = %d, want many more spaces:\n%q",
+			leading, detailHint)
+	}
+}
+
+func TestList_CursorGlyphChangesOnFocus(t *testing.T) {
+	cx := setupCortex(t)
+	addTrace(t, cx, "alpha", "note")
+	m := loadedModel(t, cx)
+
+	listW, _ := m.paneWidths()
+	bodyH := m.bodyHeight()
+	activeRender := m.renderList(listW, bodyH)
+	if !strings.Contains(activeRender, "▸") {
+		t.Errorf("list-focus render missing active cursor '▸':\n%s", activeRender)
+	}
+	if strings.Contains(activeRender, "·") {
+		t.Errorf("list-focus render should not use dim cursor '·':\n%s", activeRender)
+	}
+
+	m.focus = focusDetail
+	dimRender := m.renderList(listW, bodyH)
+	if !strings.Contains(dimRender, "·") {
+		t.Errorf("detail-focus render missing dim cursor '·':\n%s", dimRender)
+	}
+	if strings.Contains(dimRender, "▸") {
+		t.Errorf("detail-focus render should not use active cursor '▸':\n%s", dimRender)
+	}
+}
+
+// TestList_WholePaneDimsWhenDetailFocused verifies the "modal backdrop"
+// behavior: every row — not just the selected one — swaps to a dim
+// style when focus is on the detail pane, so the entire list visibly
+// recedes.
+func TestList_WholePaneDimsWhenDetailFocused(t *testing.T) {
+	cx := setupCortex(t)
+	addTrace(t, cx, "alpha", "note")
+	addTrace(t, cx, "beta", "note")
+	addTrace(t, cx, "gamma", "note")
+	m := loadedModel(t, cx)
+
+	listW, _ := m.paneWidths()
+	bodyH := m.bodyHeight()
+
+	// The two renders must differ — if they match byte-for-byte, the
+	// dim treatment isn't being applied to non-selected rows.
+	active := m.renderList(listW, bodyH)
+
+	m.focus = focusDetail
+	dim := m.renderList(listW, bodyH)
+
+	if active == dim {
+		t.Errorf("renderList output unchanged between list/detail focus — " +
+			"non-selected rows aren't dimming")
+	}
+
+	// The dim-row ANSI color (238) should be somewhere in the detail-
+	// focus render, and absent from the active render (where unselected
+	// rows render through a plain zero-style).
+	const dimFgSeq = "\x1b[38;5;238m"
+	if !strings.Contains(dim, dimFgSeq) {
+		t.Errorf("detail-focus render missing dim fg ANSI (238):\n%q", dim)
+	}
+	if strings.Contains(active, dimFgSeq) {
+		t.Errorf("list-focus render should not contain dim fg ANSI (238):\n%q", active)
 	}
 }


### PR DESCRIPTION
## Summary

A set of interlocking TUI improvements that turn the list view into a fully live, keyboard-driven memory browser:

- **Live-refresh mode** (`f` toggle) — reverse-tail auto-reload; sticky cursor across refreshes; new-row highlight fades over 2 ticks; `● live` badge in the header; stale-tick generation counter guards against runaway polling on rapid toggle.
- **Manual refresh** (`R`) — fire one reload without touching follow state.
- **Pane focus** — Tab cycles focus between the list and detail panes; Left/Right arrows set focus absolutely (left=list, right=detail) for one-handed browsing.
- **Body scroll** in the detail pane — `j/k`, `g/G`, `PgUp/PgDn`, `Ctrl+U/D`, with a scroll indicator (▴/▾/▴▾ glyph + `N/M` fraction) on the separator line, and automatic reset on trace change.
- **Modal backdrop** — when detail is focused, the list pane dims uniformly (not just the selected row); footer right-aligns as a secondary focus cue; cursor glyph swaps `▸` ↔ `·`.
- **Metadata truncation fix** — overlong id/author/tags values no longer soft-wrap and push the detail pane up by a row.
- **Brand wordmark** — header renders "Noema." in brand cream + red, using `lipgloss.CompleteColor` fallbacks so 256-color terminals get hand-picked palette indices (223, 161) instead of termenv's broken auto-downconversion (which mapped `#e10032` to near-black color 232).

**Version impact:** This is a minor bump → **v0.4.0** (five new features + a bug fix).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race -count=1 ./...` — full repo suite green
- [x] New TUI tests added: Tab/arrow focus, body scroll (all variants + bounds + reset + tab-preserved), metadata overflow guard, footer alignment, cursor glyph swap, whole-pane dim, brand wordmark colors
- [x] Manual smoke: live mode visually verified (reverse-tail, highlight fade, badge); Tab/arrow pane switching verified; brand wordmark verified to render cream + red on dark terminal
- [ ] Reviewer smoke: `go run ./cmd/noema` on your own cortex, toggle `f`, Tab between panes, scroll a long trace, confirm the wordmark colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)