### PR TITLE
feat: content hashing, source-locking, federation modes (v0.5.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,29 @@ Lineage is a separate `trace_lineage` join table populated from the `derived_fro
 
 Federation is opt-in via a `federation:` block in `cortex.md` (peers + interval). When `noema serve --transport http` starts on a Cortex with peers configured, a background syncer polls each peer's `sync_events` MCP tool over Streamable HTTP (the `/mcp` endpoint, MCP 2025-03-26), replays new events into the local Cortex, and merges the remote vector clock into the local one. Replayed events are stored with their original ID, cortex_id, and origin so the event log becomes the union of all peers' events (no event amplification). When two peers update the same trace concurrently — vector clocks neither dominate nor are dominated — Noema creates a `type: divergence` Trace preserving every conflicting version under deterministically-sorted `### Version from <name> (<id-prefix>)` headers, rather than overwriting. Resolve via `noema resolve <divergence-id> --accept <name|id-prefix>` or `--custom <body>` (or the `resolve_divergence` MCP tool).
 
+**Federation modes.** The `federation.mode` field in `cortex.md` controls sync directionality:
+
+| Mode | Syncer runs? | `sync_events` serves? | HTTP write tools? |
+|------|-------------|----------------------|-------------------|
+| `sync` (default) | Yes | Yes | Yes |
+| `publish` | No | Yes | Blocked (read-only for remote peers) |
+| `subscribe` | Yes | Blocked | Yes |
+
+In publish mode, mutating MCP tools (`create_trace`, `update_trace`, `delete_trace`, `recover_trace`, `archive_trace`, `unarchive_trace`, `resolve_divergence`) return a clear error on the HTTP transport. The local stdio transport retains full write access so operators can manage content locally. In subscribe mode, `sync_events` returns an error so remote peers cannot pull events from this cortex.
+
+Each peer can also declare `mode: paused` to temporarily skip syncing without losing cursor/identity state. CLI commands: `noema federation set-mode <sync|publish|subscribe>`, `noema federation pause-peer <name>`, `noema federation resume-peer <name>`.
+
 The full design rationale, edge cases, and phase breakdown live in `docs/design/federation-plan.md`.
+
+**Content hashing and source-locking.** Every trace mutation (`Add`, `Update`) computes a SHA-256 hash of the body (`sha256:<hex>`) and stores it in the `content_hash` frontmatter field and DB column. The hash travels through federation events so peers receive it. Three frontmatter fields support integrity:
+
+- `content_hash` — current body hash, recomputed on every write
+- `source_hash` — the origin's `content_hash` at publish time, carried through federation
+- `source_locked` — when `true`, consumer-side tooling refuses `Update`, `Trash`, and `Remove` on this trace (only enforced when `origin != local cortex name`; the publisher can always edit its own traces)
+
+`Archive` and `Unarchive` remain allowed on source-locked traces (non-destructive). CLI commands accept `--force` to bypass the lock. MCP tools surface `ErrSourceLocked` as a tool error. The TUI blocks the `e` key with a status message.
+
+CLI: `noema verify` checks all trace file hashes against their frontmatter `content_hash` (with `--backfill` for old traces). `noema drift` checks federated traces against their `source_hash`.
 
 **MCP access posture.** The HTTP MCP endpoint runs either in **open mode** (no auth, the default — suitable only for loopback) or in **keyed mode** (every request must carry `Authorization: Bearer <key>`). Keyed mode is mandatory for federation rings and any non-loopback deployment, and it also requires TLS — the server refuses to start with a bearer key over plaintext HTTP. The key is supplied via `NOEMA_MCP_KEY` (env var, wins if both are set) or via an optional `access.shared_key_file` block in `cortex.md` pointing at a 0600 sidecar file. The server logs the active posture on startup as `access=keyed source=env|file fingerprint=SHA256:...`, and `noema federation key fingerprint` reproduces the same non-secret fingerprint for out-of-band verification across ring members. The federation syncer automatically injects the local host's bearer key into every outbound `sync_events` call; there is no per-peer key config, so every host in a ring must share one key. Mixed-mode rings (some keyed, some open) are not supported — they isolate by design. See `docs/design/mcp-auth-plan.md` for the full threat model and decision log, and `internal/mcp/middleware.go` for the CORS + auth middleware chain (CORS outermost so browser preflights bypass the auth gate as the spec requires).
 
@@ -156,7 +178,7 @@ Schema changes must always be transparent and non-destructive. Rules:
 - If a migration would require removing or restructuring data, provide a separate explicit `noema migrate` command with a clear description of what it does, requiring user confirmation
 - Migration failures abort startup with a clear error; they never partially apply
 
-The runner is a thin hand-rolled loop over embedded `*.sql` files in `internal/db/migrations/`, sorted by leading version number. Currently applied: `001_initial.sql`, `002_trash.sql`, `003_events_and_lineage.sql` (event log + `trace_lineage` + `traces.origin` column), `004_federation_state.sql` (key-value store for vector clocks and per-peer cursors), and `005_cortex_identity.sql` (`cortex_id` column on `traces` and `events`).
+The runner is a thin hand-rolled loop over embedded `*.sql` files in `internal/db/migrations/`, sorted by leading version number. Currently applied: `001_initial.sql`, `002_trash.sql`, `003_events_and_lineage.sql` (event log + `trace_lineage` + `traces.origin` column), `004_federation_state.sql` (key-value store for vector clocks and per-peer cursors), `005_cortex_identity.sql` (`cortex_id` column on `traces` and `events`), `006_content_hash.sql` (`content_hash` column on `traces`), and `007_source_locking.sql` (`source_locked` + `source_hash` columns on `traces`).
 
 `cortex.md` carries a `version` field. The current `ManifestVersion` is **2** — version 2 carries a stable cortex `id` (a ULID) and re-keys the local event log + vector clock from cortex-name to cortex-id. Cortexes written by older binaries must run `noema migrate cortex-id` (an explicit, interactive, backed-up migration in `internal/cli/cmd_migrate.go`) before they can be opened by this binary; the `--reset` flag handles the case where the directory is a copy of another cortex (Gotcha #3 in the design doc).
 

--- a/README.md
+++ b/README.md
@@ -177,6 +177,9 @@ noema events backfill [--dry-run] [--yes]
                                           Synthesize create events for active traces missing one (e.g. traces added via `noema sync`)
 noema resolve <divergence-id> --accept <origin> | --custom <body>
                                           Resolve a divergence (concurrent edit conflict)
+noema verify [--backfill]                 Check trace content hashes for integrity; --backfill populates
+                                          hashes for old traces
+noema drift                               Check federated traces for drift from their source hash
 
 noema federation status                   Show federation config, MCP access posture, peer sync state, and vector clock
 noema federation peers                    List configured federation peers
@@ -185,6 +188,10 @@ noema federation add-peer <name> <endpoint>
 noema federation reset-peer <name>...     Clear stored state for a peer (forces a fresh handshake; use after a peer
                                           ran `noema migrate cortex-id --reset` and the syncer is now reporting an
                                           identity mismatch)
+noema federation set-mode <sync|publish|subscribe>
+                                          Set the cortex-level federation mode
+noema federation pause-peer <name>        Pause syncing with a peer (preserves cursor + identity)
+noema federation resume-peer <name>       Resume syncing with a paused peer
 noema federation key fingerprint          Print the SHA-256 fingerprint of the active MCP shared key (safe to
                                           say aloud over an out-of-band channel to confirm a pairing)
 
@@ -427,6 +434,66 @@ Or add a peer from the CLI:
 
 ```bash
 noema federation add-peer beta http://192.168.1.10:3000
+```
+
+### Federation modes
+
+The `federation.mode` field controls how a Cortex participates in the ring:
+
+| Mode | Syncer runs? | `sync_events` serves? | HTTP write tools? |
+|------|-------------|----------------------|-------------------|
+| `sync` (default) | Yes | Yes | Yes |
+| `publish` | No | Yes | Blocked |
+| `subscribe` | Yes | Blocked | Yes |
+
+**Publish mode** is for source-of-truth cortexes: a company knowledgebase, a curated dataset, a reference corpus. Content is managed locally via stdio; remote peers pull events via `sync_events` but cannot write back. **Subscribe mode** is the complement: pull everything, share nothing.
+
+```yaml
+federation:
+  mode: publish
+  interval: 30s
+  peers:
+    - name: consumer-1
+      endpoint: https://consumer-1.example:3000
+    - name: consumer-2
+      endpoint: https://consumer-2.example:3000
+      mode: paused    # temporarily skip this peer
+```
+
+Individual peers can be paused without affecting the rest of the ring:
+
+```bash
+noema federation pause-peer consumer-2   # skip until resumed
+noema federation resume-peer consumer-2  # re-enable
+noema federation set-mode subscribe      # switch cortex mode
+```
+
+Changes take effect on the next `noema serve` restart.
+
+### Content hashing and source-locking
+
+Every trace carries a `content_hash` (SHA-256 of the body, recomputed on every write). This enables integrity verification and federation sync optimization.
+
+Publishers can mark traces as **source-locked** — immutable on the consumer side:
+
+```yaml
+---
+id: 20260329-api-rate-limits
+title: API Rate Limits
+type: fact
+origin: company-kb
+source_hash: sha256:a3f2b8c...
+source_locked: true
+---
+```
+
+Source-locked traces refuse `update`, `delete`, and `remove` operations when the local cortex is not the origin. `archive`/`unarchive` remain allowed (non-destructive). Use `--force` on CLI commands to override in emergencies.
+
+```bash
+noema verify               # check all trace hashes for integrity
+noema verify --backfill     # populate hashes for old traces
+noema drift                 # check federated traces against source hashes
+noema edit <id> --force     # override source-lock
 ```
 
 ### Authentication

--- a/internal/cli/cmd_drift.go
+++ b/internal/cli/cmd_drift.go
@@ -1,0 +1,78 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Fail-Safe/Noema/internal/cortex"
+	"github.com/Fail-Safe/Noema/internal/trace"
+)
+
+func driftCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "drift",
+		Short: "Check federated traces for drift from their source hash",
+		Long: `Walks all traces with a foreign origin and compares the current body hash
+against the source_hash recorded in the frontmatter. Reports traces whose
+local content has diverged from the publisher's version.
+
+Only traces with a non-empty source_hash are checked — local-origin traces
+and traces from peers that predate the hashing feature are skipped.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cx, err := resolveCortex()
+			if err != nil {
+				return err
+			}
+			defer cx.Close()
+
+			rows, err := cx.List(cortex.ListOptions{All: true})
+			if err != nil {
+				return err
+			}
+
+			out := cmd.OutOrStdout()
+			var checked, drifted int
+
+			for _, r := range rows {
+				if r.Origin == cx.Name || r.Origin == "" {
+					continue // local-origin
+				}
+				if r.SourceHash == "" {
+					continue // no source hash to compare against
+				}
+
+				path := cx.TraceFile(r.ID, r.ArchivedAt != "")
+				t, err := trace.ParseFile(path)
+				if err != nil {
+					fmt.Fprintf(out, "  SKIP     %s (parse error: %v)\n", r.ID, err)
+					continue
+				}
+
+				checked++
+				current := trace.ContentHash(t.Body)
+				if current != r.SourceHash {
+					drifted++
+					lock := "no"
+					if r.SourceLocked {
+						lock = "yes"
+					}
+					fmt.Fprintf(out, "  DRIFTED  %s (source: %s, locked: %s)\n", r.ID, r.Origin, lock)
+					fmt.Fprintf(out, "           local:  %s\n", current)
+					fmt.Fprintf(out, "           source: %s\n", r.SourceHash)
+				}
+			}
+
+			fmt.Fprintf(out, "\nChecked %d federated trace(s).\n", checked)
+			if drifted > 0 {
+				fmt.Fprintf(out, "%d trace(s) have drifted from their source.\n", drifted)
+			} else if checked > 0 {
+				fmt.Fprintln(out, "No drift detected.")
+			} else {
+				fmt.Fprintln(out, "No federated traces with source hashes found.")
+			}
+			return nil
+		},
+	}
+	return cmd
+}

--- a/internal/cli/cmd_edit.go
+++ b/internal/cli/cmd_edit.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -11,7 +12,9 @@ import (
 )
 
 func editCmd() *cobra.Command {
-	return &cobra.Command{
+	var force bool
+
+	cmd := &cobra.Command{
 		Use:               "edit <id>",
 		Short:             "Edit a Trace in $EDITOR",
 		Args:              cobra.ExactArgs(1),
@@ -27,6 +30,10 @@ func editCmd() *cobra.Command {
 			row, err := cx.Get(id)
 			if err != nil {
 				return fmt.Errorf("trace %q not found", id)
+			}
+
+			if row.SourceLocked && row.Origin != cx.Name && !force {
+				return fmt.Errorf("trace %q is source-locked by origin %q (use --force to override)", id, row.Origin)
 			}
 
 			path := cx.TraceFile(id, row.ArchivedAt != "")
@@ -46,11 +53,19 @@ func editCmd() *cobra.Command {
 				return fmt.Errorf("editor exited with error: %w", err)
 			}
 
+			if force {
+				cx.SetForceSourceLock(true)
+			}
 			if err := cx.Update(id); err != nil {
+				if errors.Is(err, cortex.ErrSourceLocked) {
+					return fmt.Errorf("%w (use --force to override)", err)
+				}
 				return fmt.Errorf("syncing database: %w", err)
 			}
 			fmt.Printf("Trace %s updated.\n", id)
 			return nil
 		},
 	}
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "bypass source-lock protection")
+	return cmd
 }

--- a/internal/cli/cmd_federation.go
+++ b/internal/cli/cmd_federation.go
@@ -23,6 +23,9 @@ func federationCmd() *cobra.Command {
 		federationPeersCmd(),
 		federationAddPeerCmd(),
 		federationResetPeerCmd(),
+		federationSetModeCmd(),
+		federationPausePeerCmd(),
+		federationResumePeerCmd(),
 		federationKeyCmd(),
 	)
 	return cmd
@@ -134,6 +137,7 @@ func federationStatusCmd() *cobra.Command {
 				return nil
 			}
 
+			fmt.Printf("Mode: %s\n", m.Federation.EffectiveMode())
 			fmt.Printf("Peers: %d\n", len(m.Federation.Peers))
 			if m.Federation.Interval != "" {
 				fmt.Printf("Interval: %s\n", m.Federation.Interval)
@@ -155,8 +159,9 @@ func federationStatusCmd() *cobra.Command {
 				if ps.LastEvent != "" {
 					lastEvent = ps.LastEvent
 				}
-				fmt.Printf("  %s\n    endpoint:   %s\n    last_seen:  %s\n    last_event: %s\n",
-					p.Name, p.Endpoint, lastSeen, lastEvent)
+				peerMode := p.EffectiveMode()
+				fmt.Printf("  %s\n    endpoint:   %s\n    mode:       %s\n    last_seen:  %s\n    last_event: %s\n",
+					p.Name, p.Endpoint, peerMode, lastSeen, lastEvent)
 			}
 
 			vc, err := cx.GetClock()
@@ -364,6 +369,160 @@ func runFederationResetPeer(out io.Writer, in io.Reader, cx *cortex.Cortex, name
 		fmt.Fprintf(out, "  vector-clock buckets dropped: %d\n", bucketsDropped)
 	}
 	fmt.Fprintln(out, "Restart `noema serve` (or wait for the next syncer poll) to re-pin the peers.")
+	return nil
+}
+
+func federationSetModeCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "set-mode <sync|publish|subscribe>",
+		Short: "Set the federation mode for this cortex",
+		Long: `Sets the cortex-level federation mode in cortex.md:
+
+  sync        Bidirectional: pull events from peers and serve events to them (default)
+  publish     Outbound only: serve events but never pull; write tools are blocked on HTTP
+  subscribe   Inbound only: pull events from peers but refuse to serve them
+
+Changes take effect on the next ` + "`noema serve`" + ` restart.`,
+		Example: "  noema federation set-mode publish\n  noema federation set-mode sync",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			mode := args[0]
+			switch mode {
+			case cortex.FederationModeSync, cortex.FederationModePublish, cortex.FederationModeSubscribe:
+			default:
+				return fmt.Errorf("invalid mode %q; use sync, publish, or subscribe", mode)
+			}
+
+			cx, err := resolveCortex()
+			if err != nil {
+				return err
+			}
+			defer cx.Close()
+
+			m, err := cortex.ReadManifest(cx.Dir)
+			if err != nil {
+				return err
+			}
+
+			if m.Federation == nil {
+				m.Federation = &cortex.FederationConfig{}
+			}
+
+			prev := m.Federation.EffectiveMode()
+			if mode == cortex.FederationModeSync {
+				m.Federation.Mode = "" // omitempty: sync is the default
+			} else {
+				m.Federation.Mode = mode
+			}
+
+			if err := cortex.WriteManifest(cx.Dir, m); err != nil {
+				return err
+			}
+
+			out := cmd.OutOrStdout()
+			if prev == mode {
+				fmt.Fprintf(out, "Federation mode is already %q — no change.\n", mode)
+				return nil
+			}
+
+			fmt.Fprintf(out, "Federation mode changed: %s -> %s\n\n", prev, mode)
+			switch mode {
+			case cortex.FederationModePublish:
+				fmt.Fprintln(out, "Behavior:")
+				fmt.Fprintln(out, "  - The syncer will NOT start (no pulling from peers)")
+				fmt.Fprintln(out, "  - sync_events will continue serving events to peers")
+				fmt.Fprintln(out, "  - Write tools (create/update/delete) are blocked on HTTP")
+				fmt.Fprintln(out, "  - Local stdio transport retains full write access")
+			case cortex.FederationModeSubscribe:
+				fmt.Fprintln(out, "Behavior:")
+				fmt.Fprintln(out, "  - The syncer will pull events from peers normally")
+				fmt.Fprintln(out, "  - sync_events will refuse to serve events")
+				fmt.Fprintln(out, "  - Write tools remain available on all transports")
+			case cortex.FederationModeSync:
+				fmt.Fprintln(out, "Behavior:")
+				fmt.Fprintln(out, "  - The syncer will pull events from peers")
+				fmt.Fprintln(out, "  - sync_events will serve events to peers")
+				fmt.Fprintln(out, "  - Write tools available on all transports")
+			}
+			fmt.Fprintln(out, "\nRestart `noema serve` for the change to take effect.")
+			return nil
+		},
+	}
+}
+
+func federationPausePeerCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "pause-peer <name>",
+		Short:   "Pause syncing with a federation peer",
+		Long:    "Sets a peer's mode to \"paused\" in cortex.md. The syncer will skip this peer\nuntil it is resumed. No state is lost — the cursor and pinned identity are preserved.",
+		Example: "  noema federation pause-peer ai-2",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return setPeerMode(cmd, args[0], cortex.PeerModePaused)
+		},
+	}
+}
+
+func federationResumePeerCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:     "resume-peer <name>",
+		Short:   "Resume syncing with a paused federation peer",
+		Long:    "Clears a peer's mode back to \"sync\" in cortex.md. The syncer will resume\npulling from this peer on the next poll.",
+		Example: "  noema federation resume-peer ai-2",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return setPeerMode(cmd, args[0], cortex.PeerModeSync)
+		},
+	}
+}
+
+// setPeerMode updates a single peer's mode in cortex.md.
+func setPeerMode(cmd *cobra.Command, name string, mode string) error {
+	cx, err := resolveCortex()
+	if err != nil {
+		return err
+	}
+	defer cx.Close()
+
+	m, err := cortex.ReadManifest(cx.Dir)
+	if err != nil {
+		return err
+	}
+
+	if m.Federation == nil || len(m.Federation.Peers) == 0 {
+		return fmt.Errorf("no federation peers configured in cortex.md")
+	}
+
+	found := false
+	for i := range m.Federation.Peers {
+		if m.Federation.Peers[i].Name == name {
+			found = true
+			prev := m.Federation.Peers[i].EffectiveMode()
+			if prev == mode {
+				fmt.Fprintf(cmd.OutOrStdout(), "Peer %q is already %s — no change.\n", name, mode)
+				return nil
+			}
+			if mode == cortex.PeerModeSync {
+				m.Federation.Peers[i].Mode = "" // omitempty: sync is the default
+			} else {
+				m.Federation.Peers[i].Mode = mode
+			}
+			if err := cortex.WriteManifest(cx.Dir, m); err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "Peer %q: %s -> %s\n", name, prev, mode)
+			fmt.Fprintln(cmd.OutOrStdout(), "Restart `noema serve` for the change to take effect.")
+			return nil
+		}
+	}
+
+	if !found {
+		known := make([]string, 0, len(m.Federation.Peers))
+		for _, p := range m.Federation.Peers {
+			known = append(known, p.Name)
+		}
+		return fmt.Errorf("peer %q is not configured in cortex.md (known: %s)", name, strings.Join(known, ", "))
+	}
 	return nil
 }
 

--- a/internal/cli/cmd_remove.go
+++ b/internal/cli/cmd_remove.go
@@ -14,7 +14,7 @@ func removeCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "remove <id>",
 		Aliases:           []string{"rm", "delete"},
-		Short:             "Move a Trace to trash (use --force to hard-delete)",
+		Short:             "Move a Trace to trash (use --force to hard-delete or bypass source-lock)",
 		Args:              cobra.ExactArgs(1),
 		ValidArgsFunction: completionsFor(cortex.ListOptions{}),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -30,6 +30,7 @@ func removeCmd() *cobra.Command {
 			}
 
 			if force {
+				cx.SetForceSourceLock(true)
 				if err := cx.Remove(id); err != nil {
 					return err
 				}
@@ -45,6 +46,6 @@ func removeCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVarP(&force, "force", "f", false, "hard-delete immediately, bypassing trash")
+	cmd.Flags().BoolVarP(&force, "force", "f", false, "hard-delete immediately (also bypasses source-lock)")
 	return cmd
 }

--- a/internal/cli/cmd_serve.go
+++ b/internal/cli/cmd_serve.go
@@ -62,11 +62,11 @@ func serveCmd() *cobra.Command {
 			// not just the human-readable name.
 			fmt.Printf("[serve] cortex %q (id=%s) at %s\n", cx.Name, cx.ID, cx.Dir)
 
-			s := mcpserver.NewServer(cx, version())
-
 			var syncer *federation.Syncer
 			switch transport {
 			case "stdio", "":
+				// Stdio is local — no federation guards on tool access.
+				s := mcpserver.NewServer(cx, version(), "")
 				err = mcpgo.ServeStdio(s)
 			case "http":
 				// Read the manifest BEFORE validateHTTPServe so the
@@ -103,12 +103,16 @@ func serveCmd() *cobra.Command {
 				// Federation only runs over the HTTP transport (peers
 				// need an HTTP endpoint to call sync_events on). Start
 				// the syncer only when the bound cortex actually has
-				// peers configured. Pass the shared key so outbound
-				// sync calls carry the same Authorization header the
-				// middleware enforces on inbound calls (ring model).
-				if m.Federation != nil && len(m.Federation.Peers) > 0 {
-					syncer = startSyncer(cx, accessKey.Value)
+				// peers configured AND the mode is not "publish" (a
+				// publish-mode cortex serves events but never pulls).
+				fedMode := m.Federation.EffectiveMode()
+				if m.Federation != nil && len(m.Federation.Peers) > 0 && fedMode != cortex.FederationModePublish {
+					syncer = startSyncer(cx, accessKey.Value, m.Federation)
 				}
+				fmt.Printf("[serve] federation mode: %s\n", fedMode)
+
+				// HTTP transport: apply federation mode guards.
+				s := mcpserver.NewServer(cx, version(), fedMode)
 
 				// Surface the access posture on startup. The
 				// fingerprint lets two operators confirm they're
@@ -191,29 +195,32 @@ func serveCmd() *cobra.Command {
 	return cmd
 }
 
-// startSyncer reads the cortex manifest and, if federation peers are configured,
-// starts a background syncer that polls remote peers for new events.
-// Returns nil if federation is not configured. sharedKey is attached as an
-// Authorization: Bearer header on every outbound sync when non-empty; pass ""
-// for open-mode peers.
-func startSyncer(cx *cortex.Cortex, sharedKey string) *federation.Syncer {
-	m, err := cortex.ReadManifest(cx.Dir)
-	if err != nil || m.Federation == nil || len(m.Federation.Peers) == 0 {
+// startSyncer converts the manifest's federation config into a running
+// syncer. The caller has already verified that peers exist and the mode
+// is not "publish". sharedKey is attached as an Authorization: Bearer
+// header on every outbound sync when non-empty; pass "" for open-mode
+// peers.
+func startSyncer(cx *cortex.Cortex, sharedKey string, fc *cortex.FederationConfig) *federation.Syncer {
+	if fc == nil || len(fc.Peers) == 0 {
 		return nil
 	}
 
 	var peers []federation.PeerConfig
-	for _, p := range m.Federation.Peers {
-		peers = append(peers, federation.PeerConfig{Name: p.Name, Endpoint: p.Endpoint, CA: p.CA})
+	for _, p := range fc.Peers {
+		peers = append(peers, federation.PeerConfig{
+			Name: p.Name, Endpoint: p.Endpoint, CA: p.CA, Mode: p.Mode,
+		})
 	}
 
 	var interval time.Duration
-	if m.Federation.Interval != "" {
-		interval, _ = time.ParseDuration(m.Federation.Interval)
+	if fc.Interval != "" {
+		interval, _ = time.ParseDuration(fc.Interval)
 	}
 
 	state := federation.NewState(cx.DB.DB)
-	cfg := federation.Config{Peers: peers, Interval: interval, SharedKey: sharedKey}
+	cfg := federation.Config{
+		Mode: fc.EffectiveMode(), Peers: peers, Interval: interval, SharedKey: sharedKey,
+	}
 
 	syncer := federation.NewSyncer(cx, state, cfg)
 	syncer.Start()

--- a/internal/cli/cmd_verify.go
+++ b/internal/cli/cmd_verify.go
@@ -1,0 +1,101 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Fail-Safe/Noema/internal/trace"
+)
+
+func verifyCmd() *cobra.Command {
+	var backfill bool
+
+	cmd := &cobra.Command{
+		Use:   "verify",
+		Short: "Check trace content hashes for integrity",
+		Long: `Walks all trace files (active and archived), recomputes the SHA-256 hash
+of each body, and compares it against the content_hash in the frontmatter.
+Reports any mismatches, which indicate the file was modified outside of Noema.
+
+Use --backfill to populate content_hash for traces that predate the hashing
+feature (or were created by an older binary).`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cx, err := resolveCortex()
+			if err != nil {
+				return err
+			}
+			defer cx.Close()
+
+			dirs := []string{cx.TracesDir(), cx.ArchiveDir()}
+			var checked, mismatches, backfilled int
+
+			for _, dir := range dirs {
+				files, err := os.ReadDir(dir)
+				if os.IsNotExist(err) {
+					continue
+				}
+				if err != nil {
+					return fmt.Errorf("reading %s: %w", dir, err)
+				}
+				for _, f := range files {
+					if f.IsDir() || filepath.Ext(f.Name()) != ".md" {
+						continue
+					}
+					path := filepath.Join(dir, f.Name())
+					t, err := trace.ParseFile(path)
+					if err != nil {
+						fmt.Fprintf(cmd.OutOrStdout(), "  SKIP     %s (parse error: %v)\n", f.Name(), err)
+						continue
+					}
+
+					computed := trace.ContentHash(t.Body)
+					checked++
+
+					if t.ContentHash == "" {
+						if backfill {
+							t.ContentHash = computed
+							if err := t.Write(path); err != nil {
+								return fmt.Errorf("backfilling %s: %w", t.ID, err)
+							}
+							backfilled++
+							fmt.Fprintf(cmd.OutOrStdout(), "  BACKFILL %s\n", t.ID)
+						}
+						continue
+					}
+
+					if t.ContentHash != computed {
+						mismatches++
+						fmt.Fprintf(cmd.OutOrStdout(), "  MISMATCH %s\n", t.ID)
+						fmt.Fprintf(cmd.OutOrStdout(), "           expected: %s\n", t.ContentHash)
+						fmt.Fprintf(cmd.OutOrStdout(), "           actual:   %s\n", computed)
+						if backfill {
+							t.ContentHash = computed
+							if err := t.Write(path); err != nil {
+								return fmt.Errorf("backfilling %s: %w", t.ID, err)
+							}
+							backfilled++
+							fmt.Fprintf(cmd.OutOrStdout(), "  FIXED    %s\n", t.ID)
+						}
+					}
+				}
+			}
+
+			out := cmd.OutOrStdout()
+			fmt.Fprintf(out, "\nChecked %d trace(s).\n", checked)
+			if mismatches > 0 {
+				fmt.Fprintf(out, "%d mismatch(es) found.\n", mismatches)
+			} else {
+				fmt.Fprintln(out, "All hashes OK.")
+			}
+			if backfill && backfilled > 0 {
+				fmt.Fprintf(out, "%d trace(s) backfilled.\n", backfilled)
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&backfill, "backfill", false, "write content_hash into traces that are missing it")
+	return cmd
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -79,7 +79,7 @@ func init() {
 	addGrouped(groupTrace,
 		addCmd(), listCmd(), getCmd(), editCmd(), removeCmd(),
 		searchCmd(), archiveCmd(), unarchiveCmd(), recoverCmd(), purgeCmd(), syncCmd(),
-		eventsCmd(), resolveCmd(),
+		eventsCmd(), resolveCmd(), verifyCmd(), driftCmd(),
 	)
 	addGrouped(groupCortex,
 		initCmd(), useCmd(), cortexCmd(), federationCmd(), migrateCmd(),

--- a/internal/cortex/cortex.go
+++ b/internal/cortex/cortex.go
@@ -49,10 +49,32 @@ type AccessConfig struct {
 	SharedKeyFile string `yaml:"shared_key_file,omitempty"`
 }
 
+// Federation mode constants.
+const (
+	FederationModeSync      = "sync"      // bidirectional: pull from peers + serve events
+	FederationModePublish   = "publish"   // outbound only: serve events, never pull
+	FederationModeSubscribe = "subscribe" // inbound only: pull from peers, refuse to serve
+)
+
+// Peer mode constants.
+const (
+	PeerModeSync   = "sync"   // actively pull from this peer
+	PeerModePaused = "paused" // configured but skipped by the syncer
+)
+
 // FederationConfig holds peer declarations for cortex.md.
 type FederationConfig struct {
+	Mode     string      `yaml:"mode,omitempty"`     // sync | publish | subscribe
 	Peers    []PeerEntry `yaml:"peers,omitempty"`
 	Interval string      `yaml:"interval,omitempty"` // e.g. "30s", "1m"
+}
+
+// EffectiveMode returns the configured federation mode, defaulting to "sync".
+func (fc *FederationConfig) EffectiveMode() string {
+	if fc == nil || fc.Mode == "" {
+		return FederationModeSync
+	}
+	return fc.Mode
 }
 
 // PeerEntry is a peer declared in cortex.md.
@@ -60,13 +82,48 @@ type PeerEntry struct {
 	Name     string `yaml:"name"`
 	Endpoint string `yaml:"endpoint"`
 	CA       string `yaml:"ca,omitempty"` // path to CA cert for TLS verification
+	Mode     string `yaml:"mode,omitempty"` // sync | paused
 }
 
+// EffectiveMode returns the configured peer mode, defaulting to "sync".
+func (pe PeerEntry) EffectiveMode() string {
+	if pe.Mode == "" {
+		return PeerModeSync
+	}
+	return pe.Mode
+}
+
+// ErrSourceLocked is returned when a mutation is attempted on a
+// source-locked trace from a foreign origin.
+var ErrSourceLocked = errors.New("trace is source-locked")
+
 type Cortex struct {
-	ID   string // ULID, stable across renames; the federation identity key
-	Name string // human-readable display label
-	Dir  string
-	DB   *db.DB
+	ID              string // ULID, stable across renames; the federation identity key
+	Name            string // human-readable display label
+	Dir             string
+	DB              *db.DB
+	forceSourceLock bool // when true, checkSourceLock is a no-op
+}
+
+// SetForceSourceLock enables or disables the source-lock override. When
+// enabled, mutations on source-locked traces succeed with a warning instead
+// of being refused. Intended for CLI --force flags only.
+func (c *Cortex) SetForceSourceLock(v bool) { c.forceSourceLock = v }
+
+// CheckSourceLock returns ErrSourceLocked if the trace is source-locked
+// by a foreign origin. The check is skipped when forceSourceLock is set.
+func (c *Cortex) CheckSourceLock(id string) error {
+	if c.forceSourceLock {
+		return nil
+	}
+	r, err := c.Get(id)
+	if err != nil {
+		return err
+	}
+	if r.SourceLocked && r.Origin != c.Name {
+		return fmt.Errorf("%w by origin %q", ErrSourceLocked, r.Origin)
+	}
+	return nil
 }
 
 // Create initialises a new Cortex on disk and registers it.
@@ -106,6 +163,28 @@ func Create(name, dir string) (Manifest, error) {
 	return manifest, conn.Close()
 }
 
+// ValidateFederation checks that the federation mode and per-peer modes in
+// the manifest are recognized values. Returns nil when there is no
+// federation block or when all values are valid.
+func (m Manifest) ValidateFederation() error {
+	if m.Federation == nil {
+		return nil
+	}
+	switch m.Federation.EffectiveMode() {
+	case FederationModeSync, FederationModePublish, FederationModeSubscribe:
+	default:
+		return fmt.Errorf("federation.mode %q is not valid; use sync, publish, or subscribe", m.Federation.Mode)
+	}
+	for _, p := range m.Federation.Peers {
+		switch p.EffectiveMode() {
+		case PeerModeSync, PeerModePaused:
+		default:
+			return fmt.Errorf("federation.peers[%s].mode %q is not valid; use sync or paused", p.Name, p.Mode)
+		}
+	}
+	return nil
+}
+
 // ReadManifest parses the cortex.md manifest in the given cortex directory.
 func ReadManifest(dir string) (Manifest, error) {
 	data, err := os.ReadFile(filepath.Join(dir, "cortex.md"))
@@ -115,6 +194,9 @@ func ReadManifest(dir string) (Manifest, error) {
 	var m Manifest
 	if err := yaml.Unmarshal(data, &m); err != nil {
 		return Manifest{}, fmt.Errorf("parsing cortex.md: %w", err)
+	}
+	if err := m.ValidateFederation(); err != nil {
+		return Manifest{}, err
 	}
 	return m, nil
 }
@@ -490,6 +572,7 @@ func (c *Cortex) Add(t *trace.Trace) error {
 	if t.Origin == "" {
 		t.Origin = c.Name
 	}
+	t.ContentHash = trace.ContentHash(t.Body)
 	path := c.TraceFile(t.ID, false)
 	if err := t.Write(path); err != nil {
 		return fmt.Errorf("writing trace file: %w", err)
@@ -509,8 +592,8 @@ func (c *Cortex) insertDB(t *trace.Trace) error {
 	defer tx.Rollback()
 
 	_, err = tx.Exec(
-		`INSERT INTO traces (id, title, type, author, origin, cortex_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-		t.ID, t.Title, t.Type, t.Author, t.Origin, c.ID, t.Created, t.Updated,
+		`INSERT INTO traces (id, title, type, author, origin, cortex_id, created_at, updated_at, content_hash, source_locked, source_hash) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		t.ID, t.Title, t.Type, t.Author, t.Origin, c.ID, t.Created, t.Updated, t.ContentHash, boolToInt(t.SourceLocked), nullIfEmpty(t.SourceHash),
 	)
 	if err != nil {
 		return err
@@ -537,17 +620,20 @@ func (c *Cortex) insertDB(t *trace.Trace) error {
 
 // Row is a DB row joined with tags, returned by list/search operations.
 type Row struct {
-	ID          string
-	Title       string
-	Type        string
-	Author      string
-	Origin      string
-	Tags        []string
-	DerivedFrom []string
-	ArchivedAt  string
-	TrashedAt   string
-	CreatedAt   string
-	UpdatedAt   string
+	ID           string
+	Title        string
+	Type         string
+	Author       string
+	Origin       string
+	Tags         []string
+	DerivedFrom  []string
+	ArchivedAt   string
+	TrashedAt    string
+	CreatedAt    string
+	UpdatedAt    string
+	ContentHash  string
+	SourceLocked bool
+	SourceHash   string
 }
 
 type ListOptions struct {
@@ -561,7 +647,7 @@ type ListOptions struct {
 }
 
 func (c *Cortex) List(opts ListOptions) ([]Row, error) {
-	q := `SELECT id, title, type, author, origin, archived_at, trashed_at, created_at, updated_at FROM traces WHERE 1=1`
+	q := `SELECT id, title, type, author, origin, archived_at, trashed_at, created_at, updated_at, content_hash, source_locked, source_hash FROM traces WHERE 1=1`
 	var args []any
 
 	switch {
@@ -602,7 +688,7 @@ func (c *Cortex) List(opts ListOptions) ([]Row, error) {
 
 func (c *Cortex) Search(query string, opts ListOptions) ([]Row, error) {
 	q := `
-		SELECT t.id, t.title, t.type, t.author, t.origin, t.archived_at, t.trashed_at, t.created_at, t.updated_at
+		SELECT t.id, t.title, t.type, t.author, t.origin, t.archived_at, t.trashed_at, t.created_at, t.updated_at, t.content_hash, t.source_locked, t.source_hash
 		FROM traces t
 		WHERE t.id IN (SELECT id FROM traces_fts WHERE traces_fts MATCH ?)`
 	args := []any{query}
@@ -641,10 +727,11 @@ func (c *Cortex) Search(query string, opts ListOptions) ([]Row, error) {
 
 func (c *Cortex) Get(id string) (*Row, error) {
 	var r Row
-	var archivedAt, trashedAt *string
+	var archivedAt, trashedAt, contentHash, sourceHash *string
+	var sourceLocked int
 	err := c.DB.QueryRow(
-		`SELECT id, title, type, author, origin, archived_at, trashed_at, created_at, updated_at FROM traces WHERE id = ?`, id,
-	).Scan(&r.ID, &r.Title, &r.Type, &r.Author, &r.Origin, &archivedAt, &trashedAt, &r.CreatedAt, &r.UpdatedAt)
+		`SELECT id, title, type, author, origin, archived_at, trashed_at, created_at, updated_at, content_hash, source_locked, source_hash FROM traces WHERE id = ?`, id,
+	).Scan(&r.ID, &r.Title, &r.Type, &r.Author, &r.Origin, &archivedAt, &trashedAt, &r.CreatedAt, &r.UpdatedAt, &contentHash, &sourceLocked, &sourceHash)
 	if err != nil {
 		return nil, err
 	}
@@ -653,6 +740,13 @@ func (c *Cortex) Get(id string) (*Row, error) {
 	}
 	if trashedAt != nil {
 		r.TrashedAt = *trashedAt
+	}
+	if contentHash != nil {
+		r.ContentHash = *contentHash
+	}
+	r.SourceLocked = sourceLocked != 0
+	if sourceHash != nil {
+		r.SourceHash = *sourceHash
 	}
 	r.Tags, err = c.tagsFor(id)
 	if err != nil {
@@ -668,6 +762,9 @@ func (c *Cortex) Get(id string) (*Row, error) {
 // Remove permanently deletes a trace from disk and the database.
 // Use Trash for recoverable deletion.
 func (c *Cortex) Remove(id string) error {
+	if err := c.CheckSourceLock(id); err != nil {
+		return err
+	}
 	r, err := c.Get(id)
 	if err != nil {
 		return err
@@ -681,6 +778,9 @@ func (c *Cortex) Remove(id string) error {
 
 // Trash moves a trace to the trash directory for deferred deletion.
 func (c *Cortex) Trash(id string) error {
+	if err := c.CheckSourceLock(id); err != nil {
+		return err
+	}
 	r, err := c.Get(id)
 	if err != nil {
 		return err
@@ -847,6 +947,9 @@ func (c *Cortex) Unarchive(id string) error {
 // Update rewrites an existing trace's DB row and FTS entry from its (potentially
 // edited) markdown file on disk.
 func (c *Cortex) Update(id string) error {
+	if err := c.CheckSourceLock(id); err != nil {
+		return err
+	}
 	r, err := c.Get(id)
 	if err != nil {
 		return err
@@ -861,6 +964,7 @@ func (c *Cortex) Update(id string) error {
 	// editor left in the frontmatter — and write it back to the file so disk,
 	// DB, and emitted event all agree.
 	t.Updated = time.Now().UTC().Format(time.RFC3339)
+	t.ContentHash = trace.ContentHash(t.Body)
 	if err := t.Write(path); err != nil {
 		return fmt.Errorf("rewriting trace file with updated timestamp: %w", err)
 	}
@@ -872,8 +976,8 @@ func (c *Cortex) Update(id string) error {
 	defer tx.Rollback()
 
 	_, err = tx.Exec(
-		`UPDATE traces SET title=?, type=?, author=?, origin=?, updated_at=? WHERE id=?`,
-		t.Title, t.Type, t.Author, t.Origin, t.Updated, id,
+		`UPDATE traces SET title=?, type=?, author=?, origin=?, updated_at=?, content_hash=?, source_locked=?, source_hash=? WHERE id=?`,
+		t.Title, t.Type, t.Author, t.Origin, t.Updated, t.ContentHash, boolToInt(t.SourceLocked), nullIfEmpty(t.SourceHash), id,
 	)
 	if err != nil {
 		return err
@@ -910,8 +1014,9 @@ func (c *Cortex) scanRows(rows *sql.Rows) ([]Row, error) { //nolint:govet
 	var result []Row
 	for rows.Next() {
 		var r Row
-		var archivedAt, trashedAt *string
-		if err := rows.Scan(&r.ID, &r.Title, &r.Type, &r.Author, &r.Origin, &archivedAt, &trashedAt, &r.CreatedAt, &r.UpdatedAt); err != nil {
+		var archivedAt, trashedAt, contentHash, sourceHash *string
+		var sourceLocked int
+		if err := rows.Scan(&r.ID, &r.Title, &r.Type, &r.Author, &r.Origin, &archivedAt, &trashedAt, &r.CreatedAt, &r.UpdatedAt, &contentHash, &sourceLocked, &sourceHash); err != nil {
 			return nil, err
 		}
 		if archivedAt != nil {
@@ -919,6 +1024,13 @@ func (c *Cortex) scanRows(rows *sql.Rows) ([]Row, error) { //nolint:govet
 		}
 		if trashedAt != nil {
 			r.TrashedAt = *trashedAt
+		}
+		if contentHash != nil {
+			r.ContentHash = *contentHash
+		}
+		r.SourceLocked = sourceLocked != 0
+		if sourceHash != nil {
+			r.SourceHash = *sourceHash
 		}
 		tags, err := c.tagsFor(r.ID)
 		if err != nil {
@@ -1032,11 +1144,18 @@ func (c *Cortex) SyncWithOptions(opts SyncOptions) (SyncResult, error) {
 			cortexID = c.lookupCortexIDForTrace(t.ID)
 		}
 
+		contentHash := trace.ContentHash(t.Body)
+		if t.ContentHash != contentHash {
+			t.ContentHash = contentHash
+			if err := t.Write(e.path); err != nil {
+				return result, fmt.Errorf("updating content hash for %s: %w", t.ID, err)
+			}
+		}
 		if dbErr != nil {
 			// Not in DB — insert.
 			_, err = tx.Exec(
-				`INSERT INTO traces (id, title, type, author, origin, cortex_id, created_at, updated_at, archived_at, trashed_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-				t.ID, t.Title, t.Type, t.Author, t.Origin, cortexID, t.Created, t.Updated, archivedAt, trashedAt,
+				`INSERT INTO traces (id, title, type, author, origin, cortex_id, created_at, updated_at, archived_at, trashed_at, content_hash, source_locked, source_hash) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				t.ID, t.Title, t.Type, t.Author, t.Origin, cortexID, t.Created, t.Updated, archivedAt, trashedAt, contentHash, boolToInt(t.SourceLocked), nullIfEmpty(t.SourceHash),
 			)
 			if err != nil {
 				tx.Rollback()
@@ -1046,8 +1165,8 @@ func (c *Cortex) SyncWithOptions(opts SyncOptions) (SyncResult, error) {
 		} else {
 			// Already in DB — update metadata and reconcile state.
 			_, err = tx.Exec(
-				`UPDATE traces SET title=?, type=?, author=?, origin=?, cortex_id=?, updated_at=?, archived_at=?, trashed_at=? WHERE id=?`,
-				t.Title, t.Type, t.Author, t.Origin, cortexID, t.Updated, archivedAt, trashedAt, t.ID,
+				`UPDATE traces SET title=?, type=?, author=?, origin=?, cortex_id=?, updated_at=?, archived_at=?, trashed_at=?, content_hash=?, source_locked=?, source_hash=? WHERE id=?`,
+				t.Title, t.Type, t.Author, t.Origin, cortexID, t.Updated, archivedAt, trashedAt, contentHash, boolToInt(t.SourceLocked), nullIfEmpty(t.SourceHash), t.ID,
 			)
 			if err != nil {
 				tx.Rollback()
@@ -1145,13 +1264,16 @@ func (c *Cortex) recoverOrphanFromEventLog(id string) (bool, error) {
 	}
 
 	var data struct {
-		Title       string   `json:"title"`
-		Type        string   `json:"type"`
-		Author      string   `json:"author"`
-		Tags        []string `json:"tags"`
-		DerivedFrom []string `json:"derived_from"`
-		Origin      string   `json:"origin"`
-		Body        string   `json:"body"`
+		Title        string   `json:"title"`
+		Type         string   `json:"type"`
+		Author       string   `json:"author"`
+		Tags         []string `json:"tags"`
+		DerivedFrom  []string `json:"derived_from"`
+		Origin       string   `json:"origin"`
+		Body         string   `json:"body"`
+		ContentHash  string   `json:"content_hash"`
+		SourceHash   string   `json:"source_hash"`
+		SourceLocked bool     `json:"source_locked"`
 	}
 	if err := json.Unmarshal(last.Data, &data); err != nil {
 		return false, fmt.Errorf("parsing event data: %w", err)
@@ -1166,15 +1288,18 @@ func (c *Cortex) recoverOrphanFromEventLog(id string) (bool, error) {
 
 	t := &trace.Trace{
 		Frontmatter: trace.Frontmatter{
-			ID:          id,
-			Title:       data.Title,
-			Type:        data.Type,
-			Author:      data.Author,
-			Tags:        data.Tags,
-			DerivedFrom: data.DerivedFrom,
-			Origin:      data.Origin,
-			Created:     r.CreatedAt,
-			Updated:     last.Timestamp,
+			ID:           id,
+			Title:        data.Title,
+			Type:         data.Type,
+			Author:       data.Author,
+			Tags:         data.Tags,
+			DerivedFrom:  data.DerivedFrom,
+			Origin:       data.Origin,
+			Created:      r.CreatedAt,
+			Updated:      last.Timestamp,
+			ContentHash:  data.ContentHash,
+			SourceHash:   data.SourceHash,
+			SourceLocked: data.SourceLocked,
 		},
 		Body: data.Body,
 	}
@@ -1289,6 +1414,11 @@ func (c *Cortex) ResolveDivergence(divergenceID, acceptOrigin, customBody string
 	}
 
 	originalID := divRow.DerivedFrom[0]
+
+	if err := c.CheckSourceLock(originalID); err != nil {
+		return err
+	}
+
 	divPath := c.filePath(divRow)
 
 	if customBody != "" {
@@ -1577,13 +1707,16 @@ func (c *Cortex) ReplayEvent(e event.Event) error {
 
 func (c *Cortex) replayCreate(e event.Event) error {
 	var data struct {
-		Title       string   `json:"title"`
-		Type        string   `json:"type"`
-		Author      string   `json:"author"`
-		Tags        []string `json:"tags"`
-		DerivedFrom []string `json:"derived_from"`
-		Origin      string   `json:"origin"`
-		Body        string   `json:"body"`
+		Title        string   `json:"title"`
+		Type         string   `json:"type"`
+		Author       string   `json:"author"`
+		Tags         []string `json:"tags"`
+		DerivedFrom  []string `json:"derived_from"`
+		Origin       string   `json:"origin"`
+		Body         string   `json:"body"`
+		ContentHash  string   `json:"content_hash"`
+		SourceHash   string   `json:"source_hash"`
+		SourceLocked bool     `json:"source_locked"`
 	}
 	if err := json.Unmarshal(e.Data, &data); err != nil {
 		return fmt.Errorf("parsing create event data: %w", err)
@@ -1591,15 +1724,18 @@ func (c *Cortex) replayCreate(e event.Event) error {
 
 	t := &trace.Trace{
 		Frontmatter: trace.Frontmatter{
-			ID:          e.TraceID,
-			Title:       data.Title,
-			Type:        data.Type,
-			Author:      data.Author,
-			Tags:        data.Tags,
-			DerivedFrom: data.DerivedFrom,
-			Origin:      data.Origin,
-			Created:     e.Timestamp,
-			Updated:     e.Timestamp,
+			ID:           e.TraceID,
+			Title:        data.Title,
+			Type:         data.Type,
+			Author:       data.Author,
+			Tags:         data.Tags,
+			DerivedFrom:  data.DerivedFrom,
+			Origin:       data.Origin,
+			Created:      e.Timestamp,
+			Updated:      e.Timestamp,
+			ContentHash:  data.ContentHash,
+			SourceHash:   data.SourceHash,
+			SourceLocked: data.SourceLocked,
 		},
 		Body: data.Body,
 	}
@@ -1626,8 +1762,8 @@ func (c *Cortex) replayCreate(e event.Event) error {
 	defer tx.Rollback()
 
 	_, err = tx.Exec(
-		`INSERT INTO traces (id, title, type, author, origin, cortex_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-		t.ID, t.Title, t.Type, t.Author, t.Origin, e.CortexID, t.Created, t.Updated,
+		`INSERT INTO traces (id, title, type, author, origin, cortex_id, created_at, updated_at, content_hash, source_locked, source_hash) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		t.ID, t.Title, t.Type, t.Author, t.Origin, e.CortexID, t.Created, t.Updated, t.ContentHash, boolToInt(t.SourceLocked), nullIfEmpty(t.SourceHash),
 	)
 	if err != nil {
 		cleanupFile(err)
@@ -1658,13 +1794,16 @@ func (c *Cortex) replayCreate(e event.Event) error {
 
 func (c *Cortex) replayUpdate(e event.Event) error {
 	var data struct {
-		Title       string   `json:"title"`
-		Type        string   `json:"type"`
-		Author      string   `json:"author"`
-		Tags        []string `json:"tags"`
-		DerivedFrom []string `json:"derived_from"`
-		Origin      string   `json:"origin"`
-		Body        string   `json:"body"`
+		Title        string   `json:"title"`
+		Type         string   `json:"type"`
+		Author       string   `json:"author"`
+		Tags         []string `json:"tags"`
+		DerivedFrom  []string `json:"derived_from"`
+		Origin       string   `json:"origin"`
+		Body         string   `json:"body"`
+		ContentHash  string   `json:"content_hash"`
+		SourceHash   string   `json:"source_hash"`
+		SourceLocked bool     `json:"source_locked"`
 	}
 	if err := json.Unmarshal(e.Data, &data); err != nil {
 		return fmt.Errorf("parsing update event data: %w", err)
@@ -1700,15 +1839,18 @@ func (c *Cortex) replayUpdate(e event.Event) error {
 
 	t := &trace.Trace{
 		Frontmatter: trace.Frontmatter{
-			ID:          e.TraceID,
-			Title:       data.Title,
-			Type:        data.Type,
-			Author:      data.Author,
-			Tags:        data.Tags,
-			DerivedFrom: data.DerivedFrom,
-			Origin:      data.Origin,
-			Created:     r.CreatedAt,
-			Updated:     e.Timestamp,
+			ID:           e.TraceID,
+			Title:        data.Title,
+			Type:         data.Type,
+			Author:       data.Author,
+			Tags:         data.Tags,
+			DerivedFrom:  data.DerivedFrom,
+			Origin:       data.Origin,
+			Created:      r.CreatedAt,
+			Updated:      e.Timestamp,
+			ContentHash:  data.ContentHash,
+			SourceHash:   data.SourceHash,
+			SourceLocked: data.SourceLocked,
 		},
 		Body: data.Body,
 	}
@@ -1725,8 +1867,8 @@ func (c *Cortex) replayUpdate(e event.Event) error {
 	defer tx.Rollback()
 
 	if _, err := tx.Exec(
-		`UPDATE traces SET title=?, type=?, author=?, origin=?, updated_at=? WHERE id=?`,
-		t.Title, t.Type, t.Author, t.Origin, t.Updated, e.TraceID,
+		`UPDATE traces SET title=?, type=?, author=?, origin=?, updated_at=?, content_hash=?, source_locked=?, source_hash=? WHERE id=?`,
+		t.Title, t.Type, t.Author, t.Origin, t.Updated, t.ContentHash, boolToInt(t.SourceLocked), nullIfEmpty(t.SourceHash), e.TraceID,
 	); err != nil {
 		return err
 	}
@@ -2195,23 +2337,43 @@ func (c *Cortex) backfillCreateEvent(traceID string) error {
 // marshalTraceData builds a JSON snapshot of a trace for event payloads.
 func marshalTraceData(t *trace.Trace) json.RawMessage {
 	payload := struct {
-		Title       string   `json:"title"`
-		Type        string   `json:"type"`
-		Author      string   `json:"author,omitempty"`
-		Tags        []string `json:"tags,omitempty"`
-		DerivedFrom []string `json:"derived_from,omitempty"`
-		Origin      string   `json:"origin,omitempty"`
-		Body        string   `json:"body"`
+		Title        string   `json:"title"`
+		Type         string   `json:"type"`
+		Author       string   `json:"author,omitempty"`
+		Tags         []string `json:"tags,omitempty"`
+		DerivedFrom  []string `json:"derived_from,omitempty"`
+		Origin       string   `json:"origin,omitempty"`
+		Body         string   `json:"body"`
+		ContentHash  string   `json:"content_hash,omitempty"`
+		SourceHash   string   `json:"source_hash,omitempty"`
+		SourceLocked bool     `json:"source_locked,omitempty"`
 	}{
-		Title:       t.Title,
-		Type:        t.Type,
-		Author:      t.Author,
-		Tags:        t.Tags,
-		DerivedFrom: t.DerivedFrom,
-		Origin:      t.Origin,
-		Body:        t.Body,
+		Title:        t.Title,
+		Type:         t.Type,
+		Author:       t.Author,
+		Tags:         t.Tags,
+		DerivedFrom:  t.DerivedFrom,
+		Origin:       t.Origin,
+		Body:         t.Body,
+		ContentHash:  t.ContentHash,
+		SourceHash:   t.SourceHash,
+		SourceLocked: t.SourceLocked,
 	}
 	data, _ := json.Marshal(payload)
 	return data
+}
+
+func boolToInt(b bool) int {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+func nullIfEmpty(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
 }
 

--- a/internal/cortex/cortex_test.go
+++ b/internal/cortex/cortex_test.go
@@ -1934,3 +1934,88 @@ func TestReplayEvent_SoftStateOnMissingTrace_NoOpAndStored(t *testing.T) {
 // Verify the _ imports are used
 var _ = federation.VClock{}
 var _ = trace.TypeDivergence
+
+// ---- federation mode validation -------------------------------------------
+
+func TestFederationConfig_EffectiveMode_Defaults(t *testing.T) {
+	// nil config
+	var fc *cortex.FederationConfig
+	if got := fc.EffectiveMode(); got != cortex.FederationModeSync {
+		t.Errorf("nil config: got %q, want %q", got, cortex.FederationModeSync)
+	}
+	// empty mode
+	fc = &cortex.FederationConfig{}
+	if got := fc.EffectiveMode(); got != cortex.FederationModeSync {
+		t.Errorf("empty mode: got %q, want %q", got, cortex.FederationModeSync)
+	}
+}
+
+func TestPeerEntry_EffectiveMode_Defaults(t *testing.T) {
+	pe := cortex.PeerEntry{Name: "x", Endpoint: "http://x"}
+	if got := pe.EffectiveMode(); got != cortex.PeerModeSync {
+		t.Errorf("empty peer mode: got %q, want %q", got, cortex.PeerModeSync)
+	}
+}
+
+func TestValidateFederation_ValidModes(t *testing.T) {
+	for _, mode := range []string{"sync", "publish", "subscribe"} {
+		m := cortex.Manifest{
+			Federation: &cortex.FederationConfig{Mode: mode},
+		}
+		if err := m.ValidateFederation(); err != nil {
+			t.Errorf("mode %q: unexpected error: %v", mode, err)
+		}
+	}
+}
+
+func TestValidateFederation_InvalidCortexMode(t *testing.T) {
+	m := cortex.Manifest{
+		Federation: &cortex.FederationConfig{Mode: "broadcast"},
+	}
+	err := m.ValidateFederation()
+	if err == nil {
+		t.Fatal("expected error on invalid federation mode")
+	}
+	if !strings.Contains(err.Error(), "broadcast") {
+		t.Errorf("error should name the bad mode, got: %v", err)
+	}
+}
+
+func TestValidateFederation_InvalidPeerMode(t *testing.T) {
+	m := cortex.Manifest{
+		Federation: &cortex.FederationConfig{
+			Peers: []cortex.PeerEntry{
+				{Name: "bob", Endpoint: "http://bob", Mode: "push"},
+			},
+		},
+	}
+	err := m.ValidateFederation()
+	if err == nil {
+		t.Fatal("expected error on invalid peer mode")
+	}
+	if !strings.Contains(err.Error(), "bob") || !strings.Contains(err.Error(), "push") {
+		t.Errorf("error should name the peer and bad mode, got: %v", err)
+	}
+}
+
+func TestValidateFederation_ValidPeerModes(t *testing.T) {
+	for _, mode := range []string{"sync", "paused", ""} {
+		m := cortex.Manifest{
+			Federation: &cortex.FederationConfig{
+				Peers: []cortex.PeerEntry{
+					{Name: "x", Endpoint: "http://x", Mode: mode},
+				},
+			},
+		}
+		if err := m.ValidateFederation(); err != nil {
+			t.Errorf("peer mode %q: unexpected error: %v", mode, err)
+		}
+	}
+}
+
+func TestValidateFederation_NilFederation(t *testing.T) {
+	m := cortex.Manifest{}
+	if err := m.ValidateFederation(); err != nil {
+		t.Errorf("nil federation should pass validation: %v", err)
+	}
+}

--- a/internal/db/migrations/006_content_hash.sql
+++ b/internal/db/migrations/006_content_hash.sql
@@ -1,0 +1,1 @@
+ALTER TABLE traces ADD COLUMN content_hash TEXT;

--- a/internal/db/migrations/007_source_locking.sql
+++ b/internal/db/migrations/007_source_locking.sql
@@ -1,0 +1,2 @@
+ALTER TABLE traces ADD COLUMN source_locked INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE traces ADD COLUMN source_hash TEXT;

--- a/internal/federation/federation.go
+++ b/internal/federation/federation.go
@@ -4,15 +4,23 @@ import "time"
 
 const DefaultInterval = 30 * time.Second
 
+// Peer mode constants — checked by the syncer to skip paused peers.
+const (
+	PeerModeSync   = "sync"
+	PeerModePaused = "paused"
+)
+
 // PeerConfig is a peer entry as declared in cortex.md.
 type PeerConfig struct {
 	Name     string `yaml:"name"`
 	Endpoint string `yaml:"endpoint"`
 	CA       string `yaml:"ca,omitempty"` // path to CA certificate for TLS verification
+	Mode     string `yaml:"mode,omitempty"` // sync | paused
 }
 
 // Config holds federation settings from cortex.md.
 type Config struct {
+	Mode     string        // federation-level mode: sync | publish | subscribe
 	Peers    []PeerConfig  `yaml:"peers,omitempty"`
 	Interval time.Duration // parsed from string
 

--- a/internal/federation/syncer.go
+++ b/internal/federation/syncer.go
@@ -48,6 +48,10 @@ func NewSyncer(replayer EventReplayer, state *State, cfg Config) *Syncer {
 
 func (s *Syncer) Start() {
 	for _, peer := range s.config.Peers {
+		if peer.Mode == PeerModePaused {
+			log.Printf("[federation] peer %q is paused, skipping", peer.Name)
+			continue
+		}
 		s.wg.Add(1)
 		go s.syncLoop(peer)
 	}

--- a/internal/federation/syncer_test.go
+++ b/internal/federation/syncer_test.go
@@ -138,6 +138,41 @@ func TestReplayBatch_AdvancesOnAllSuccess(t *testing.T) {
 	}
 }
 
+// TestSyncer_Start_SkipsPausedPeers verifies that the syncer does not
+// spawn a goroutine for peers whose mode is "paused". The test creates
+// a syncer with three peers (one paused, two active with unreachable
+// endpoints) and checks that the paused peer never gets a state entry.
+func TestSyncer_Start_SkipsPausedPeers(t *testing.T) {
+	fr := &fakeReplayer{}
+	dir := t.TempDir()
+	conn, err := db.Open(dir)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { conn.Close() })
+
+	state := NewState(conn.DB)
+	s := NewSyncer(fr, state, Config{
+		Peers: []PeerConfig{
+			{Name: "active-1", Endpoint: "http://127.0.0.1:1", Mode: PeerModeSync},
+			{Name: "paused-1", Endpoint: "http://127.0.0.1:2", Mode: PeerModePaused},
+			{Name: "active-2", Endpoint: "http://127.0.0.1:3"}, // empty = defaults to sync
+		},
+	})
+
+	s.Start()
+	s.Stop()
+
+	// The paused peer should have no state at all — the syncer never
+	// even attempted to reach it.
+	for _, key := range []string{PeerCursorKey("paused-1"), PeerSeenKey("paused-1")} {
+		val, _ := state.Get(key)
+		if val != "" {
+			t.Errorf("paused peer state %q = %q, want empty", key, val)
+		}
+	}
+}
+
 // TestReplayBatch_FirstEventFailure_LeavesCursorUnset covers the edge
 // case where the very first event fails: there is no previous successful
 // event to pin the cursor against, so the cursor must remain whatever it

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -21,13 +21,31 @@ import (
 // noema build they're talking to without grepping logs. Callers should
 // pass cli.version() so the value matches `noema --version`. An empty
 // string is normalized to "dev" so the protocol field is never blank.
-func NewServer(cx *cortex.Cortex, noemaVersion string) *server.MCPServer {
+// NewServer creates a new MCP server for the given cortex. federationMode
+// controls tool access: "publish" blocks mutating tools (source of truth),
+// "subscribe" blocks sync_events (consumer only), "sync"/empty allows all.
+func NewServer(cx *cortex.Cortex, noemaVersion string, federationMode string) *server.MCPServer {
 	if noemaVersion == "" {
 		noemaVersion = "dev"
 	}
 	s := server.NewMCPServer("noema", noemaVersion,
 		server.WithToolCapabilities(true),
 	)
+
+	// readOnlyGuard wraps a tool handler to reject calls when the cortex is
+	// in publish mode. Publish-mode cortexes are read-only for remote peers;
+	// local writes go through a separate stdio transport process.
+	type toolHandler = func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error)
+	readOnlyGuard := func(next toolHandler) toolHandler {
+		if federationMode != cortex.FederationModePublish {
+			return next
+		}
+		return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return mcp.NewToolResultError(
+				"this cortex is in publish mode (read-only for remote peers); " +
+					"use a local stdio transport for writes"), nil
+		}
+	}
 
 	s.AddTool(mcp.NewTool("get_instructions",
 		mcp.WithDescription("Returns a reference guide for working with this Cortex: terminology, trace types, field definitions, filtering options, and tool usage. Call this first if you are unfamiliar with Noema."),
@@ -90,6 +108,15 @@ func NewServer(cx *cortex.Cortex, noemaVersion string) *server.MCPServer {
 		if len(row.DerivedFrom) > 0 {
 			out += fmt.Sprintf("\nDerived From: %s", strings.Join(row.DerivedFrom, ", "))
 		}
+		if row.SourceLocked {
+			out += "\nSource Locked: yes"
+		}
+		if row.SourceHash != "" {
+			out += fmt.Sprintf("\nSource Hash: %s", row.SourceHash)
+		}
+		if row.ContentHash != "" {
+			out += fmt.Sprintf("\nContent Hash: %s", row.ContentHash)
+		}
 		out += fmt.Sprintf("\n\n%s", t.Body)
 		return mcp.NewToolResultText(out), nil
 	})
@@ -104,7 +131,9 @@ func NewServer(cx *cortex.Cortex, noemaVersion string) *server.MCPServer {
 		mcp.WithString("tags", mcp.Description("Comma-separated tags")),
 		mcp.WithString("derived_from", mcp.Description("Comma-separated trace IDs this trace was derived from")),
 		mcp.WithString("origin", mcp.Description("Origin cortex name (defaults to current cortex)")),
-	), func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		mcp.WithBoolean("source_locked", mcp.Description("Mark trace as source-locked (immutable on consumer side)")),
+		mcp.WithString("source_hash", mcp.Description("Content hash from the source/publisher cortex")),
+	), readOnlyGuard(func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		title, err := req.RequireString("title")
 		if err != nil {
 			return nil, err
@@ -137,11 +166,17 @@ func NewServer(cx *cortex.Cortex, noemaVersion string) *server.MCPServer {
 		if origin := req.GetString("origin", ""); origin != "" {
 			t.Origin = origin
 		}
+		if req.GetBool("source_locked", false) {
+			t.SourceLocked = true
+		}
+		if sh := req.GetString("source_hash", ""); sh != "" {
+			t.SourceHash = sh
+		}
 		if err := cx.Add(t); err != nil {
 			return nil, err
 		}
 		return mcp.NewToolResultText(fmt.Sprintf("Trace created: %s", t.ID)), nil
-	})
+	}))
 
 	s.AddTool(mcp.NewTool("search_traces",
 		mcp.WithDescription("Full-text search across traces"),
@@ -164,7 +199,7 @@ func NewServer(cx *cortex.Cortex, noemaVersion string) *server.MCPServer {
 	s.AddTool(mcp.NewTool("delete_trace",
 		mcp.WithDescription("Move a trace to trash (soft-delete, recoverable for 30 days). Use recover_trace to restore it."),
 		mcp.WithString("id", mcp.Description("Trace ID"), mcp.Required()),
-	), func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	), readOnlyGuard(func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		id, err := req.RequireString("id")
 		if err != nil {
 			return nil, err
@@ -173,12 +208,12 @@ func NewServer(cx *cortex.Cortex, noemaVersion string) *server.MCPServer {
 			return nil, err
 		}
 		return mcp.NewToolResultText(fmt.Sprintf("Trace %s moved to trash.", id)), nil
-	})
+	}))
 
 	s.AddTool(mcp.NewTool("recover_trace",
 		mcp.WithDescription("Restore a trace from trash back to active"),
 		mcp.WithString("id", mcp.Description("Trace ID"), mcp.Required()),
-	), func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	), readOnlyGuard(func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		id, err := req.RequireString("id")
 		if err != nil {
 			return nil, err
@@ -187,12 +222,12 @@ func NewServer(cx *cortex.Cortex, noemaVersion string) *server.MCPServer {
 			return nil, err
 		}
 		return mcp.NewToolResultText(fmt.Sprintf("Trace %s recovered.", id)), nil
-	})
+	}))
 
 	s.AddTool(mcp.NewTool("archive_trace",
 		mcp.WithDescription("Archive a trace"),
 		mcp.WithString("id", mcp.Description("Trace ID"), mcp.Required()),
-	), func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	), readOnlyGuard(func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		id, err := req.RequireString("id")
 		if err != nil {
 			return nil, err
@@ -201,12 +236,12 @@ func NewServer(cx *cortex.Cortex, noemaVersion string) *server.MCPServer {
 			return nil, err
 		}
 		return mcp.NewToolResultText(fmt.Sprintf("Trace %s archived.", id)), nil
-	})
+	}))
 
 	s.AddTool(mcp.NewTool("unarchive_trace",
 		mcp.WithDescription("Restore an archived trace"),
 		mcp.WithString("id", mcp.Description("Trace ID"), mcp.Required()),
-	), func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	), readOnlyGuard(func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		id, err := req.RequireString("id")
 		if err != nil {
 			return nil, err
@@ -215,7 +250,7 @@ func NewServer(cx *cortex.Cortex, noemaVersion string) *server.MCPServer {
 			return nil, err
 		}
 		return mcp.NewToolResultText(fmt.Sprintf("Trace %s restored.", id)), nil
-	})
+	}))
 
 	s.AddTool(mcp.NewTool("update_trace",
 		mcp.WithDescription("Update fields of an existing trace. Only provided fields are changed."),
@@ -227,7 +262,7 @@ func NewServer(cx *cortex.Cortex, noemaVersion string) *server.MCPServer {
 		mcp.WithString("tags", mcp.Description("New tags, comma-separated (replaces existing tags)")),
 		mcp.WithString("derived_from", mcp.Description("New derived_from, comma-separated trace IDs (replaces existing lineage)")),
 		mcp.WithString("body", mcp.Description("New body content")),
-	), func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	), readOnlyGuard(func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		id, err := req.RequireString("id")
 		if err != nil {
 			return nil, err
@@ -271,6 +306,9 @@ func NewServer(cx *cortex.Cortex, noemaVersion string) *server.MCPServer {
 			}
 			t.DerivedFrom = sources
 		}
+		if err := cx.CheckSourceLock(id); err != nil {
+			return nil, err
+		}
 		if err := t.Write(path); err != nil {
 			return nil, err
 		}
@@ -278,7 +316,7 @@ func NewServer(cx *cortex.Cortex, noemaVersion string) *server.MCPServer {
 			return nil, err
 		}
 		return mcp.NewToolResultText(fmt.Sprintf("Trace %s updated.", id)), nil
-	})
+	}))
 
 	// ---- Event Log & Lineage tools ----
 
@@ -342,7 +380,7 @@ func NewServer(cx *cortex.Cortex, noemaVersion string) *server.MCPServer {
 		mcp.WithString("id", mcp.Description("Divergence trace ID"), mcp.Required()),
 		mcp.WithString("accept", mcp.Description("Origin name whose version to accept. See the '**Conflicting origins:**' line in the divergence body for valid values.")),
 		mcp.WithString("body", mcp.Description("Custom merged body content. Mutually exclusive with 'accept'.")),
-	), func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	), readOnlyGuard(func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		id, err := req.RequireString("id")
 		if err != nil {
 			return nil, err
@@ -356,7 +394,7 @@ func NewServer(cx *cortex.Cortex, noemaVersion string) *server.MCPServer {
 			return mcp.NewToolResultText(fmt.Sprintf("Divergence %s resolved (accepted %s).", id, accept)), nil
 		}
 		return mcp.NewToolResultText(fmt.Sprintf("Divergence %s resolved (custom merge).", id)), nil
-	})
+	}))
 
 	// ---- Federation tools ----
 
@@ -371,6 +409,7 @@ func NewServer(cx *cortex.Cortex, noemaVersion string) *server.MCPServer {
 			"id":      cx.ID,
 			"name":    m.Name,
 			"version": m.Version,
+			"mode":    m.Federation.EffectiveMode(),
 		}
 		data, err := json.Marshal(payload)
 		if err != nil {
@@ -384,6 +423,10 @@ func NewServer(cx *cortex.Cortex, noemaVersion string) *server.MCPServer {
 		mcp.WithString("since", mcp.Description("ULID cursor — return only events after this ID")),
 		mcp.WithNumber("limit", mcp.Description("Max events to return (default 100, max 1000)")),
 	), func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		if federationMode == cortex.FederationModeSubscribe {
+			return mcp.NewToolResultError(
+				"this cortex is in subscribe mode and does not serve events"), nil
+		}
 		since := req.GetString("since", "")
 		limit := req.GetInt("limit", 100)
 		if limit <= 0 || limit > 1000 {
@@ -410,6 +453,7 @@ func NewServer(cx *cortex.Cortex, noemaVersion string) *server.MCPServer {
 
 		var sb strings.Builder
 		sb.WriteString(fmt.Sprintf("Cortex: %s\n", m.Name))
+		sb.WriteString(fmt.Sprintf("Mode: %s\n", m.Federation.EffectiveMode()))
 
 		// Surface the MCP access posture alongside federation state so a
 		// peer calling this tool sees exactly what the middleware is
@@ -452,8 +496,9 @@ func NewServer(cx *cortex.Cortex, noemaVersion string) *server.MCPServer {
 				if ps.CortexID != "" {
 					cortexID = ps.CortexID
 				}
-				sb.WriteString(fmt.Sprintf("  %s\n    endpoint:   %s\n    cortex_id:  %s\n    last_seen:  %s\n    last_event: %s\n",
-					p.Name, p.Endpoint, cortexID, lastSeen, lastEvent))
+				peerMode := p.EffectiveMode()
+				sb.WriteString(fmt.Sprintf("  %s\n    endpoint:   %s\n    mode:       %s\n    cortex_id:  %s\n    last_seen:  %s\n    last_event: %s\n",
+					p.Name, p.Endpoint, peerMode, cortexID, lastSeen, lastEvent))
 			}
 		}
 
@@ -595,6 +640,9 @@ Choose the type that best reflects the intent of the memory:
   tags          optional  list of keyword strings
   derived_from  optional  list of trace IDs this trace was derived from
   origin        optional  cortex name that created this trace (auto-set)
+  content_hash  auto      SHA-256 of body (sha256:<hex>), recomputed on every write
+  source_hash   optional  origin's content_hash at publish time (immutable on consumer)
+  source_locked optional  when true, consumer-side mutations are refused
 
 ## Tools
 
@@ -602,7 +650,7 @@ Choose the type that best reflects the intent of the memory:
   list_traces [type] [author] [tag] [origin] [archived] [all]
                                  → list traces; defaults to active only
   get_trace id                   → full content including body, origin, lineage
-  create_trace title type body [author] [tags] [derived_from] [origin]
+  create_trace title type body [author] [tags] [derived_from] [origin] [source_locked] [source_hash]
                                  → create a new trace; tags/derived_from = comma-separated.
                                    Do NOT include a date in the title — the ID
                                    generator prepends today's date automatically,
@@ -675,6 +723,34 @@ Choose the type that best reflects the intent of the memory:
   your client either has it configured and every tool call works, or it doesn't and
   you'll see a 401 from the transport layer.
 - Stdio is unaffected by this posture: stdio implies local-process trust.
+
+## Federation Modes
+The cortex-level federation mode controls how this instance participates in a ring:
+
+  sync        (default) Bidirectional: pull events from peers and serve events to them.
+  publish     Outbound only: serve events via sync_events, but never pull. Write tools
+              (create/update/delete/archive/recover/resolve) are blocked on HTTP — use
+              a local stdio transport for content management.
+  subscribe   Inbound only: pull events from peers normally. sync_events refuses to
+              serve — remote peers cannot pull from this cortex.
+
+Each peer can also be paused individually (mode=paused in cortex.md) without affecting
+the rest of the ring. A paused peer keeps its cursor and identity pin intact.
+
+cortex_identity reports the active mode. federation_status shows both the cortex mode
+and per-peer modes.
+
+## Source-Locking
+Traces can be source-locked by setting source_locked=true on creation. A source-locked
+trace refuses update, delete, and remove when the local cortex is not the trace's origin.
+This enforces publisher authority: consumers receive the trace via federation but cannot
+modify it. archive/unarchive remain allowed (non-destructive).
+
+content_hash is auto-computed (SHA-256 of the body) on every write and carried through
+federation events. source_hash records the origin's content_hash at publish time so
+consumers can detect drift.
+
+get_trace shows Source Locked, Source Hash, and Content Hash fields when present.
 
 ## Tips
 - Prefer specific types over "note" — it helps retrieval and reasoning later.

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
 
 	"github.com/Fail-Safe/Noema/internal/cortex"
 )
@@ -174,7 +175,7 @@ func newTestCortex(t *testing.T) *cortex.Cortex {
 // can ever talk to, so a failed handshake is never a "soft" condition.
 func initializeServer(t *testing.T, cx *cortex.Cortex, version string) mcp.InitializeResult {
 	t.Helper()
-	s := NewServer(cx, version)
+	s := NewServer(cx, version, "")
 
 	initReq := mcp.JSONRPCRequest{
 		JSONRPC: mcp.JSONRPC_VERSION,
@@ -243,5 +244,173 @@ func TestNewServer_EmptyVersionNormalizesToDev(t *testing.T) {
 
 	if result.ServerInfo.Version != "dev" {
 		t.Errorf("ServerInfo.Version = %q, want %q (empty should normalize)", result.ServerInfo.Version, "dev")
+	}
+}
+
+// --------- Federation mode guards ---------
+
+// callTool invokes a named tool on an already-initialized MCP server
+// and returns the result text + whether it was an error result.
+func callTool(t *testing.T, s *server.MCPServer, toolName string, args map[string]any) (string, bool) {
+	t.Helper()
+	if args == nil {
+		args = map[string]any{}
+	}
+	params, _ := json.Marshal(map[string]any{
+		"name":      toolName,
+		"arguments": args,
+	})
+	req := mcp.JSONRPCRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      mcp.NewRequestId(int64(42)),
+		Request: mcp.Request{Method: "tools/call"},
+	}
+	reqBytes, _ := json.Marshal(req)
+	// Splice params into the raw JSON.
+	reqBytes = []byte(strings.TrimSuffix(string(reqBytes), "}") + `,"params":` + string(params) + "}")
+
+	result := s.HandleMessage(context.Background(), reqBytes)
+	if result == nil {
+		t.Fatalf("HandleMessage returned nil for %s", toolName)
+	}
+	resp, ok := result.(mcp.JSONRPCResponse)
+	if !ok {
+		t.Fatalf("expected JSONRPCResponse for %s, got %T", toolName, result)
+	}
+	data, _ := json.Marshal(resp.Result)
+	var toolResult mcp.CallToolResult
+	if err := json.Unmarshal(data, &toolResult); err != nil {
+		t.Fatalf("unmarshal CallToolResult for %s: %v", toolName, err)
+	}
+	text := ""
+	if len(toolResult.Content) > 0 {
+		if tc, ok := toolResult.Content[0].(mcp.TextContent); ok {
+			text = tc.Text
+		}
+	}
+	return text, toolResult.IsError
+}
+
+// initServer drives the MCP initialize handshake so tools can be called.
+func initServer(t *testing.T, s *server.MCPServer) {
+	t.Helper()
+	initReq := mcp.JSONRPCRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      mcp.NewRequestId(int64(1)),
+		Request: mcp.Request{Method: "initialize"},
+		Params: struct {
+			ProtocolVersion string                 `json:"protocolVersion"`
+			ClientInfo      mcp.Implementation     `json:"clientInfo"`
+			Capabilities    mcp.ClientCapabilities `json:"capabilities"`
+		}{
+			ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
+			ClientInfo:      mcp.Implementation{Name: "test", Version: "1.0"},
+		},
+	}
+	body, _ := json.Marshal(initReq)
+	resp := s.HandleMessage(context.Background(), body)
+	if resp == nil {
+		t.Fatal("initialize returned nil")
+	}
+}
+
+func TestPublishMode_BlocksMutatingTools(t *testing.T) {
+	cx := newTestCortex(t)
+	s := NewServer(cx, "test", "publish")
+	initServer(t, s)
+
+	mutating := []struct {
+		name string
+		args map[string]any
+	}{
+		{"create_trace", map[string]any{"title": "x", "type": "note", "body": "y"}},
+		{"update_trace", map[string]any{"id": "nonexistent", "title": "x"}},
+		{"delete_trace", map[string]any{"id": "nonexistent"}},
+		{"recover_trace", map[string]any{"id": "nonexistent"}},
+		{"archive_trace", map[string]any{"id": "nonexistent"}},
+		{"unarchive_trace", map[string]any{"id": "nonexistent"}},
+		{"resolve_divergence", map[string]any{"id": "nonexistent"}},
+	}
+
+	for _, tc := range mutating {
+		text, isErr := callTool(t, s, tc.name, tc.args)
+		if !isErr {
+			t.Errorf("%s: expected error result in publish mode, got success: %s", tc.name, text)
+		}
+		if !strings.Contains(text, "publish mode") {
+			t.Errorf("%s: error should mention publish mode, got: %s", tc.name, text)
+		}
+	}
+}
+
+func TestPublishMode_AllowsReadTools(t *testing.T) {
+	cx := newTestCortex(t)
+	s := NewServer(cx, "test", "publish")
+	initServer(t, s)
+
+	// These should all succeed (not return publish-mode errors).
+	readTools := []struct {
+		name string
+		args map[string]any
+	}{
+		{"list_traces", nil},
+		{"search_traces", map[string]any{"query": "test"}},
+		{"sync_events", nil},
+		{"federation_status", nil},
+	}
+
+	for _, tc := range readTools {
+		text, isErr := callTool(t, s, tc.name, tc.args)
+		if isErr && strings.Contains(text, "publish mode") {
+			t.Errorf("%s: should not be blocked in publish mode, got: %s", tc.name, text)
+		}
+	}
+}
+
+func TestSubscribeMode_BlocksSyncEvents(t *testing.T) {
+	cx := newTestCortex(t)
+	s := NewServer(cx, "test", "subscribe")
+	initServer(t, s)
+
+	text, isErr := callTool(t, s, "sync_events", nil)
+	if !isErr {
+		t.Errorf("sync_events should be blocked in subscribe mode, got: %s", text)
+	}
+	if !strings.Contains(text, "subscribe mode") {
+		t.Errorf("error should mention subscribe mode, got: %s", text)
+	}
+}
+
+func TestSubscribeMode_AllowsMutatingTools(t *testing.T) {
+	cx := newTestCortex(t)
+	s := NewServer(cx, "test", "subscribe")
+	initServer(t, s)
+
+	// create_trace should work in subscribe mode.
+	text, isErr := callTool(t, s, "create_trace", map[string]any{
+		"title": "sub-test", "type": "note", "body": "hello",
+	})
+	if isErr {
+		t.Errorf("create_trace should work in subscribe mode, got error: %s", text)
+	}
+}
+
+func TestSyncMode_AllowsEverything(t *testing.T) {
+	cx := newTestCortex(t)
+	s := NewServer(cx, "test", "")
+	initServer(t, s)
+
+	// create_trace should work.
+	text, isErr := callTool(t, s, "create_trace", map[string]any{
+		"title": "sync-test", "type": "note", "body": "hello",
+	})
+	if isErr {
+		t.Errorf("create_trace should work in sync mode, got error: %s", text)
+	}
+
+	// sync_events should work.
+	text, isErr = callTool(t, s, "sync_events", nil)
+	if isErr && strings.Contains(text, "subscribe mode") {
+		t.Errorf("sync_events should work in sync mode, got: %s", text)
 	}
 }

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -1,6 +1,8 @@
 package trace
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"strings"
@@ -46,9 +48,12 @@ type Frontmatter struct {
 	Author      string   `yaml:"author,omitempty"`
 	Tags        []string `yaml:"tags,omitempty"`
 	DerivedFrom []string `yaml:"derived_from,omitempty"`
-	Origin      string   `yaml:"origin,omitempty"`
-	Created     string   `yaml:"created"`
-	Updated     string   `yaml:"updated"`
+	Origin       string   `yaml:"origin,omitempty"`
+	Created      string   `yaml:"created"`
+	Updated      string   `yaml:"updated"`
+	ContentHash  string   `yaml:"content_hash,omitempty"`
+	SourceHash   string   `yaml:"source_hash,omitempty"`
+	SourceLocked bool     `yaml:"source_locked,omitempty"`
 }
 
 type Trace struct {
@@ -160,6 +165,14 @@ func allDigits(s string) bool {
 		}
 	}
 	return true
+}
+
+// ContentHash returns the SHA-256 hash of a trace body, prefixed with
+// "sha256:" for algorithm-explicitness. Used for integrity verification
+// and federation sync optimization.
+func ContentHash(body string) string {
+	h := sha256.Sum256([]byte(body))
+	return "sha256:" + hex.EncodeToString(h[:])
 }
 
 func slug(s string) string {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -585,6 +585,10 @@ func (m model) updateList(msg tea.KeyMsg) (model, tea.Cmd) {
 			return m, nil
 		}
 		row := m.rows[m.cursor]
+		if row.SourceLocked && row.Origin != m.cx.Name {
+			m.status = "Trace is source-locked by " + row.Origin
+			return m, nil
+		}
 		path := m.cx.TraceFile(row.ID, row.ArchivedAt != "")
 		return m, editorCmd(path, row.ID, false)
 


### PR DESCRIPTION
## Summary

- **Content hashing:** SHA-256 of trace bodies computed on every write, stored in frontmatter + DB + federation event payloads. `noema verify` checks integrity; `--backfill` fixes missing/stale hashes.
- **Source-locking:** Publisher-origin traces marked `source_locked: true` are immutable on consumer cortexes. `Update`, `Trash`, `Remove` refused; `Archive`/`Unarchive` allowed. CLI `--force` bypasses; MCP surfaces `ErrSourceLocked`; TUI blocks edit key.
- **Federation modes:** `noema federation set-mode <sync|publish|subscribe>` controls sync directionality. Publish mode blocks remote writes over HTTP. Subscribe mode blocks `sync_events` serving. Per-peer `pause-peer`/`resume-peer`.
- **Drift detection:** `noema drift` checks foreign-origin traces against their `source_hash`.
- **TUI:** Dark/light theme toggle, tag chips, `noema config` command.

## Bug fixes

- MCP `update_trace` wrote file before checking source-lock (body mutated despite error)
- `verify --backfill` only fixed missing hashes, not stale mismatches
- `SyncWithOptions` computed content hash for DB but didn't write it back to the file

All three bugs found by automated MCP/CLI test playbooks run by a dedicated QA agent.

## Test plan

- [x] `go build ./... && go vet ./... && go test ./...` — all pass
- [x] MCP test playbook: 19 pass, 0 fail, 1 skip (S01–S20)
- [x] CLI test playbook: 13 pass, 0 fail, 0 skip (C01–C13)
- [x] DB migrations 006 + 007 apply cleanly on existing cortexes
- [x] Old cortexes without hash fields open and work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)