### PR TITLE
feat(tui): dark/light theme, tag chips, config command

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,10 +193,20 @@ noema serve [--transport stdio|http] [--host <addr>] [--tls-cert <file> --tls-ke
 noema serve --print-config                Print a ready-to-use .mcp.json snippet and exit
 noema serve ... --print-systemd-unit      Print a systemd service unit for the current serve flags
 noema serve ... --print-launchd-plist     Print a launchd LaunchAgent plist for the current serve flags
-noema tui                                 Open the interactive TUI
+noema tui [--theme auto|dark|light]       Open the interactive TUI
+noema config get <key>                    Print a user-level setting (ui.theme, trash_days)
+noema config set <key> <value>            Update and persist a user-level setting
+noema config list                         List every known config key with its current value
 noema completion [bash|zsh|fish|install]  Generate shell completions
 noema version                             Print version, commit, and build date
 ```
+
+**TUI theme priority** (highest wins):
+
+1. `--theme` flag on `noema tui`
+2. `NOEMA_THEME` environment variable
+3. `ui.theme` in `~/.config/noema/config.yaml` (`noema config set ui.theme dark`)
+4. `auto` — detected from the terminal's reported background color
 
 **Common flags:**
 

--- a/internal/cli/cmd_config.go
+++ b/internal/cli/cmd_config.go
@@ -1,0 +1,198 @@
+package cli
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Fail-Safe/Noema/internal/config"
+)
+
+// configCmd exposes a `get`/`set` surface over a small whitelist of
+// user-level settings in ~/.config/noema/config.yaml. Keys are flat
+// dotted names (`ui.theme`, `trash_days`) — we refuse unknown keys
+// rather than letting users scribble arbitrary fields into the file,
+// so the YAML stays parseable by older binaries.
+func configCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Get or set user-level settings",
+	}
+	cmd.AddCommand(configGetCmd(), configSetCmd(), configListCmd())
+	return cmd
+}
+
+// configKey describes one settable field. Parse validates + coerces
+// the user's raw string into the Go type the Config struct expects.
+// Apply writes the parsed value into the loaded config. Format turns
+// the current value back into a user-facing display string.
+type configKey struct {
+	name     string
+	describe string
+	parse    func(raw string) (any, error)
+	apply    func(cfg *config.Config, value any)
+	format   func(cfg *config.Config) string
+}
+
+// configKeys is the whitelist. Adding a new setting is a three-field
+// entry here; nothing else about `noema config` has to change.
+var configKeys = []configKey{
+	{
+		name:     "ui.theme",
+		describe: `TUI color scheme — "auto", "dark", or "light"`,
+		parse: func(raw string) (any, error) {
+			switch raw {
+			case "auto", "dark", "light":
+				return raw, nil
+			case "":
+				// Treat empty as "clear the preference" — handled in apply
+				// by passing the empty string through to SetTheme.
+				return "", nil
+			default:
+				return nil, fmt.Errorf(`invalid theme %q: must be "auto", "dark", or "light"`, raw)
+			}
+		},
+		apply: func(cfg *config.Config, value any) {
+			cfg.SetTheme(value.(string))
+		},
+		format: func(cfg *config.Config) string {
+			return cfg.Theme()
+		},
+	},
+	{
+		name:     "trash_days",
+		describe: "How many days trashed traces are kept before auto-purge (0 = default of 30)",
+		parse: func(raw string) (any, error) {
+			n, err := strconv.Atoi(raw)
+			if err != nil {
+				return nil, fmt.Errorf("invalid trash_days %q: must be a non-negative integer", raw)
+			}
+			if n < 0 {
+				return nil, fmt.Errorf("invalid trash_days %d: must be non-negative", n)
+			}
+			return n, nil
+		},
+		apply: func(cfg *config.Config, value any) {
+			cfg.TrashDays = value.(int)
+		},
+		format: func(cfg *config.Config) string {
+			if cfg.TrashDays == 0 {
+				return "0 (default: 30)"
+			}
+			return strconv.Itoa(cfg.TrashDays)
+		},
+	},
+}
+
+func lookupConfigKey(name string) (configKey, bool) {
+	for _, k := range configKeys {
+		if k.name == name {
+			return k, true
+		}
+	}
+	return configKey{}, false
+}
+
+func knownKeyNames() string {
+	names := make([]string, 0, len(configKeys))
+	for _, k := range configKeys {
+		names = append(names, k.name)
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
+}
+
+func configGetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "get <key>",
+		Short: "Print the current value of a config key",
+		Args:  cobra.ExactArgs(1),
+		ValidArgsFunction: func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+			if len(args) > 0 {
+				return nil, cobra.ShellCompDirectiveNoFileComp
+			}
+			names := make([]string, 0, len(configKeys))
+			for _, k := range configKeys {
+				names = append(names, k.name+"\t"+k.describe)
+			}
+			return names, cobra.ShellCompDirectiveNoFileComp
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			key, ok := lookupConfigKey(args[0])
+			if !ok {
+				return fmt.Errorf("unknown config key %q — known keys: %s", args[0], knownKeyNames())
+			}
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), key.format(cfg))
+			return nil
+		},
+	}
+}
+
+func configSetCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "set <key> <value>",
+		Short: "Update a config key and persist it",
+		Args:  cobra.ExactArgs(2),
+		ValidArgsFunction: func(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+			if len(args) == 0 {
+				names := make([]string, 0, len(configKeys))
+				for _, k := range configKeys {
+					names = append(names, k.name+"\t"+k.describe)
+				}
+				return names, cobra.ShellCompDirectiveNoFileComp
+			}
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			key, ok := lookupConfigKey(args[0])
+			if !ok {
+				return fmt.Errorf("unknown config key %q — known keys: %s", args[0], knownKeyNames())
+			}
+			parsed, err := key.parse(args[1])
+			if err != nil {
+				return err
+			}
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+			key.apply(cfg, parsed)
+			if err := cfg.Save(); err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "%s = %s\n", key.name, key.format(cfg))
+			return nil
+		},
+	}
+}
+
+func configListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List every known config key with its current value",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			cfg, err := config.Load()
+			if err != nil {
+				return err
+			}
+			sorted := make([]configKey, len(configKeys))
+			copy(sorted, configKeys)
+			sort.Slice(sorted, func(i, j int) bool { return sorted[i].name < sorted[j].name })
+
+			w := cmd.OutOrStdout()
+			for _, k := range sorted {
+				fmt.Fprintf(w, "%-12s %s\n", k.name, k.format(cfg))
+				fmt.Fprintf(w, "             %s\n", k.describe)
+			}
+			return nil
+		},
+	}
+}

--- a/internal/cli/cmd_config_test.go
+++ b/internal/cli/cmd_config_test.go
@@ -1,0 +1,194 @@
+package cli
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Fail-Safe/Noema/internal/config"
+)
+
+// withTempConfigHome redirects HOME and XDG_CONFIG_HOME so config
+// reads/writes land in a per-test scratch directory. Returns the
+// directory so callers can poke at the file directly if they want.
+func withTempConfigHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, ".config"))
+	return dir
+}
+
+// runConfigCmd executes `noema config <args...>` against a fresh
+// command tree (so flag state from prior tests doesn't leak) and
+// returns the captured stdout, stderr, and run error. The command
+// tree is built fresh on each call because cobra's RunE error is
+// the only signal we get for invalid input.
+func runConfigCmd(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	cmd := configCmd()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return stdout.String(), err
+}
+
+// TestConfigSet_Theme_PersistsAndReadsBack pins the round-trip:
+// `config set ui.theme dark` writes the value, and a follow-up
+// `config get ui.theme` returns it. This is the user-visible
+// contract — flag/env/config priority is tested elsewhere via
+// resolveTheme.
+func TestConfigSet_Theme_PersistsAndReadsBack(t *testing.T) {
+	withTempConfigHome(t)
+
+	if _, err := runConfigCmd(t, "set", "ui.theme", "dark"); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+
+	out, err := runConfigCmd(t, "get", "ui.theme")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got := strings.TrimSpace(out); got != "dark" {
+		t.Errorf("get returned %q, want %q", got, "dark")
+	}
+
+	// Verify the on-disk file has the value too — guards against a
+	// path where the value lived only in memory.
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.Theme() != "dark" {
+		t.Errorf("loaded theme = %q, want dark", cfg.Theme())
+	}
+}
+
+// TestConfigSet_Theme_RejectsUnknown pins the validation: an
+// invalid theme value is refused with a clear error rather than
+// silently writing garbage to the config file.
+func TestConfigSet_Theme_RejectsUnknown(t *testing.T) {
+	withTempConfigHome(t)
+
+	_, err := runConfigCmd(t, "set", "ui.theme", "midnight")
+	if err == nil {
+		t.Fatal("expected error on invalid theme, got nil")
+	}
+	if !strings.Contains(err.Error(), "midnight") {
+		t.Errorf("error should name the bad value, got: %v", err)
+	}
+
+	// File must not have been written with the bad value.
+	cfg, _ := config.Load()
+	if cfg != nil && cfg.UI != nil && cfg.UI.Theme == "midnight" {
+		t.Error("invalid theme leaked into the config file")
+	}
+}
+
+// TestConfigSet_RejectsUnknownKey pins the whitelist: arbitrary
+// keys are refused so users can't accidentally scribble fields the
+// loader doesn't understand.
+func TestConfigSet_RejectsUnknownKey(t *testing.T) {
+	withTempConfigHome(t)
+
+	_, err := runConfigCmd(t, "set", "ui.font", "comic-sans")
+	if err == nil {
+		t.Fatal("expected error on unknown key")
+	}
+	if !strings.Contains(err.Error(), "ui.font") {
+		t.Errorf("error should name the unknown key, got: %v", err)
+	}
+}
+
+// TestConfigGet_Theme_DefaultIsAuto verifies the default surface:
+// a fresh config (no `ui:` block) reports the theme as "auto" so
+// the user gets a sensible answer instead of an empty string.
+func TestConfigGet_Theme_DefaultIsAuto(t *testing.T) {
+	withTempConfigHome(t)
+
+	out, err := runConfigCmd(t, "get", "ui.theme")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if got := strings.TrimSpace(out); got != "auto" {
+		t.Errorf("default theme = %q, want auto", got)
+	}
+}
+
+// TestResolveTheme_PriorityChain pins the flag/env/config priority
+// order documented for `noema tui --theme`. Flag wins over env,
+// env wins over config, config wins over the built-in "auto"
+// default. Each layer is exercised independently to keep failure
+// signals localized.
+func TestResolveTheme_PriorityChain(t *testing.T) {
+	t.Run("flag wins over env and config", func(t *testing.T) {
+		withTempConfigHome(t)
+		// Pre-populate the config with "dark"...
+		if _, err := runConfigCmd(t, "set", "ui.theme", "dark"); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		// ...and the env var with "dark" too...
+		t.Setenv("NOEMA_THEME", "dark")
+		// ...but the flag explicitly says "light", so light wins.
+		got, err := resolveTheme("light")
+		if err != nil {
+			t.Fatalf("resolveTheme: %v", err)
+		}
+		if got != "light" {
+			t.Errorf("got %q, want light", got)
+		}
+	})
+
+	t.Run("env wins over config", func(t *testing.T) {
+		withTempConfigHome(t)
+		if _, err := runConfigCmd(t, "set", "ui.theme", "dark"); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		t.Setenv("NOEMA_THEME", "light")
+		got, err := resolveTheme("")
+		if err != nil {
+			t.Fatalf("resolveTheme: %v", err)
+		}
+		if got != "light" {
+			t.Errorf("got %q, want light", got)
+		}
+	})
+
+	t.Run("config wins over default", func(t *testing.T) {
+		withTempConfigHome(t)
+		t.Setenv("NOEMA_THEME", "")
+		if _, err := runConfigCmd(t, "set", "ui.theme", "light"); err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+		got, err := resolveTheme("")
+		if err != nil {
+			t.Fatalf("resolveTheme: %v", err)
+		}
+		if got != "light" {
+			t.Errorf("got %q, want light", got)
+		}
+	})
+
+	t.Run("default is auto when nothing is set", func(t *testing.T) {
+		withTempConfigHome(t)
+		t.Setenv("NOEMA_THEME", "")
+		got, err := resolveTheme("")
+		if err != nil {
+			t.Fatalf("resolveTheme: %v", err)
+		}
+		if got != "auto" {
+			t.Errorf("got %q, want auto", got)
+		}
+	})
+
+	t.Run("rejects garbage flag value", func(t *testing.T) {
+		withTempConfigHome(t)
+		t.Setenv("NOEMA_THEME", "")
+		if _, err := resolveTheme("midnight"); err == nil {
+			t.Fatal("expected error on invalid theme")
+		}
+	})
+}

--- a/internal/cli/cmd_tui.go
+++ b/internal/cli/cmd_tui.go
@@ -1,22 +1,63 @@
 package cli
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/spf13/cobra"
 
+	"github.com/Fail-Safe/Noema/internal/config"
 	"github.com/Fail-Safe/Noema/internal/tui"
 )
 
 func tuiCmd() *cobra.Command {
-	return &cobra.Command{
+	var themeFlag string
+	cmd := &cobra.Command{
 		Use:   "tui",
 		Short: "Open the interactive TUI",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			theme, err := resolveTheme(themeFlag)
+			if err != nil {
+				return err
+			}
 			cx, err := resolveCortex()
 			if err != nil {
 				return err
 			}
 			defer cx.Close()
-			return tui.Run(cx)
+			return tui.Run(cx, theme)
 		},
+	}
+	cmd.Flags().StringVar(&themeFlag, "theme", "", `TUI theme: "auto", "dark", or "light" (overrides NOEMA_THEME and config)`)
+	cmd.RegisterFlagCompletionFunc("theme", func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
+		return []string{"auto", "dark", "light"}, cobra.ShellCompDirectiveNoFileComp
+	})
+	return cmd
+}
+
+// resolveTheme picks the TUI theme using the standard Noema priority
+// chain: explicit flag > NOEMA_THEME env var > config file > "auto".
+// Validation happens once here so the TUI entry point can trust its
+// input string.
+func resolveTheme(flag string) (string, error) {
+	candidate := flag
+	if candidate == "" {
+		candidate = os.Getenv("NOEMA_THEME")
+	}
+	if candidate == "" {
+		cfg, err := config.Load()
+		if err != nil {
+			return "", fmt.Errorf("loading config: %w", err)
+		}
+		candidate = cfg.Theme()
+	}
+	switch candidate {
+	case "", "auto", "dark", "light":
+		if candidate == "" {
+			candidate = "auto"
+		}
+		return candidate, nil
+	default:
+		return "", fmt.Errorf(`invalid theme %q: must be "auto", "dark", or "light"`, candidate)
 	}
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -88,10 +88,11 @@ func init() {
 		serveCmd(), tuiCmd(), completionCmd(),
 	)
 
-	// versionCmd is intentionally ungrouped — it's meta (about the
-	// binary itself, not Traces or Cortexes), so it lands under
-	// cobra's "Additional Commands:" section at the bottom of help.
-	rootCmd.AddCommand(versionCmd())
+	// versionCmd and configCmd are intentionally ungrouped — they're
+	// meta (about the binary or user settings, not Traces or
+	// Cortexes), so they land under cobra's "Additional Commands:"
+	// section at the bottom of help.
+	rootCmd.AddCommand(versionCmd(), configCmd())
 }
 
 func addGrouped(group string, cmds ...*cobra.Command) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,11 +12,52 @@ type Config struct {
 	Default   string                 `yaml:"default"`
 	Cortexes  map[string]CortexEntry `yaml:"cortexes"`
 	TrashDays int                    `yaml:"trash_days,omitempty"` // 0 means use default (30)
+	UI        *UIConfig              `yaml:"ui,omitempty"`
 }
 
 type CortexEntry struct {
 	Path string `yaml:"path"`
 	ID   string `yaml:"id,omitempty"` // ULID, used to disambiguate same-named cortexes
+}
+
+// UIConfig holds user-level TUI preferences. Stored as a pointer on
+// Config so it can be omitted from the YAML output entirely when the
+// user has never touched any of these settings — a fresh config stays
+// visually identical to what older Noema binaries produced.
+type UIConfig struct {
+	// Theme is the TUI color scheme: "auto", "dark", or "light".
+	// Empty is treated as "auto" (detect terminal background).
+	Theme string `yaml:"theme,omitempty"`
+}
+
+// Theme returns the configured UI theme, defaulting to "auto" when
+// UI is nil or Theme is unset. This is the single source of truth
+// for what "no explicit theme configured" means.
+func (c *Config) Theme() string {
+	if c == nil || c.UI == nil || c.UI.Theme == "" {
+		return "auto"
+	}
+	return c.UI.Theme
+}
+
+// SetTheme records a theme preference, allocating the UI block if
+// needed. An empty string clears the preference (falls back to auto).
+func (c *Config) SetTheme(theme string) {
+	if theme == "" {
+		if c.UI != nil {
+			c.UI.Theme = ""
+			// If the UI block is now entirely empty, drop it so the
+			// serialized config stays clean.
+			if *c.UI == (UIConfig{}) {
+				c.UI = nil
+			}
+		}
+		return
+	}
+	if c.UI == nil {
+		c.UI = &UIConfig{}
+	}
+	c.UI.Theme = theme
 }
 
 func Path() (string, error) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -96,6 +96,76 @@ func TestSave_NormalizesPathBeforeComparing(t *testing.T) {
 	}
 }
 
+// TestUITheme_RoundTrip pins the YAML round-trip behavior of the
+// UI.Theme field added in v0.4.1: it serializes under a `ui:` block,
+// loads back identically, and the Theme()/SetTheme() helpers reflect
+// the persisted value. The pointer-typed UI struct also means an
+// untouched config never writes a `ui:` block, which keeps the file
+// shape identical to what older Noema binaries produced.
+func TestUITheme_RoundTrip(t *testing.T) {
+	original := &config.Config{
+		Default:  "work",
+		Cortexes: map[string]config.CortexEntry{"work": {Path: "/tmp/work"}},
+	}
+	original.SetTheme("dark")
+
+	data, err := yaml.Marshal(original)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if !strings.Contains(string(data), "theme: dark") {
+		t.Errorf("YAML missing theme: dark\n%s", data)
+	}
+
+	var restored config.Config
+	if err := yaml.Unmarshal(data, &restored); err != nil {
+		t.Fatalf("Unmarshal: %v", err)
+	}
+	if restored.Theme() != "dark" {
+		t.Errorf("restored theme = %q, want dark", restored.Theme())
+	}
+}
+
+// TestUITheme_DefaultsToAuto verifies the zero-value contract: a
+// fresh Config (no UI block) reports its theme as "auto", which is
+// what the TUI's resolveTheme treats as "consult the terminal".
+func TestUITheme_DefaultsToAuto(t *testing.T) {
+	cfg := &config.Config{}
+	if got := cfg.Theme(); got != "auto" {
+		t.Errorf("empty config Theme() = %q, want auto", got)
+	}
+}
+
+// TestUITheme_ClearOnEmpty verifies SetTheme("") removes the UI block
+// entirely, so a config that toggled to dark and back doesn't leave
+// a stale `ui: {}` artifact in the file.
+func TestUITheme_ClearOnEmpty(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.SetTheme("dark")
+	cfg.SetTheme("")
+	if cfg.UI != nil {
+		t.Errorf("SetTheme(\"\") should drop the UI block, got %+v", cfg.UI)
+	}
+}
+
+// TestConfig_OmitsUIWhenNil documents that an untouched config has
+// no `ui:` field at all in the marshaled YAML — so older Noema
+// binaries (which don't know about the field) parse the file
+// unchanged.
+func TestConfig_OmitsUIWhenNil(t *testing.T) {
+	cfg := &config.Config{
+		Default:  "x",
+		Cortexes: map[string]config.CortexEntry{"x": {Path: "/tmp/x"}},
+	}
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if strings.Contains(string(data), "ui:") {
+		t.Errorf("YAML should not contain a ui: block when UI is nil:\n%s", data)
+	}
+}
+
 func TestLoadMissingFile(t *testing.T) {
 	// Load should return an empty config (not an error) when the file doesn't exist.
 	// We can't easily redirect os.UserConfigDir on macOS, so we test via the Load

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -17,106 +17,269 @@ import (
 
 // ---- styles ----------------------------------------------------------------
 
-// Brand palette — mirrors the Noema website (src/styles/global.css).
-// We use CompleteColor rather than bare hex so 256-color terminals get
-// hand-picked palette indices instead of termenv's automatic downmatch
-// (which picks color 232 — near-black — for the brand red, rendering
-// the wordmark period invisible on dark backgrounds).
-//
-// Kept as package-level vars so a future light/dark toggle only has to
-// swap these assignments without touching the style definitions below.
+// Brand palette — locked to BRAND.md (three values, no supporting
+// palettes). We use CompleteColor rather than bare hex so 256-color
+// terminals get hand-picked indices instead of termenv's automatic
+// downmatch (which picks color 232 — near-black — for the brand red,
+// rendering the period invisible on dark backgrounds).
 var (
-	// brandFg — cream "Noema" wordmark.
-	//   TrueColor: #ece4d4 (website --fg)
-	//   ANSI256:   223      (#ffd7af — warm beige, closest to cream)
-	//   ANSI:      7        (white)
-	brandFg = lipgloss.CompleteColor{
+	// brandCream — warm cream `#ece4d4`. Foreground in dark mode,
+	// background in light mode.
+	brandCream = lipgloss.CompleteColor{
 		TrueColor: "#ece4d4",
-		ANSI256:   "223",
-		ANSI:      "7",
+		ANSI256:   "223", // #ffd7af — warm beige, closest to cream
+		ANSI:      "7",   // white
 	}
 
-	// brandRed — accent period in "Noema."
-	//   TrueColor: #e10032 (website --red)
-	//   ANSI256:   161      (#d7005f — closest saturated red)
-	//   ANSI:      1        (red)
+	// brandInk — near-black `#1a1a1a`. Background in dark mode,
+	// foreground in light mode.
+	brandInk = lipgloss.CompleteColor{
+		TrueColor: "#1a1a1a",
+		ANSI256:   "234", // very dark gray
+		ANSI:      "0",   // black
+	}
+
+	// brandRed — rubricated accent `#e10032`. Period only; never
+	// recolored. One value across both themes per BRAND.md.
 	brandRed = lipgloss.CompleteColor{
 		TrueColor: "#e10032",
-		ANSI256:   "161",
-		ANSI:      "1",
+		ANSI256:   "161", // #d7005f — closest saturated red
+		ANSI:      "1",   // red
 	}
 )
+
+// palette holds every color the TUI uses for a single theme variant.
+// Two instances exist — darkPalette() and lightPalette() — selected
+// at startup by loadPalette(). All style vars below are assigned from
+// the active palette, so a theme swap rebuilds every style without
+// touching the render paths.
+type palette struct {
+	bg       lipgloss.TerminalColor // surface background
+	fg       lipgloss.TerminalColor // brand accent — wordmark + chip fill ONLY
+	body     lipgloss.TerminalColor // default body text (row titles, detail values)
+	red      lipgloss.TerminalColor // accent (period only)
+	label    lipgloss.TerminalColor // dimmer than body — row labels, metadata keys
+	value    lipgloss.TerminalColor // metadata values; matches body in current themes
+	dim      lipgloss.TerminalColor // header decoration, "no rows" placeholder
+	divider  lipgloss.TerminalColor // pane divider + separator lines
+	footer   lipgloss.TerminalColor // footer hint text
+	selBg    lipgloss.TerminalColor // selected row backdrop
+	selFg    lipgloss.TerminalColor // selected row text
+	dimRow   lipgloss.TerminalColor // background-pane rows when detail has focus
+	selDim   lipgloss.TerminalColor // selected row when detail has focus
+	newRow   lipgloss.TerminalColor // highlight for just-arrived rows
+	newDim   lipgloss.TerminalColor // newRow shade while detail has focus
+	live     lipgloss.TerminalColor // live-mode badge
+	errorFg  lipgloss.TerminalColor // footer error text
+	statusFg lipgloss.TerminalColor // footer status text
+}
+
+// darkPalette is the primary brand surface: near-black background,
+// cream foreground, rubricated red accent.
+func darkPalette() palette {
+	return palette{
+		bg:       brandInk,
+		fg:       brandCream,
+		body:     lipgloss.Color("250"),
+		red:      brandRed,
+		label:    lipgloss.Color("244"),
+		value:    lipgloss.Color("250"),
+		dim:      lipgloss.Color("240"),
+		divider:  lipgloss.Color("238"),
+		footer:   lipgloss.Color("241"),
+		selBg:    lipgloss.Color("236"),
+		selFg:    lipgloss.Color("255"),
+		dimRow:   lipgloss.Color("238"),
+		selDim:   lipgloss.Color("244"),
+		newRow:   lipgloss.Color("71"),
+		newDim:   lipgloss.Color("65"),
+		live:     lipgloss.Color("71"),
+		errorFg:  lipgloss.Color("196"),
+		statusFg: lipgloss.Color("71"),
+	}
+}
+
+// lightPalette uses a cool off-white background (ANSI 230) so the
+// warm brand cream can serve as an accent (selected row, chips)
+// rather than flooding the entire surface. Ink stays the wordmark
+// accent, mirroring cream's role in dark mode.
+func lightPalette() palette {
+	return palette{
+		bg:       lipgloss.Color("255"), // near-white, no color cast — cream is the accent
+		fg:       brandInk,
+		body:     lipgloss.Color("238"),
+		red:      brandRed,
+		label:    lipgloss.Color("243"),
+		value:    lipgloss.Color("238"),
+		dim:      lipgloss.Color("248"),
+		divider:  lipgloss.Color("249"),
+		footer:   lipgloss.Color("244"),
+		selBg:    brandCream, // cream as accent — the cursor row is the warm band
+		selFg:    lipgloss.Color("232"),
+		dimRow:   lipgloss.Color("249"),
+		selDim:   lipgloss.Color("244"),
+		newRow:   lipgloss.Color("22"),
+		newDim:   lipgloss.Color("28"),
+		live:     lipgloss.Color("22"),
+		errorFg:  lipgloss.Color("124"),
+		statusFg: lipgloss.Color("22"),
+	}
+}
+
+// activePalette is set by loadPalette() at startup. Tests that need
+// deterministic styling can call loadPalette("dark") explicitly.
+var activePalette = darkPalette()
 
 var (
 	// styleHeader renders the "Noema" portion of the wordmark in the
 	// brand cream. styleHeaderAccent renders the trailing period in
-	// brand red — matching the website's wordmark. Splitting them
-	// keeps the two colors independent for theming.
-	styleHeader = lipgloss.NewStyle().
-			Bold(true).
-			Foreground(brandFg)
+	// brand red. Splitting them keeps the two colors independent.
+	styleHeader       lipgloss.Style
+	styleHeaderAccent lipgloss.Style
 
-	styleHeaderAccent = lipgloss.NewStyle().
-				Bold(true).
-				Foreground(brandRed)
+	styleSelected lipgloss.Style
+	styleDim      lipgloss.Style
 
-	styleSelected = lipgloss.NewStyle().
-			Bold(true).
-			Background(lipgloss.Color("236")).
-			Foreground(lipgloss.Color("255"))
+	// styleChip renders tag values (and the type value) as inline
+	// pills — inverted brand palette with 1-cell padding. See
+	// renderTagChips for the wrap logic.
+	styleChip lipgloss.Style
 
-	styleDim = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("240"))
-
-	styleBadge = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("214"))
-
-	styleDivider = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("238"))
-
-	styleLabel = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("244"))
-
-	styleValue = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("252"))
-
-	styleFooter = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("241"))
-
-	styleError = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("196"))
-
-	styleStatus = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("71"))
+	styleDivider lipgloss.Style
+	styleLabel   lipgloss.Style
+	styleValue   lipgloss.Style
+	styleFooter  lipgloss.Style
+	styleError   lipgloss.Style
+	styleStatus  lipgloss.Style
 
 	// styleNewRow tints rows that arrived on the most recent refresh —
 	// the visible "pop in" effect when watching live updates.
-	styleNewRow = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("71"))
+	styleNewRow lipgloss.Style
 
 	// styleLive is the header badge shown while follow mode is active.
-	styleLive = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("71")).
-			Bold(true)
+	styleLive lipgloss.Style
 
 	// When the detail pane owns focus, the list pane gets a "modal
 	// backdrop" treatment — every row renders through a dim palette
 	// so it visibly recedes. The selected row stays a notch brighter
 	// than the rest so the cursor position is still legible.
-	//
-	// Brightness ladder (dim mode):
-	//   styleRowDim        238  very faint   — unselected rows
-	//   styleNewRowDim      65  muted green  — highlighted arrivals
-	//   styleSelectedDim   244  soft gray    — current selection
+	styleSelectedDim lipgloss.Style
+	styleRowDim      lipgloss.Style
+	styleNewRowDim   lipgloss.Style
+
+	// styleSurface paints the active palette's background on any
+	// region passed through it. Used for header, footer, and the
+	// implicit fill behind the list/detail/divider block so the
+	// whole TUI reads as one brand surface.
+	styleSurface lipgloss.Style
+)
+
+func init() {
+	loadPalette("dark")
+}
+
+// loadPalette reassigns every style variable from the named theme
+// ("dark", "light", or "auto" — auto consults lipgloss' terminal
+// background detection). Safe to call multiple times; call once at
+// startup before Run().
+func loadPalette(theme string) {
+	switch resolveTheme(theme) {
+	case "light":
+		activePalette = lightPalette()
+	default:
+		activePalette = darkPalette()
+	}
+	p := activePalette
+
+	styleSurface = lipgloss.NewStyle().Background(p.bg).Foreground(p.body)
+
+	styleHeader = lipgloss.NewStyle().
+		Bold(true).
+		Background(p.bg).
+		Foreground(p.fg)
+
+	styleHeaderAccent = lipgloss.NewStyle().
+		Bold(true).
+		Background(p.bg).
+		Foreground(p.red)
+
+	styleSelected = lipgloss.NewStyle().
+		Bold(true).
+		Background(p.selBg).
+		Foreground(p.selFg)
+
+	styleDim = lipgloss.NewStyle().
+		Background(p.bg).
+		Foreground(p.dim)
+
+	// Chips use the inverted palette — a small "patch of light mode"
+	// in dark mode, and vice versa — so they read as a distinct
+	// labeled object without introducing a fourth brand color.
+	styleChip = lipgloss.NewStyle().
+		Background(p.fg).
+		Foreground(p.bg).
+		Padding(0, 1)
+
+	styleDivider = lipgloss.NewStyle().
+		Background(p.bg).
+		Foreground(p.divider)
+
+	styleLabel = lipgloss.NewStyle().
+		Background(p.bg).
+		Foreground(p.label)
+
+	styleValue = lipgloss.NewStyle().
+		Background(p.bg).
+		Foreground(p.value)
+
+	styleFooter = lipgloss.NewStyle().
+		Background(p.bg).
+		Foreground(p.footer)
+
+	styleError = lipgloss.NewStyle().
+		Background(p.bg).
+		Foreground(p.errorFg)
+
+	styleStatus = lipgloss.NewStyle().
+		Background(p.bg).
+		Foreground(p.statusFg)
+
+	styleNewRow = lipgloss.NewStyle().
+		Background(p.bg).
+		Foreground(p.newRow)
+
+	styleLive = lipgloss.NewStyle().
+		Background(p.bg).
+		Foreground(p.live).
+		Bold(true)
+
 	styleSelectedDim = lipgloss.NewStyle().
-				Foreground(lipgloss.Color("244"))
+		Background(p.bg).
+		Foreground(p.selDim)
 
 	styleRowDim = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("238"))
+		Background(p.bg).
+		Foreground(p.dimRow)
 
 	styleNewRowDim = lipgloss.NewStyle().
-			Foreground(lipgloss.Color("65"))
-)
+		Background(p.bg).
+		Foreground(p.newDim)
+}
+
+// resolveTheme picks a concrete theme ("dark" or "light") from an
+// input that may be "auto", empty, or already concrete. Empty and
+// "auto" consult the terminal background via lipgloss.
+func resolveTheme(in string) string {
+	switch in {
+	case "dark", "light":
+		return in
+	default:
+		if lipgloss.HasDarkBackground() {
+			return "dark"
+		}
+		return "light"
+	}
+}
 
 // followInterval is how often the TUI polls the cortex when follow mode
 // is on. 1s is fast enough to feel live when an agent is writing into
@@ -749,7 +912,17 @@ func (m model) detailMetaLineCount() int {
 		n++
 	}
 	if len(m.current.Tags) > 0 {
-		n++
+		// Tags render as chip rows — potentially more than one line
+		// when the chips wrap. Query renderTagChips directly with the
+		// same width inputs renderDetail uses, so the body budget
+		// stays honest even when a trace has a lot of tags.
+		_, detailW := m.paneWidths()
+		labelW := 10
+		metaValW := detailW - labelW - 2
+		if metaValW < 4 {
+			metaValW = 4
+		}
+		n += len(renderTagChips(m.current.Tags, labelW, metaValW))
 	}
 	return n
 }
@@ -865,11 +1038,14 @@ func (m model) View() string {
 
 	body := lipgloss.JoinHorizontal(lipgloss.Top, list, divider, detail)
 
-	return lipgloss.JoinVertical(lipgloss.Left,
-		m.renderHeader(),
-		body,
-		m.renderFooter(),
-	)
+	// Header and footer are single-row strings that only stretch as
+	// far as their content goes; right-pad them with surface cells so
+	// the entire row renders on the same brand background rather than
+	// leaking the terminal default at the right edge.
+	header := padLineToWidth(m.renderHeader(), m.width)
+	footer := padLineToWidth(m.renderFooter(), m.width)
+
+	return lipgloss.JoinVertical(lipgloss.Left, header, body, footer)
 }
 
 func (m model) renderHeader() string {
@@ -891,7 +1067,10 @@ func (m model) renderHeader() string {
 	if gap < 1 {
 		gap = 1
 	}
-	return left + strings.Repeat(" ", gap) + right
+	// Gap spacer is painted with the surface background so the raw
+	// space characters don't leak the terminal default through the
+	// middle of the header row.
+	return left + styleSurface.Render(strings.Repeat(" ", gap)) + right
 }
 
 func (m model) renderList(width, height int) string {
@@ -976,7 +1155,7 @@ func (m model) renderList(width, height int) string {
 			if dim {
 				sb.WriteString(styleRowDim.Width(width).Render(line))
 			} else {
-				sb.WriteString(lipgloss.NewStyle().Width(width).Render(line))
+				sb.WriteString(styleSurface.Width(width).Render(line))
 			}
 		}
 		if i < end-1 {
@@ -988,7 +1167,7 @@ func (m model) renderList(width, height int) string {
 	rendered := sb.String()
 	lines := strings.Count(rendered, "\n") + 1
 	for lines < height {
-		rendered += "\n" + lipgloss.NewStyle().Width(width).Render("")
+		rendered += "\n" + styleSurface.Width(width).Render("")
 		lines++
 	}
 	return rendered
@@ -1018,15 +1197,24 @@ func (m model) renderDetail(width, height int) string {
 		return l + v
 	}
 
+	// chipLine renders a metadata row where the value is a single chip
+	// (e.g. the type field). The label column is rendered plain so the
+	// chip lines up with wrapped tag chips below.
+	chipLine := func(label, value string) string {
+		l := styleLabel.Render(fmt.Sprintf("  %-*s", labelW, label+":"))
+		chip := styleChip.Render(chipContent(value))
+		return l + chip
+	}
+
 	var lines []string
 	lines = append(lines, metaLine("id", t.ID))
 	lines = append(lines, metaLine("title", t.Title))
-	lines = append(lines, metaLine("type", t.Type))
+	lines = append(lines, chipLine("type", t.Type))
 	if t.Author != "" {
 		lines = append(lines, metaLine("author", t.Author))
 	}
 	if len(t.Tags) > 0 {
-		lines = append(lines, metaLine("tags", strings.Join(t.Tags, ", ")))
+		lines = append(lines, renderTagChips(t.Tags, labelW, metaValW)...)
 	}
 	created := t.Created
 	if len(created) > 10 {
@@ -1088,7 +1276,7 @@ func (m model) renderDetail(width, height int) string {
 		if sepRule > indW+2 {
 			dashW := sepRule - indW - 1
 			lines = append(lines,
-				"  "+styleDivider.Render(strings.Repeat("─", dashW))+" "+styleDim.Render(indicator))
+				surfacePad(2)+styleDivider.Render(strings.Repeat("─", dashW))+surfacePad(1)+styleDim.Render(indicator))
 		} else {
 			lines = append(lines, styleDivider.Render("  "+strings.Repeat("─", sepRule)))
 		}
@@ -1114,13 +1302,13 @@ func (m model) renderDetail(width, height int) string {
 	}
 
 	content := strings.Join(lines, "\n")
-	return lipgloss.NewStyle().Width(width).Height(height).Render(content)
+	return styleSurface.Width(width).Height(height).Render(content)
 }
 
 func (m model) renderFooter() string {
 	switch m.state {
 	case stateSearch:
-		return " /" + m.search.View()
+		return styleSurface.Render(" /") + m.search.View()
 
 	case stateConfirm:
 		prompt := fmt.Sprintf("  %s %q? [y/N] ", m.confirm.action, m.confirm.id)
@@ -1156,10 +1344,113 @@ func (m model) renderFooter() string {
 			if pad < 0 {
 				pad = 0
 			}
-			return strings.Repeat(" ", pad) + styled + "  "
+			return surfacePad(pad) + styled + surfacePad(2)
 		}
-		return "  " + styled
+		return surfacePad(2) + styled
 	}
+}
+
+// surfacePad returns n space characters painted with the active
+// surface background. Used anywhere raw spaces would otherwise leak
+// the terminal default background through the brand surface —
+// header/footer gaps, pane-fill padding, alignment indents.
+func surfacePad(n int) string {
+	if n <= 0 {
+		return ""
+	}
+	return styleSurface.Render(strings.Repeat(" ", n))
+}
+
+// padLineToWidth right-pads an already-rendered line with surface
+// background cells so its visual width equals `width`. Lines that
+// already meet or exceed the target width are returned unchanged.
+func padLineToWidth(line string, width int) string {
+	cur := lipgloss.Width(line)
+	if cur >= width {
+		return line
+	}
+	return line + surfacePad(width-cur)
+}
+
+// chipContent returns the inner text of a chip — prefixed with a
+// hash so the glyph reinforces the "this is a tag/label" meaning
+// even before the inverted-bg color registers. `type` chips also
+// share this prefix for visual consistency across the metadata
+// block.
+func chipContent(s string) string {
+	return "#" + s
+}
+
+// renderTagChips returns one or more pre-rendered metadata lines for
+// the tags field, wrapping chips across rows when the total width
+// exceeds the pane's value column. Wrapped rows are indented to sit
+// under the first chip (so the "tags:" label only appears once).
+//
+// The chips themselves are rendered with styleChip (inverted brand
+// palette). Each chip consumes `chipCellWidth` cells: `#tag` plus one
+// cell of padding on each side. A single trailing space between chips
+// acts as the gap.
+func renderTagChips(tags []string, labelW, valueW int) []string {
+	if len(tags) == 0 {
+		return nil
+	}
+	// Label column for the first row; subsequent rows use spaces so
+	// wrapped chips line up under the first chip visually.
+	head := styleLabel.Render(fmt.Sprintf("  %-*s", labelW, "tags:"))
+	blank := styleLabel.Render(strings.Repeat(" ", labelW+2))
+
+	// Gap between adjacent chips on the same row.
+	const chipGap = " "
+	gapW := lipgloss.Width(chipGap)
+
+	var rows []string
+	var current strings.Builder
+	currentW := 0 // visual width of chips in `current`, excluding the leading label
+
+	flush := func(first bool) {
+		var prefix string
+		if first {
+			prefix = head
+		} else {
+			prefix = blank
+		}
+		rows = append(rows, prefix+current.String())
+		current.Reset()
+		currentW = 0
+	}
+
+	first := true
+	for _, tag := range tags {
+		chip := styleChip.Render(chipContent(tag))
+		chipW := lipgloss.Width(chip)
+		// Project the row width as if we appended this chip (plus the
+		// gap separator if there's already something on the row). If
+		// that overflows the value column, flush the current row first
+		// and start a new one with this chip alone.
+		//
+		// Chips wider than the whole value column still get rendered
+		// in full — truncation would lie about the tag content, and
+		// the pane scroll math budgets by row count, not rendered
+		// width, so an overflow row is harmless.
+		projected := currentW + chipW
+		if currentW > 0 {
+			projected += gapW
+		}
+		if currentW > 0 && projected > valueW {
+			flush(first)
+			first = false
+		}
+		if currentW > 0 {
+			current.WriteString(chipGap)
+			currentW += gapW
+		}
+		current.WriteString(chip)
+		currentW += chipW
+	}
+	if currentW > 0 {
+		flush(first)
+	}
+	return rows
 }
 
 // ---- helpers ---------------------------------------------------------------
@@ -1182,11 +1473,15 @@ func padRunes(s string, n int) string {
 	return s + strings.Repeat(" ", n-len(r))
 }
 
-// padBlock pads a rendered block to width × height with empty lines.
+// padBlock pads a rendered block to width × height with empty lines
+// painted in the active surface background. Without the palette paint
+// the empty filler rows would leak the terminal default background
+// through, producing a visible gray-shade mismatch against the styled
+// rows above them.
 func padBlock(content string, width, height int) string {
 	lines := strings.Split(content, "\n")
 	for len(lines) < height {
-		lines = append(lines, lipgloss.NewStyle().Width(width).Render(""))
+		lines = append(lines, styleSurface.Width(width).Render(""))
 	}
 	return strings.Join(lines[:height], "\n")
 }
@@ -1223,8 +1518,12 @@ func wrapLine(line string, width int) []string {
 
 // ---- entry point -----------------------------------------------------------
 
-// Run starts the full-screen TUI against the given Cortex.
-func Run(cx *cortex.Cortex) error {
+// Run starts the full-screen TUI against the given Cortex using the
+// supplied theme ("auto", "dark", or "light"). Callers resolve the
+// theme string from their own flag/env/config chain and pass it in;
+// this function is the single place that actually applies it.
+func Run(cx *cortex.Cortex, theme string) error {
+	loadPalette(theme)
 	p := tea.NewProgram(
 		initialModel(cx),
 		tea.WithAltScreen(),

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -13,6 +14,14 @@ import (
 	"github.com/Fail-Safe/Noema/internal/cortex"
 	"github.com/Fail-Safe/Noema/internal/trace"
 )
+
+// ansiSGR matches the SGR escape sequences lipgloss emits so tests
+// that need to assert on visible (post-style) text structure can
+// strip them. Using a narrow SGR-only pattern — not a general ESC
+// matcher — so malformed sequences still show up in diagnostics.
+var ansiSGR = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+func stripANSI(s string) string { return ansiSGR.ReplaceAllString(s, "") }
 
 // TestMain forces lipgloss into a known color profile for the whole
 // test binary. Without this, lipgloss detects the go-test environment
@@ -885,18 +894,23 @@ func TestHeader_BrandWordmark(t *testing.T) {
 	}
 
 	// Brand cream resolves to 256-color 223 on the ANSI256 profile
-	// pinned by TestMain. Bold + fg 223.
-	if !strings.Contains(header, "\x1b[1;38;5;223m") {
+	// pinned by TestMain. Bold + fg 223. The matcher anchors on the
+	// fg portion of the SGR sequence so it tolerates a trailing
+	// background specifier (added when the dark surface was painted
+	// across the whole TUI in v0.4.1).
+	if !strings.Contains(header, "\x1b[1;38;5;223") {
 		t.Errorf("header missing brand cream SGR (1;38;5;223):\n%q", header)
 	}
 
 	// Brand red resolves to 256-color 161 on the ANSI256 profile.
 	// Bold + fg 161. The old bug downconverted to 232 (near-black);
 	// guard against any regression that reintroduces it.
-	if !strings.Contains(header, "\x1b[1;38;5;161m") {
+	if !strings.Contains(header, "\x1b[1;38;5;161") {
 		t.Errorf("header missing brand red SGR (1;38;5;161):\n%q", header)
 	}
-	if strings.Contains(header, "\x1b[1;38;5;232m") {
+	// Foreground 232 specifically — the broken downconversion shows
+	// up as `[1;38;5;232` (period only, bold). Background 232 is fine.
+	if strings.Contains(header, "\x1b[1;38;5;232") {
 		t.Error("header period downconverted to near-black (232) — " +
 			"CompleteColor ANSI256 fallback is broken")
 	}
@@ -1269,8 +1283,11 @@ func TestFooter_AlignmentTracksFocus(t *testing.T) {
 	addTrace(t, cx, "first", "note")
 	m := loadedModel(t, cx)
 
-	// List focus: leading gutter, no trailing pad run.
-	listHint := m.renderFooter()
+	// List focus: leading gutter, no trailing pad run. Strip SGR so
+	// the prefix check sees the visible text — surfacePad now wraps
+	// padding in background-fill escape codes to stop terminal
+	// default gray from bleeding through.
+	listHint := stripANSI(m.renderFooter())
 	if !strings.HasPrefix(listHint, "  ") {
 		t.Errorf("list-focus footer missing leading 2-space gutter:\n%q", listHint)
 	}
@@ -1279,13 +1296,14 @@ func TestFooter_AlignmentTracksFocus(t *testing.T) {
 	// footer (leading pad + styled hint + trailing pad) should equal
 	// the model width — i.e. the hint is pinned to the right edge.
 	m.focus = focusDetail
-	detailHint := m.renderFooter()
+	rawDetail := m.renderFooter()
+	detailHint := stripANSI(rawDetail)
 	if !strings.HasSuffix(detailHint, "  ") {
 		t.Errorf("detail-focus footer missing trailing 2-space gutter:\n%q", detailHint)
 	}
-	if lipgloss.Width(detailHint) != m.width {
+	if lipgloss.Width(rawDetail) != m.width {
 		t.Errorf("detail-focus footer width = %d, want %d (full pane width)",
-			lipgloss.Width(detailHint), m.width)
+			lipgloss.Width(rawDetail), m.width)
 	}
 	// Spot-check: a lot of leading spaces, meaning the hint was pushed
 	// right — it should start with at least a dozen blanks.
@@ -1347,14 +1365,171 @@ func TestList_WholePaneDimsWhenDetailFocused(t *testing.T) {
 			"non-selected rows aren't dimming")
 	}
 
-	// The dim-row ANSI color (238) should be somewhere in the detail-
+	// The dim-row foreground (238) should be somewhere in the detail-
 	// focus render, and absent from the active render (where unselected
-	// rows render through a plain zero-style).
-	const dimFgSeq = "\x1b[38;5;238m"
+	// rows render through a plain zero-style). The matcher anchors on
+	// the fg portion of the SGR (`38;5;238`) so it tolerates a
+	// trailing background specifier added by the v0.4.1 surface paint.
+	const dimFgSeq = "\x1b[38;5;238"
 	if !strings.Contains(dim, dimFgSeq) {
 		t.Errorf("detail-focus render missing dim fg ANSI (238):\n%q", dim)
 	}
 	if strings.Contains(active, dimFgSeq) {
 		t.Errorf("list-focus render should not contain dim fg ANSI (238):\n%q", active)
+	}
+}
+
+// ---- theme palette ---------------------------------------------------------
+
+// TestLoadPalette_DarkSetsBrandInkBackground verifies that loading the
+// dark theme paints the surface background as brand ink (#1a1a1a →
+// ANSI256 234) and body text as soft gray (250). Brand cream (223) is
+// reserved for the wordmark and chip fill — styleSurface intentionally
+// does NOT use cream as its foreground.
+func TestLoadPalette_DarkSetsBrandInkBackground(t *testing.T) {
+	loadPalette("dark")
+	defer loadPalette("dark") // restore for downstream tests
+
+	rendered := styleSurface.Render("hello")
+	if !strings.Contains(rendered, "48;5;234") {
+		t.Errorf("dark surface missing brand-ink background (48;5;234):\n%q", rendered)
+	}
+	if !strings.Contains(rendered, "38;5;250") {
+		t.Errorf("dark surface missing body foreground (38;5;250):\n%q", rendered)
+	}
+	// Cream must still appear on the wordmark, not on the surface.
+	wordmark := styleHeader.Render("Noema")
+	if !strings.Contains(wordmark, "38;5;223") {
+		t.Errorf("dark wordmark missing brand-cream (38;5;223):\n%q", wordmark)
+	}
+}
+
+// TestLoadPalette_LightInvertsRoles verifies the light theme uses a
+// cool off-white background (230) — not full cream — so cream can
+// serve as the selected-row accent. Ink stays the wordmark color.
+func TestLoadPalette_LightInvertsRoles(t *testing.T) {
+	loadPalette("light")
+	defer loadPalette("dark") // restore
+
+	rendered := styleSurface.Render("hello")
+	if !strings.Contains(rendered, "48;5;255") {
+		t.Errorf("light surface missing near-white background (48;5;255):\n%q", rendered)
+	}
+	if !strings.Contains(rendered, "38;5;238") {
+		t.Errorf("light surface missing body foreground (38;5;238):\n%q", rendered)
+	}
+	// Cream is now the selected-row accent, not the surface bg.
+	sel := styleSelected.Render("cursor")
+	if !strings.Contains(sel, "48;5;223") {
+		t.Errorf("light selected row missing cream background (48;5;223):\n%q", sel)
+	}
+}
+
+// TestResolveTheme_PassesThroughExplicit verifies the auto-detection
+// guard only kicks in when the input is empty or "auto" — explicit
+// "dark" and "light" pass through unchanged so the user's flag/env/
+// config choice is honored on terminals where lipgloss would otherwise
+// guess differently.
+func TestResolveTheme_PassesThroughExplicit(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"dark", "dark"},
+		{"light", "light"},
+	}
+	for _, c := range cases {
+		if got := resolveTheme(c.in); got != c.want {
+			t.Errorf("resolveTheme(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// ---- tag chip rendering ----------------------------------------------------
+
+// TestRenderTagChips_FitsOneRow checks the happy path: a handful of
+// short tags whose total rendered width fits comfortably in the value
+// column produces exactly one output row.
+func TestRenderTagChips_FitsOneRow(t *testing.T) {
+	loadPalette("dark")
+	tags := []string{"go", "tui", "brand"}
+	rows := renderTagChips(tags, 10, 80)
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d:\n%v", len(rows), rows)
+	}
+	// Each tag must appear with its hash prefix.
+	for _, tag := range tags {
+		if !strings.Contains(rows[0], "#"+tag) {
+			t.Errorf("row missing chip for %q:\n%q", tag, rows[0])
+		}
+	}
+	// The label appears exactly once (on the first row only).
+	if !strings.Contains(rows[0], "tags:") {
+		t.Errorf("first row missing 'tags:' label:\n%q", rows[0])
+	}
+}
+
+// TestRenderTagChips_WrapsWhenOverflow verifies the wrap behavior:
+// when the accumulated chip width exceeds the value column, chips
+// flow to a second row whose label column is blank (so the "tags:"
+// label only renders on the first row). The total chip count must
+// be preserved across the two rows.
+func TestRenderTagChips_WrapsWhenOverflow(t *testing.T) {
+	loadPalette("dark")
+	// Each chip renders as `#tagN ` with 1-cell padding on each side
+	// — roughly 8 cells per chip. With valueW=20 we should get
+	// ~2 chips per row, forcing the 5-tag set onto multiple rows.
+	tags := []string{"alpha", "beta", "gamma", "delta", "epsilon"}
+	rows := renderTagChips(tags, 10, 20)
+	if len(rows) < 2 {
+		t.Fatalf("expected wrap to produce ≥2 rows, got %d:\n%v", len(rows), rows)
+	}
+	// First row carries the "tags:" label; subsequent rows do not.
+	if !strings.Contains(rows[0], "tags:") {
+		t.Errorf("first row missing 'tags:' label:\n%q", rows[0])
+	}
+	for i := 1; i < len(rows); i++ {
+		if strings.Contains(rows[i], "tags:") {
+			t.Errorf("wrapped row %d should not repeat the 'tags:' label:\n%q", i, rows[i])
+		}
+	}
+	// Every tag's chip text appears exactly once across all rows.
+	joined := strings.Join(rows, "\n")
+	for _, tag := range tags {
+		if c := strings.Count(joined, "#"+tag); c != 1 {
+			t.Errorf("expected exactly 1 chip for %q across wrapped rows, got %d", tag, c)
+		}
+	}
+}
+
+// TestRenderTagChips_EmptyReturnsNil documents the no-tags case so a
+// future caller doesn't accidentally render an empty "tags:" row.
+func TestRenderTagChips_EmptyReturnsNil(t *testing.T) {
+	loadPalette("dark")
+	if rows := renderTagChips(nil, 10, 80); rows != nil {
+		t.Errorf("expected nil for empty tags, got %v", rows)
+	}
+	if rows := renderTagChips([]string{}, 10, 80); rows != nil {
+		t.Errorf("expected nil for empty slice, got %v", rows)
+	}
+}
+
+// TestRenderTagChips_UsesInvertedPalette confirms each chip renders
+// with the inverted brand palette in dark mode — cream background,
+// ink foreground — so the chip reads as a "patch of light mode"
+// against the dark surface. This is the brand-compliant alternative
+// to introducing a fourth accent color.
+func TestRenderTagChips_UsesInvertedPalette(t *testing.T) {
+	loadPalette("dark")
+	rows := renderTagChips([]string{"go"}, 10, 80)
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	// 48;5;223 = cream bg, 38;5;234 = ink fg.
+	if !strings.Contains(rows[0], "48;5;223") {
+		t.Errorf("chip missing inverted cream background (48;5;223):\n%q", rows[0])
+	}
+	if !strings.Contains(rows[0], "38;5;234") {
+		t.Errorf("chip missing inverted ink foreground (38;5;234):\n%q", rows[0])
 	}
 }


### PR DESCRIPTION
## Summary

- **Theme support**: configurable dark/light theme with priority chain (`--theme` flag > `NOEMA_THEME` env > config file > auto-detect). Brand cream reserved for wordmark and chip accents; body text uses neutral gray for visual hierarchy. Light mode uses near-white surface with cream as the selected-row accent.
- **Tag chips**: tag and type values render as inverted-palette inline pills with greedy row-packing and wrap.
- **`noema config` command**: new `get`/`set`/`list` subcommand for persistent user settings (`ui.theme`, `trash_days`).
- **Surface background fixes**: eliminated terminal-default gray leaking through unstyled fill paths (header gaps, footer padding, separator indicators, pane fill).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` all packages pass (new tests for config round-trip, theme priority chain, palette roles, tag chip wrapping)
- [x] Visual verification: dark mode shows uniform ink surface with cream wordmark accent only
- [x] Visual verification: light mode shows neutral near-white surface with cream selected-row accent
- [x] `noema config set ui.theme dark` / `light` / `auto` round-trips correctly
- [x] `noema tui --theme light` flag override works

🤖 Generated with [Claude Code](https://claude.com/claude-code)