### PR TITLE
feat: append_trace tool, README badges, SECURITY.md, tap rename

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -126,7 +126,7 @@ release:
 
 # Homebrew publishing — dual strategy: formula + cask.
 #
-# Both blocks target the same tap repo (Fail-Safe/homebrew-noema) and the
+# Both blocks target the same tap repo (Fail-Safe/homebrew-tap) and the
 # same bearer token (HOMEBREW_TAP_TOKEN in the Noema repo's Actions
 # secrets). The two blocks write to different subdirectories of the tap:
 # Formula/noema.rb for `brews:`, Casks/noema.rb for `homebrew_casks:`.
@@ -169,7 +169,7 @@ brews:
   - name: noema
     repository:
       owner: Fail-Safe
-      name: homebrew-noema
+      name: homebrew-tap
       branch: main
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     directory: Formula
@@ -196,7 +196,7 @@ homebrew_casks:
       - noema
     repository:
       owner: Fail-Safe
-      name: homebrew-noema
+      name: homebrew-tap
       branch: main
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     directory: Casks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,13 +146,13 @@ Federation is opt-in via a `federation:` block in `cortex.md` (peers + interval)
 | `publish` | No | Yes | Blocked (read-only for remote peers) |
 | `subscribe` | Yes | Blocked | Yes |
 
-In publish mode, mutating MCP tools (`create_trace`, `update_trace`, `delete_trace`, `recover_trace`, `archive_trace`, `unarchive_trace`, `resolve_divergence`) return a clear error on the HTTP transport. The local stdio transport retains full write access so operators can manage content locally. In subscribe mode, `sync_events` returns an error so remote peers cannot pull events from this cortex.
+In publish mode, mutating MCP tools (`create_trace`, `update_trace`, `append_trace`, `delete_trace`, `recover_trace`, `archive_trace`, `unarchive_trace`, `resolve_divergence`) return a clear error on the HTTP transport. The local stdio transport retains full write access so operators can manage content locally. In subscribe mode, `sync_events` returns an error so remote peers cannot pull events from this cortex.
 
 Each peer can also declare `mode: paused` to temporarily skip syncing without losing cursor/identity state. CLI commands: `noema federation set-mode <sync|publish|subscribe>`, `noema federation pause-peer <name>`, `noema federation resume-peer <name>`.
 
 The full design rationale, edge cases, and phase breakdown live in `docs/design/federation-plan.md`.
 
-**Content hashing and source-locking.** Every trace mutation (`Add`, `Update`) computes a SHA-256 hash of the body (`sha256:<hex>`) and stores it in the `content_hash` frontmatter field and DB column. The hash travels through federation events so peers receive it. Three frontmatter fields support integrity:
+**Content hashing and source-locking.** Every trace mutation (`Add`, `Update`, `Append`) computes a SHA-256 hash of the body (`sha256:<hex>`) and stores it in the `content_hash` frontmatter field and DB column. The hash travels through federation events so peers receive it. Three frontmatter fields support integrity:
 
 - `content_hash` — current body hash, recomputed on every write
 - `source_hash` — the origin's `content_hash` at publish time, carried through federation
@@ -166,7 +166,7 @@ CLI: `noema verify` checks all trace file hashes against their frontmatter `cont
 
 ### MCP Tools
 
-The MCP server (`internal/mcp/server.go`) exposes the full Cortex surface: `get_instructions`, `list_traces`, `get_trace`, `create_trace`, `update_trace`, `delete_trace`, `recover_trace`, `archive_trace`, `unarchive_trace`, `search_traces`, `trace_history`, `trace_lineage`, `resolve_divergence`, `cortex_identity`, `sync_events`, `federation_status`, and `announce_peer`. The `get_instructions` tool returns a live reference guide for the active Cortex; agents should call it first in any new session. `cortex_identity` returns the stable ULID + display name + manifest version and is called by federation peers on every sync to verify the remote endpoint still belongs to the cortex they paired with.
+The MCP server (`internal/mcp/server.go`) exposes the full Cortex surface: `get_instructions`, `list_traces`, `get_trace`, `create_trace`, `update_trace`, `append_trace`, `delete_trace`, `recover_trace`, `archive_trace`, `unarchive_trace`, `search_traces`, `trace_history`, `trace_lineage`, `resolve_divergence`, `cortex_identity`, `sync_events`, `federation_status`, and `announce_peer`. The `get_instructions` tool returns a live reference guide for the active Cortex; agents should call it first in any new session. `cortex_identity` returns the stable ULID + display name + manifest version and is called by federation peers on every sync to verify the remote endpoint still belongs to the cortex they paired with.
 
 ### DB Schema Migrations
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@
   </picture>
 </p>
 
+<p align="center">
+  <a href="https://github.com/Fail-Safe/Noema/actions/workflows/ci.yml"><img src="https://github.com/Fail-Safe/Noema/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
+  <a href="https://github.com/Fail-Safe/Noema/releases/latest"><img src="https://img.shields.io/github/v/release/Fail-Safe/Noema" alt="Latest Release"></a>
+  <a href="https://github.com/Fail-Safe/Noema/blob/main/go.mod"><img src="https://img.shields.io/github/go-mod/go-version/Fail-Safe/Noema" alt="Go Version"></a>
+  <a href="https://github.com/Fail-Safe/Noema/blob/main/LICENSE"><img src="https://img.shields.io/github/license/Fail-Safe/Noema" alt="License"></a>
+</p>
+
 **The intentional memory layer for your AI agents.**
 
 Noema gives AI agents — and the humans working alongside them — a persistent, structured place to record what they know, decide, observe, and intend. Every memory is a plain markdown file. The index is a local SQLite database. Nothing lives in the cloud; nothing requires an API key.
@@ -248,6 +255,7 @@ Noema can run as an [MCP](https://modelcontextprotocol.io) server, giving any MC
 | `get_trace` | Fetch a trace's full body, origin, and lineage |
 | `create_trace` | Create a new trace (supports `derived_from`, `origin`) |
 | `update_trace` | Update any subset of fields on an existing trace |
+| `append_trace` | Append content to an existing trace without reading it first (fire-and-forget logging) |
 | `search_traces` | FTS5 full-text search |
 | `archive_trace` / `unarchive_trace` | Archive a trace or restore it |
 | `delete_trace` / `recover_trace` | Soft-delete (move to trash) or restore from trash |

--- a/README.md
+++ b/README.md
@@ -45,19 +45,19 @@ A Trace has a **type** that describes its intent:
 
 ### With Homebrew (macOS + Linux)
 
-The fastest path. One command taps `Fail-Safe/homebrew-noema` and
+The fastest path. One command taps `Fail-Safe/homebrew-tap` and
 installs the cross-platform formula covering `darwin/{amd64,arm64}`
 and `linux/{amd64,arm64}`:
 
 ```bash
-brew install Fail-Safe/noema/noema
+brew install Fail-Safe/tap/noema
 ```
 
 On macOS a cask is also published for users who prefer the cask
 ecosystem:
 
 ```bash
-brew install --cask Fail-Safe/noema/noema
+brew install --cask Fail-Safe/tap/noema
 ```
 
 > The formula path is the default on macOS — when a tap contains both a
@@ -68,7 +68,7 @@ brew install --cask Fail-Safe/noema/noema
 Prefer the two-step form? It works the same:
 
 ```bash
-brew tap Fail-Safe/noema
+brew tap Fail-Safe/tap
 brew install noema          # formula (macOS + Linux)
 brew install --cask noema   # cask (macOS only)
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Please do not open a public GitHub Issue for security vulnerabilities.**
+
+Instead, use GitHub's private vulnerability reporting:
+
+1. Go to [Report a vulnerability](https://github.com/Fail-Safe/Noema/security/advisories/new)
+2. Fill in a description of the issue, steps to reproduce, and any affected versions
+3. Submit — this creates a private advisory visible only to you and the maintainers
+
+You will receive a response acknowledging the report within 72 hours. Fixes for confirmed vulnerabilities are prioritized and shipped as patch releases.
+
+## Scope
+
+Noema is pre-1.0 software. The following areas are in scope for security reports:
+
+- Path traversal or file-system escapes (e.g. via crafted trace IDs or federation events)
+- Authentication bypass on the keyed HTTP transport
+- Federation event replay attacks (hash forgery, source-lock abuse, payload injection)
+- SQL injection or FTS5 query injection
+- TLS configuration weaknesses in the MCP HTTP server
+- Denial of service via unbounded input (query length, payload size, connection exhaustion)
+
+Out of scope:
+
+- Vulnerabilities that require local filesystem access to the cortex directory (Noema trusts the local operator)
+- Issues in dependencies — please report those upstream, but feel free to flag them here if Noema's usage makes the issue exploitable
+
+## Supported Versions
+
+Only the latest release is actively supported with security patches. Upgrade to the latest version before reporting.

--- a/internal/cortex/cortex.go
+++ b/internal/cortex/cortex.go
@@ -1017,6 +1017,62 @@ func (c *Cortex) Update(id string) error {
 	return tx.Commit()
 }
 
+// Append adds content to the end of an existing trace's body. It reads the
+// current file, appends the new content (with a newline separator if the
+// existing body doesn't already end with one), recomputes the content hash,
+// and emits a standard "update" event. Designed for fire-and-forget logging
+// where agents append to a running trace without consuming its full body.
+func (c *Cortex) Append(id, content string) error {
+	if err := c.CheckSourceLock(id); err != nil {
+		return err
+	}
+	r, err := c.Get(id)
+	if err != nil {
+		return err
+	}
+	path := c.filePath(r)
+	t, err := trace.ParseFile(path)
+	if err != nil {
+		return err
+	}
+
+	// Append with a newline separator if the body doesn't already end with one.
+	if t.Body != "" && !strings.HasSuffix(t.Body, "\n") {
+		t.Body += "\n"
+	}
+	t.Body += content
+
+	t.Updated = time.Now().UTC().Format(time.RFC3339)
+	t.ContentHash = trace.ContentHash(t.Body)
+	if err := t.Write(path); err != nil {
+		return fmt.Errorf("rewriting trace file for append: %w", err)
+	}
+
+	tx, err := c.DB.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	_, err = tx.Exec(
+		`UPDATE traces SET updated_at=?, content_hash=? WHERE id=?`,
+		t.Updated, t.ContentHash, id,
+	)
+	if err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`DELETE FROM traces_fts WHERE id = ?`, id); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`INSERT INTO traces_fts (id, title, body) VALUES (?, ?, ?)`, id, t.Title, t.Body); err != nil {
+		return err
+	}
+	if err := c.emitEvent(tx, event.ActionUpdate, id, t.Updated, marshalTraceData(t)); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
 func (c *Cortex) scanRows(rows *sql.Rows) ([]Row, error) { //nolint:govet
 	var result []Row
 	for rows.Next() {

--- a/internal/cortex/cortex_test.go
+++ b/internal/cortex/cortex_test.go
@@ -812,6 +812,148 @@ func TestUpdate(t *testing.T) {
 	}
 }
 
+// ---- Append ----
+
+func TestAppend(t *testing.T) {
+	cx := setup(t)
+
+	tr := trace.New("Append target", "note", "agent-1", []string{"log"}, "Line one.")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	if err := cx.Append(tr.ID, "Line two."); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	// Verify the file on disk has the appended content.
+	path := cx.TraceFile(tr.ID, false)
+	parsed, err := trace.ParseFile(path)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	want := "Line one.\nLine two."
+	if parsed.Body != want {
+		t.Errorf("Body = %q, want %q", parsed.Body, want)
+	}
+
+	// FTS5 should find the appended content.
+	results, err := cx.Search("line two", cortex.ListOptions{})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) != 1 || results[0].ID != tr.ID {
+		t.Errorf("FTS not updated: search returned %v", results)
+	}
+
+	// Content hash should be recomputed.
+	row, err := cx.Get(tr.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	wantHash := trace.ContentHash(want)
+	if row.ContentHash != wantHash {
+		t.Errorf("ContentHash = %q, want %q", row.ContentHash, wantHash)
+	}
+}
+
+func TestAppend_ToEmptyBody(t *testing.T) {
+	cx := setup(t)
+
+	tr := trace.New("Empty body append", "note", "", nil, "")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	if err := cx.Append(tr.ID, "First entry."); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	path := cx.TraceFile(tr.ID, false)
+	parsed, err := trace.ParseFile(path)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	if parsed.Body != "First entry." {
+		t.Errorf("Body = %q, want %q", parsed.Body, "First entry.")
+	}
+}
+
+func TestAppend_MultipleAppends(t *testing.T) {
+	cx := setup(t)
+
+	tr := trace.New("Multi append", "note", "", nil, "A")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	for _, line := range []string{"B", "C", "D"} {
+		if err := cx.Append(tr.ID, line); err != nil {
+			t.Fatalf("Append %q: %v", line, err)
+		}
+	}
+
+	path := cx.TraceFile(tr.ID, false)
+	parsed, err := trace.ParseFile(path)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	want := "A\nB\nC\nD"
+	if parsed.Body != want {
+		t.Errorf("Body = %q, want %q", parsed.Body, want)
+	}
+}
+
+func TestAppend_EmitsUpdateEvent(t *testing.T) {
+	cx := setup(t)
+
+	tr := trace.New("Event test", "note", "", nil, "Initial.")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	if err := cx.Append(tr.ID, "Appended."); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	events, err := cx.Events(tr.ID)
+	if err != nil {
+		t.Fatalf("History: %v", err)
+	}
+	// Should have create + update.
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	if events[1].Action != "update" {
+		t.Errorf("second event action = %q, want %q", events[1].Action, "update")
+	}
+}
+
+func TestAppend_RespectsSourceLock(t *testing.T) {
+	cx := setup(t)
+
+	tr := trace.New("Locked trace", "note", "", nil, "Body.")
+	tr.Origin = "remote-peer"
+	tr.SourceLocked = true
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	err := cx.Append(tr.ID, "Should fail.")
+	if err == nil {
+		t.Fatal("expected source lock error, got nil")
+	}
+}
+
+func TestAppend_NotFound(t *testing.T) {
+	cx := setup(t)
+
+	err := cx.Append("99999999-nonexistent", "content")
+	if err == nil {
+		t.Fatal("expected error for missing trace, got nil")
+	}
+}
+
 // ---- Origin ----
 
 func TestOrigin_DefaultsToCortexName(t *testing.T) {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -318,6 +318,25 @@ func NewServer(cx *cortex.Cortex, noemaVersion string, federationMode string) *s
 		return mcp.NewToolResultText(fmt.Sprintf("Trace %s updated.", id)), nil
 	}))
 
+	s.AddTool(mcp.NewTool("append_trace",
+		mcp.WithDescription("Append content to an existing trace's body without reading the full trace first. Ideal for fire-and-forget logging, running journals, or any case where an agent needs to add to a trace without consuming its current content."),
+		mcp.WithString("id", mcp.Description("Trace ID"), mcp.Required()),
+		mcp.WithString("content", mcp.Description("Content to append to the trace body"), mcp.Required()),
+	), readOnlyGuard(func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		id, err := req.RequireString("id")
+		if err != nil {
+			return nil, err
+		}
+		content, err := req.RequireString("content")
+		if err != nil {
+			return nil, err
+		}
+		if err := cx.Append(id, content); err != nil {
+			return nil, err
+		}
+		return mcp.NewToolResultText(fmt.Sprintf("Content appended to trace %s.", id)), nil
+	}))
+
 	// ---- Event Log & Lineage tools ----
 
 	s.AddTool(mcp.NewTool("trace_history",
@@ -661,6 +680,9 @@ Choose the type that best reflects the intent of the memory:
                                    or in a tag (e.g. tags=event-2026-04-02) instead
   update_trace id [title] [type] [author] [tags] [derived_from] [body]
                                  → update any subset of fields
+  append_trace id content        → append content to an existing trace's body
+                                   without reading the full trace first; ideal
+                                   for running logs and fire-and-forget writes
   search_traces query [all]      → FTS5 full-text search
   archive_trace id               → move to archive (reversible)
   unarchive_trace id             → restore from archive

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -110,6 +110,13 @@ func TestRenderInstructions_ManifestVersionReflectsInput(t *testing.T) {
 // the Tools section could quietly drop the warning and the doubled-
 // prefix bug would re-emerge from agent habit even though the code-
 // level defense would still catch it.
+func TestRenderInstructions_IncludesAppendTrace(t *testing.T) {
+	out := renderInstructions(cortex.Manifest{Name: "test", Version: 2}, "dev")
+	if !strings.Contains(out, "append_trace") {
+		t.Errorf("instructions should mention append_trace\nfull output:\n%s", out)
+	}
+}
+
 func TestRenderInstructions_WarnsAgainstDateInTitle(t *testing.T) {
 	out := renderInstructions(cortex.Manifest{Name: "test", Version: 2}, "dev")
 
@@ -325,6 +332,7 @@ func TestPublishMode_BlocksMutatingTools(t *testing.T) {
 	}{
 		{"create_trace", map[string]any{"title": "x", "type": "note", "body": "y"}},
 		{"update_trace", map[string]any{"id": "nonexistent", "title": "x"}},
+		{"append_trace", map[string]any{"id": "nonexistent", "content": "x"}},
 		{"delete_trace", map[string]any{"id": "nonexistent"}},
 		{"recover_trace", map[string]any{"id": "nonexistent"}},
 		{"archive_trace", map[string]any{"id": "nonexistent"}},


### PR DESCRIPTION
## Summary

- **`append_trace` MCP tool** — fire-and-forget append to an existing trace's body without reading the full trace first. Reuses the standard `update` event action so federation stays unchanged. Includes Cortex.Append() method, MCP tool registration, get_instructions update, and full test coverage.
- **README badges** — CI status, latest release, Go version, license (all dynamic via shields.io / GitHub Actions badges)
- **SECURITY.md** — points vulnerability reporters to GitHub's private vulnerability reporting instead of public issues
- **Homebrew tap rename** — `homebrew-noema` → `homebrew-tap` so the install command reads `brew install Fail-Safe/tap/noema` instead of the repetitive `brew install Fail-Safe/noema/noema`

## Test plan

- [x] `go test ./...` — all passing
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [ ] Verify badges render on the PR's README diff
- [ ] Verify `append_trace` appears in `get_instructions` output via MCP
- [ ] Next release: confirm GoReleaser pushes to `Fail-Safe/homebrew-tap`

🤖 Generated with [Claude Code](https://claude.com/claude-code)