### PR TITLE
Hermes memory provider plugin + FTS5 search fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@
 # Local MCP config (machine-specific paths)
 .mcp.json
 
+# Caches
+**/__pycache__
+.pytest_cache
+
 # Editor
 *.swp
 *.swo

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,6 +29,8 @@ project_name: noema
 before:
   hooks:
     - go mod tidy
+    # Bundle the Hermes memory provider plugin as a release asset.
+    - tar -czf noema-hermes-plugin.tar.gz -C plugins hermes
 
 builds:
   - id: noema
@@ -119,6 +121,8 @@ release:
     until v1.0. Cortex data on disk is forward-compatible via
     non-destructive migrations; on-disk `cortex.md` version bumps that
     require a manual step ship with an explicit `noema migrate` command.**
+  extra_files:
+    - glob: ./noema-hermes-plugin.tar.gz
   footer: |
     ---
     **Install:** see [README — Installation](https://github.com/Fail-Safe/Noema#installation).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,16 @@ CLI: `noema verify` checks all trace file hashes against their frontmatter `cont
 
 The MCP server (`internal/mcp/server.go`) exposes the full Cortex surface: `get_instructions`, `list_traces`, `get_trace`, `create_trace`, `update_trace`, `append_trace`, `delete_trace`, `recover_trace`, `archive_trace`, `unarchive_trace`, `search_traces`, `trace_history`, `trace_lineage`, `resolve_divergence`, `cortex_identity`, `sync_events`, `federation_status`, and `announce_peer`. The `get_instructions` tool returns a live reference guide for the active Cortex; agents should call it first in any new session. `cortex_identity` returns the stable ULID + display name + manifest version and is called by federation peers on every sync to verify the remote endpoint still belongs to the cortex they paired with.
 
+### Hermes Memory Provider Plugin
+
+A Python plugin at `plugins/hermes/` implements the Hermes `MemoryProvider` ABC, letting any [Hermes](https://hermes-agent.nousresearch.com/) agent use a Noema Cortex as its memory backend. The plugin communicates with Noema via MCP (JSON-RPC 2.0 over stdio or HTTP) — it does not import any Go code.
+
+**Files:** `__init__.py` (NoemaMemoryProvider + register()), `transport.py` (StdioTransport, HttpTransport), `plugin.yaml` (metadata), `README.md` (setup).
+
+**Agent-facing tools:** `noema_search`, `noema_remember`, `noema_recall`, `noema_list`, `noema_update`, `noema_lineage` — mapped to `search_traces`, `create_trace`, `get_trace`, `list_traces`, `update_trace`, `trace_lineage` respectively.
+
+**Internal tools used:** `get_instructions` (system prompt), `cortex_identity` (connectivity check), `append_trace` (session log), `archive_trace` (session end).
+
 ### DB Schema Migrations
 
 Schema changes must always be transparent and non-destructive. Rules:

--- a/README.md
+++ b/README.md
@@ -618,6 +618,30 @@ Each agent identifies itself via the `author` field when creating Traces. Filter
 
 ---
 
+## Hermes Integration
+
+Noema ships a [Hermes](https://hermes-agent.nousresearch.com/) memory provider plugin in `plugins/hermes/`. It implements the Hermes `MemoryProvider` ABC so any Hermes agent can use a Noema Cortex as its memory backend — structured traces with types, tags, lineage, and full-text search, all through the standard Hermes lifecycle hooks.
+
+**Quick setup:**
+
+```bash
+# Download the plugin from the latest release
+curl -LO https://github.com/Fail-Safe/Noema/releases/latest/download/noema-hermes-plugin.tar.gz
+mkdir -p <hermes-install>/plugins/memory/noema
+tar -xzf noema-hermes-plugin.tar.gz -C <hermes-install>/plugins/memory/noema/
+
+# Configure
+hermes memory setup    # select "noema", provide your cortex name
+```
+
+The plugin exposes six tools to the agent (`noema_search`, `noema_remember`, `noema_recall`, `noema_list`, `noema_update`, `noema_lineage`), manages a session log trace across turns, creates a summary trace at session end, and mirrors Hermes built-in memory writes as Noema traces.
+
+By default the plugin spawns `noema serve --transport stdio` as a subprocess — no network config needed. For remote cortexes or multi-agent setups, set `transport=http` to connect to an already-running HTTP endpoint.
+
+See [`plugins/hermes/README.md`](plugins/hermes/README.md) for full configuration and usage details.
+
+---
+
 ## License
 
 MIT — see [LICENSE](LICENSE).

--- a/internal/cli/cmd_serve.go
+++ b/internal/cli/cmd_serve.go
@@ -60,7 +60,7 @@ func serveCmd() *cobra.Command {
 			// first log line instead of finding out via peer drift hours
 			// later. The ULID is the federation key — print it explicitly,
 			// not just the human-readable name.
-			fmt.Printf("[serve] cortex %q (id=%s) at %s\n", cx.Name, cx.ID, cx.Dir)
+			fmt.Fprintf(os.Stderr, "[serve] cortex %q (id=%s) at %s\n", cx.Name, cx.ID, cx.Dir)
 
 			var syncer *federation.Syncer
 			switch transport {
@@ -87,7 +87,7 @@ func serveCmd() *cobra.Command {
 					return fmt.Errorf("loading MCP access key: %w", accessErr)
 				}
 				if accessKey.EnvOverride() {
-					fmt.Printf("[serve] %s overrides access.shared_key_file at %s\n",
+					fmt.Fprintf(os.Stderr, "[serve] %s overrides access.shared_key_file at %s\n",
 						cortex.AccessKeyEnvVar, accessKey.Path)
 				}
 
@@ -109,7 +109,7 @@ func serveCmd() *cobra.Command {
 				if m.Federation != nil && len(m.Federation.Peers) > 0 && fedMode != cortex.FederationModePublish {
 					syncer = startSyncer(cx, accessKey.Value, m.Federation)
 				}
-				fmt.Printf("[serve] federation mode: %s\n", fedMode)
+				fmt.Fprintf(os.Stderr, "[serve] federation mode: %s\n", fedMode)
 
 				// HTTP transport: apply federation mode guards.
 				s := mcpserver.NewServer(cx, version(), fedMode)
@@ -119,10 +119,10 @@ func serveCmd() *cobra.Command {
 				// running the same key without speaking the secret
 				// itself.
 				if accessKey.Keyed() {
-					fmt.Printf("[serve] access=keyed source=%s fingerprint=%s\n",
+					fmt.Fprintf(os.Stderr, "[serve] access=keyed source=%s fingerprint=%s\n",
 						accessKey.Source, accessKey.Fingerprint)
 				} else {
-					fmt.Printf("[serve] access=open\n")
+					fmt.Fprintf(os.Stderr, "[serve] access=open\n")
 				}
 
 				// IPv6 addresses need brackets in listen addresses.
@@ -164,7 +164,7 @@ func serveCmd() *cobra.Command {
 				if useTLS {
 					scheme = "https"
 				}
-				fmt.Printf("Starting Streamable HTTP server on %s://%s/mcp\n", scheme, addr)
+				fmt.Fprintf(os.Stderr, "Starting Streamable HTTP server on %s://%s/mcp\n", scheme, addr)
 				if useTLS {
 					err = httpSrv.ListenAndServeTLS(tlsCert, tlsKey)
 				} else {
@@ -227,7 +227,7 @@ func startSyncer(cx *cortex.Cortex, sharedKey string, fc *cortex.FederationConfi
 	syncer := federation.NewSyncer(cx, state, cfg)
 	syncer.Start()
 
-	fmt.Printf("Federation syncer started (%d peers, interval %s)\n", len(peers), cfg.EffectiveInterval())
+	fmt.Fprintf(os.Stderr, "Federation syncer started (%d peers, interval %s)\n", len(peers), cfg.EffectiveInterval())
 	return syncer
 }
 

--- a/internal/cortex/cortex.go
+++ b/internal/cortex/cortex.go
@@ -101,6 +101,33 @@ var ErrSourceLocked = errors.New("trace is source-locked")
 // denial of service via expensive wildcard or deeply nested expressions.
 const MaxSearchQueryLen = 1000
 
+// SanitizeFTS5Query quotes each whitespace-delimited token so that FTS5
+// treats hyphens, colons, and other operator characters as literals.
+// Tokens that are already quoted or use explicit FTS5 operators (AND, OR,
+// NOT, prefix*) are passed through unchanged to preserve power-user syntax.
+func SanitizeFTS5Query(q string) string {
+	tokens := strings.Fields(q)
+	if len(tokens) == 0 {
+		return q
+	}
+	out := make([]string, 0, len(tokens))
+	for _, t := range tokens {
+		switch {
+		case t == "AND" || t == "OR" || t == "NOT":
+			out = append(out, t)
+		case strings.HasPrefix(t, "\""):
+			out = append(out, t) // already quoted
+		case strings.HasSuffix(t, "*"):
+			out = append(out, t) // prefix search
+		case strings.ContainsAny(t, "-:"):
+			out = append(out, "\""+t+"\"")
+		default:
+			out = append(out, t)
+		}
+	}
+	return strings.Join(out, " ")
+}
+
 type Cortex struct {
 	ID              string // ULID, stable across renames; the federation identity key
 	Name            string // human-readable display label
@@ -694,11 +721,12 @@ func (c *Cortex) Search(query string, opts ListOptions) ([]Row, error) {
 	if len(query) > MaxSearchQueryLen {
 		return nil, fmt.Errorf("search query too long (%d chars, max %d)", len(query), MaxSearchQueryLen)
 	}
+	ftsQuery := SanitizeFTS5Query(query)
 	q := `
 		SELECT t.id, t.title, t.type, t.author, t.origin, t.archived_at, t.trashed_at, t.created_at, t.updated_at, t.content_hash, t.source_locked, t.source_hash
 		FROM traces t
 		WHERE t.id IN (SELECT id FROM traces_fts WHERE traces_fts MATCH ?)`
-	args := []any{query}
+	args := []any{ftsQuery}
 
 	switch {
 	case opts.Trashed:

--- a/internal/cortex/cortex_test.go
+++ b/internal/cortex/cortex_test.go
@@ -408,6 +408,70 @@ func TestSearch_MalformedQuery(t *testing.T) {
 	}
 }
 
+func TestSearch_HyphenatedTerms(t *testing.T) {
+	cx := setup(t)
+
+	tr := trace.New("format-test-create", "note", "hermes/testbot", []string{"hermes-contract-test"}, "Testing create response format.")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	// Search by hyphenated title — previously caused "no such column" FTS5 error.
+	rows, err := cx.Search("format-test-create", cortex.ListOptions{})
+	if err != nil {
+		t.Fatalf("Search with hyphenated query: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d results for hyphenated query, want 1", len(rows))
+	}
+	if rows[0].ID != tr.ID {
+		t.Errorf("result = %q, want %q", rows[0].ID, tr.ID)
+	}
+}
+
+func TestSearch_ColonInQuery(t *testing.T) {
+	cx := setup(t)
+
+	tr := trace.New("hermes-session: my-session", "context", "hermes/agent", nil, "Session log content.")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	// Colons are FTS5 column-prefix syntax — must be quoted.
+	rows, err := cx.Search("hermes-session:", cortex.ListOptions{})
+	if err != nil {
+		t.Fatalf("Search with colon query: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d results for colon query, want 1", len(rows))
+	}
+}
+
+func TestSanitizeFTS5Query(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"simple query", "simple query"},
+		{"format-test-create", "\"format-test-create\""},
+		{"hermes-session: log", "\"hermes-session:\" log"},
+		{"single-binary deployment", "\"single-binary\" deployment"},
+		{"word AND other", "word AND other"},
+		{"word OR other", "word OR other"},
+		{"NOT bad", "NOT bad"},
+		{"prefix*", "prefix*"},
+		{"\"already quoted\"", "\"already quoted\""},
+		{"", ""},
+		{"no-hyphens-here AND plain", "\"no-hyphens-here\" AND plain"},
+	}
+	for _, tt := range tests {
+		got := cortex.SanitizeFTS5Query(tt.input)
+		if got != tt.want {
+			t.Errorf("SanitizeFTS5Query(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
 // ---- Archive / Unarchive ----
 
 func TestArchiveUnarchive(t *testing.T) {

--- a/plugins/hermes/README.md
+++ b/plugins/hermes/README.md
@@ -1,0 +1,119 @@
+# Noema Memory Provider for Hermes
+
+A [Hermes](https://hermes-agent.nousresearch.com/) memory provider plugin that
+gives any Hermes agent structured, persistent memory backed by a
+[Noema](https://github.com/Fail-Safe/Noema) Cortex.
+
+Every memory is a plain markdown file (a "Trace") with typed frontmatter —
+searchable via FTS5, linked through derivation lineage, and federable across
+Cortexes.
+
+## Installation
+
+1. Install the Noema binary:
+
+   ```
+   brew install Fail-Safe/tap/noema
+   ```
+
+2. Create a Cortex if you don't already have one:
+
+   ```
+   noema init --name my-cortex
+   ```
+
+3. Download the plugin and copy it into your Hermes plugins folder:
+
+   ```
+   # Download from the latest GitHub Release
+   curl -LO https://github.com/Fail-Safe/Noema/releases/latest/download/noema-hermes-plugin.tar.gz
+   mkdir -p <hermes-install>/plugins/memory/noema
+   tar -xzf noema-hermes-plugin.tar.gz -C <hermes-install>/plugins/memory/noema/
+   ```
+
+   Or, if you cloned the Noema repo:
+
+   ```
+   cp -r plugins/hermes/ <hermes-install>/plugins/memory/noema/
+   ```
+
+4. Run the Hermes memory setup wizard:
+
+   ```
+   hermes memory setup
+   ```
+
+   Select **noema** when prompted and provide your cortex name.
+
+## Configuration
+
+| Key | Required | Secret | Env var | Default | Description |
+|-----|----------|--------|---------|---------|-------------|
+| `cortex_name` | Yes | No | `NOEMA_CORTEX` | — | Noema cortex to use |
+| `noema_binary` | No | No | `NOEMA_BINARY` | auto-detect | Path to noema binary |
+| `transport` | No | No | — | `stdio` | `stdio` or `http` |
+| `http_url` | No | No | `NOEMA_HTTP_URL` | — | MCP endpoint URL (HTTP transport only) |
+| `bearer_key` | No | Yes | `NOEMA_MCP_KEY` | — | Bearer key for keyed mode |
+
+Config is saved to `{hermes_home}/noema.json`.
+
+### Transport modes
+
+**stdio** (default) — the plugin spawns `noema serve --transport stdio` as a
+subprocess. No network configuration needed. The process lifecycle is fully
+managed: started on `initialize()`, terminated on `shutdown()`.
+
+**http** — the plugin connects to an already-running `noema serve --transport http`
+endpoint. Use this for remote Cortexes or multi-agent setups sharing one server.
+Set `http_url` to the server's base URL (e.g., `http://localhost:3000`).
+
+## Agent tools
+
+Six Noema tools are exposed to the Hermes agent:
+
+| Hermes tool | Noema tool | Purpose |
+|-------------|------------|---------|
+| `noema_search` | `search_traces` | Full-text search across traces |
+| `noema_remember` | `create_trace` | Create a new memory trace |
+| `noema_recall` | `get_trace` | Read a specific trace by ID |
+| `noema_list` | `list_traces` | Browse/filter by type, tag, author |
+| `noema_update` | `update_trace` | Modify an existing trace |
+| `noema_lineage` | `trace_lineage` | Follow derivation chains |
+
+## Session lifecycle
+
+The plugin automatically manages session state:
+
+- **On initialize** — creates a session log trace (`type: context`) and caches
+  the Cortex instructions for system prompt injection.
+- **Each turn** — appends the user/assistant exchange to the session log
+  (non-blocking, runs in a background thread).
+- **On context compression** — appends the compressed context to the session log
+  and returns a breadcrumb pointing back to the trace.
+- **On session end** — creates a summary trace (`type: observation`) derived
+  from the session log, then archives the session log.
+
+## Prefetch
+
+On each turn, `prefetch()` searches the Cortex with the user's message and
+returns the top 5 matching traces (excluding verbose session logs). FTS5 on
+local SQLite is sub-millisecond, so no cache warming is needed.
+
+## Memory mirroring
+
+When Hermes writes to its built-in memory via `on_memory_write()`, the plugin
+mirrors the operation as a Noema trace tagged `hermes-mirror`:
+
+- `add` creates a new trace (`type: note`)
+- `update` updates the matching mirrored trace
+- `delete` archives the mirrored trace (never hard-deletes)
+
+## Requirements
+
+- Python 3.9+
+- Noema binary (v0.6.0+) installed and accessible
+- A Noema Cortex initialized with `noema init`
+
+## License
+
+MIT — same as Noema.

--- a/plugins/hermes/__init__.py
+++ b/plugins/hermes/__init__.py
@@ -1,0 +1,729 @@
+"""Noema memory provider plugin for Hermes.
+
+Gives any Hermes agent structured, persistent memory backed by a Noema Cortex.
+Traces (markdown files with typed frontmatter) are searched, created, and
+appended through the standard Hermes lifecycle hooks.
+
+Usage:
+    1. Copy this directory into <hermes>/plugins/memory/noema/
+    2. Run `hermes memory setup` and select noema
+    3. Set NOEMA_CORTEX=<cortex-name> (or configure via the setup wizard)
+
+See README.md for full setup instructions.
+"""
+
+__version__ = "0.1.0"
+
+import json
+import logging
+import os
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+try:
+    from agent.memory_provider import MemoryProvider
+except ImportError:
+    # Allow importing outside of Hermes for testing.
+    class MemoryProvider:  # type: ignore[no-redef]
+        pass
+
+from .transport import StdioTransport, HttpTransport, find_binary, reset_binary_cache
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Tool schemas (OpenAI function-calling format)
+# ---------------------------------------------------------------------------
+
+SEARCH_SCHEMA = {
+    "name": "noema_search",
+    "description": (
+        "Search your memory for relevant traces. Returns matching memories "
+        "ranked by relevance (FTS5 full-text search)."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Search query — keywords or natural phrases.",
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+REMEMBER_SCHEMA = {
+    "name": "noema_remember",
+    "description": (
+        "Create a new memory trace. Choose a type that reflects the intent: "
+        "fact, decision, preference, context, skill, intent, observation, or note."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "title": {
+                "type": "string",
+                "description": (
+                    "Short descriptive title. Do NOT include a date — "
+                    "the ID generator prepends today's date automatically."
+                ),
+            },
+            "type": {
+                "type": "string",
+                "description": "Memory type.",
+                "enum": [
+                    "fact", "decision", "preference", "context",
+                    "skill", "intent", "observation", "note",
+                ],
+            },
+            "body": {
+                "type": "string",
+                "description": "Full content of the memory (markdown).",
+            },
+            "tags": {
+                "type": "string",
+                "description": "Comma-separated keyword tags.",
+            },
+            "derived_from": {
+                "type": "string",
+                "description": "Comma-separated trace IDs this memory was derived from.",
+            },
+        },
+        "required": ["title", "type", "body"],
+    },
+}
+
+RECALL_SCHEMA = {
+    "name": "noema_recall",
+    "description": "Read a specific memory trace by ID, including its full body.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "id": {
+                "type": "string",
+                "description": "Trace ID (e.g. 20260412-my-trace).",
+            },
+        },
+        "required": ["id"],
+    },
+}
+
+LIST_SCHEMA = {
+    "name": "noema_list",
+    "description": "List memory traces, optionally filtered by type, author, tag, or origin.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "type": {"type": "string", "description": "Filter by trace type."},
+            "author": {"type": "string", "description": "Filter by author."},
+            "tag": {"type": "string", "description": "Filter by tag."},
+            "origin": {"type": "string", "description": "Filter by origin cortex."},
+        },
+        "required": [],
+    },
+}
+
+UPDATE_SCHEMA = {
+    "name": "noema_update",
+    "description": "Update fields of an existing memory trace. Only provided fields are changed.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "id": {"type": "string", "description": "Trace ID to update."},
+            "title": {"type": "string", "description": "New title."},
+            "type": {
+                "type": "string",
+                "description": "New type.",
+                "enum": [
+                    "fact", "decision", "preference", "context",
+                    "skill", "intent", "observation", "note",
+                ],
+            },
+            "body": {"type": "string", "description": "New body content."},
+            "tags": {"type": "string", "description": "New tags (comma-separated, replaces existing)."},
+        },
+        "required": ["id"],
+    },
+}
+
+LINEAGE_SCHEMA = {
+    "name": "noema_lineage",
+    "description": "Show the derivation graph for a trace: what it was derived from and what derives from it.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "id": {"type": "string", "description": "Trace ID."},
+        },
+        "required": ["id"],
+    },
+}
+
+ALL_TOOL_SCHEMAS = [
+    SEARCH_SCHEMA, REMEMBER_SCHEMA, RECALL_SCHEMA,
+    LIST_SCHEMA, UPDATE_SCHEMA, LINEAGE_SCHEMA,
+]
+
+# Map Hermes tool names to Noema MCP tool names.
+_TOOL_MAP = {
+    "noema_search": "search_traces",
+    "noema_remember": "create_trace",
+    "noema_recall": "get_trace",
+    "noema_list": "list_traces",
+    "noema_update": "update_trace",
+    "noema_lineage": "trace_lineage",
+}
+
+# Max chars to keep from user/assistant content in the session log.
+_TURN_MAX_CHARS = 2000
+
+
+def _tool_error(msg: str) -> str:
+    return json.dumps({"error": msg})
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# Config loading
+# ---------------------------------------------------------------------------
+
+def _load_config(hermes_home: str) -> dict:
+    """Load noema.json from the Hermes home directory."""
+    config_path = Path(hermes_home) / "noema.json"
+    if config_path.exists():
+        try:
+            return json.loads(config_path.read_text(encoding="utf-8"))
+        except Exception:
+            logger.debug("Failed to parse %s", config_path, exc_info=True)
+    return {}
+
+
+def _load_config_from_hermes_home() -> dict:
+    """Locate and load noema.json without an explicit hermes_home path.
+
+    Resolution: HERMES_HOME env -> ~/.hermes (default).
+    Called by is_available() which runs before initialize() provides hermes_home.
+    """
+    try:
+        hermes_home = os.environ.get("HERMES_HOME", "")
+        if not hermes_home:
+            hermes_home = str(Path.home() / ".hermes")
+        return _load_config(hermes_home)
+    except Exception:
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# NoemaMemoryProvider
+# ---------------------------------------------------------------------------
+
+class NoemaMemoryProvider(MemoryProvider):
+    """Hermes memory provider backed by a Noema Cortex."""
+
+    def __init__(self):
+        self._config: dict = {}
+        self._transport = None
+        self._cortex_name: str = ""
+        self._cortex_id: str = ""
+        self._instructions_cache: str = ""
+        self._session_id: str = ""
+        self._session_trace_id: str = ""
+        self._agent_identity: str = "unknown"
+        self._session_title: str = ""
+        self._platform: str = ""
+        self._turn_count: int = 0
+        self._author: str = "hermes/unknown"
+
+        # Thread tracking for non-blocking hooks.
+        self._sync_thread: Optional[threading.Thread] = None
+        self._end_thread: Optional[threading.Thread] = None
+        self._mirror_thread: Optional[threading.Thread] = None
+
+    # ---- Core required methods ----
+
+    @property
+    def name(self) -> str:
+        return "noema"
+
+    def is_available(self) -> bool:
+        """Check if the plugin can activate — no network calls."""
+        # Load config eagerly if not yet loaded (is_available is called
+        # before initialize, so self._config may be empty).
+        config = self._config
+        if not config:
+            config = _load_config_from_hermes_home()
+        cortex = os.environ.get("NOEMA_CORTEX", "")
+        if not cortex:
+            cortex = config.get("cortex_name", "")
+        if not cortex:
+            return False
+        transport = config.get("transport", "stdio")
+        if transport == "stdio":
+            return find_binary(config.get("noema_binary")) is not None
+        elif transport == "http":
+            return bool(
+                config.get("http_url") or os.environ.get("NOEMA_HTTP_URL")
+            )
+        return False
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        hermes_home = kwargs.get("hermes_home", "")
+        self._config = _load_config(hermes_home) if hermes_home else {}
+        self._session_id = session_id
+        self._agent_identity = kwargs.get("agent_identity", "unknown")
+        self._session_title = kwargs.get("session_title", "")
+        self._platform = kwargs.get("platform", "cli")
+        self._author = f"hermes/{self._agent_identity}"
+
+        self._cortex_name = (
+            os.environ.get("NOEMA_CORTEX", "")
+            or self._config.get("cortex_name", "")
+        )
+
+        transport_mode = self._config.get("transport", "stdio")
+        if transport_mode == "http":
+            url = (
+                self._config.get("http_url")
+                or os.environ.get("NOEMA_HTTP_URL", "")
+            )
+            key = (
+                os.environ.get("NOEMA_MCP_KEY", "")
+                or self._config.get("bearer_key", "")
+            )
+            self._transport = HttpTransport(url, bearer_key=key or None)
+        else:
+            binary = find_binary(self._config.get("noema_binary"))
+            if not binary:
+                raise RuntimeError("noema binary not found")
+            self._transport = StdioTransport(binary, self._cortex_name)
+
+        self._transport.start()
+
+        # Learn cortex identity.
+        try:
+            identity_text = self._transport.call_tool("cortex_identity")
+            identity = json.loads(identity_text)
+            self._cortex_name = identity.get("name", self._cortex_name)
+            self._cortex_id = identity.get("id", "")
+        except Exception as e:
+            logger.warning("Failed to get cortex identity: %s", e)
+
+        # Cache instructions for system_prompt_block.
+        try:
+            self._instructions_cache = self._transport.call_tool("get_instructions")
+        except Exception as e:
+            logger.warning("Failed to get instructions: %s", e)
+
+        # Create the session log trace.
+        self._create_session_trace()
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return list(ALL_TOOL_SCHEMAS)
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
+        noema_tool = _TOOL_MAP.get(tool_name)
+        if not noema_tool:
+            return _tool_error(f"Unknown tool: {tool_name}")
+
+        if not self._transport:
+            return _tool_error("Noema is not connected.")
+
+        # Build arguments for the Noema MCP tool.
+        mcp_args: Dict[str, Any] = {}
+
+        if tool_name == "noema_search":
+            mcp_args["query"] = args.get("query", "")
+
+        elif tool_name == "noema_remember":
+            mcp_args["title"] = args.get("title", "")
+            mcp_args["type"] = args.get("type", "note")
+            mcp_args["body"] = args.get("body", "")
+            mcp_args["author"] = self._author
+            if args.get("tags"):
+                mcp_args["tags"] = args["tags"]
+            if args.get("derived_from"):
+                mcp_args["derived_from"] = args["derived_from"]
+
+        elif tool_name == "noema_recall":
+            mcp_args["id"] = args.get("id", "")
+
+        elif tool_name == "noema_list":
+            for key in ("type", "author", "tag", "origin"):
+                if args.get(key):
+                    mcp_args[key] = args[key]
+
+        elif tool_name == "noema_update":
+            mcp_args["id"] = args.get("id", "")
+            for key in ("title", "type", "body", "tags"):
+                if args.get(key):
+                    mcp_args[key] = args[key]
+
+        elif tool_name == "noema_lineage":
+            mcp_args["id"] = args.get("id", "")
+
+        try:
+            result = self._transport.call_tool(noema_tool, mcp_args)
+            return json.dumps({"result": result})
+        except Exception as e:
+            # Attempt one restart for stdio transport.
+            if isinstance(self._transport, StdioTransport) and not self._transport.is_alive:
+                try:
+                    logger.info("Noema subprocess died, attempting restart")
+                    self._transport.start()
+                    result = self._transport.call_tool(noema_tool, mcp_args)
+                    return json.dumps({"result": result})
+                except Exception as e2:
+                    return _tool_error(f"Noema restart failed: {e2}")
+            return _tool_error(str(e))
+
+    # ---- Optional lifecycle hooks ----
+
+    def system_prompt_block(self) -> str:
+        return self._instructions_cache
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        if not self._transport or not query.strip():
+            return ""
+        try:
+            result = self._transport.call_tool("search_traces", {"query": query[:500]})
+            if not result or result == "No traces found.":
+                return ""
+            # Filter out session log traces from prefetch results.
+            lines = result.split("\n")
+            filtered = []
+            skip_until_next = False
+            for line in lines:
+                if "hermes-session" in line and "hermes-session-summary" not in line:
+                    skip_until_next = True
+                    continue
+                if skip_until_next and line.startswith("["):
+                    skip_until_next = False
+                if not skip_until_next:
+                    filtered.append(line)
+            context = "\n".join(filtered).strip()
+            if not context:
+                return ""
+            return (
+                "## Relevant Memories (from Noema)\n\n"
+                f"{context}\n\n"
+                "---\n"
+                "Use noema_search for more specific queries, "
+                "or noema_recall to read a full trace."
+            )
+        except Exception as e:
+            logger.debug("Noema prefetch failed: %s", e)
+            return ""
+
+    def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
+        # No-op in v1 — FTS5 on local SQLite is sub-millisecond.
+        pass
+
+    def on_turn_start(self, turn_number: int, message: str, **kwargs) -> None:
+        self._turn_count = turn_number
+
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        if not self._transport or not self._session_trace_id:
+            return
+
+        user_trunc = user_content[:_TURN_MAX_CHARS]
+        asst_trunc = assistant_content[:_TURN_MAX_CHARS]
+        turn_num = self._turn_count
+        timestamp = _now_iso()
+
+        def _sync():
+            try:
+                block = (
+                    f"\n---\n### Turn {turn_num} — {timestamp}\n\n"
+                    f"**User:** {user_trunc}\n\n"
+                    f"**Assistant:** {asst_trunc}"
+                )
+                self._transport.call_tool("append_trace", {
+                    "id": self._session_trace_id,
+                    "content": block,
+                })
+            except Exception as e:
+                logger.debug("Noema sync_turn failed: %s", e)
+
+        if self._sync_thread and self._sync_thread.is_alive():
+            self._sync_thread.join(timeout=5.0)
+        self._sync_thread = threading.Thread(target=_sync, daemon=True, name="noema-sync")
+        self._sync_thread.start()
+
+    def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
+        if not self._transport or not self._session_trace_id:
+            return
+
+        session_trace_id = self._session_trace_id
+        turn_count = self._turn_count
+        title = self._session_title or self._session_id[:12]
+
+        # Extract last assistant message for the summary.
+        last_assistant = ""
+        for msg in reversed(messages or []):
+            if msg.get("role") == "assistant":
+                content = msg.get("content", "")
+                if isinstance(content, str) and content.strip():
+                    last_assistant = content[:3000]
+                    break
+
+        def _end():
+            try:
+                # Wait for any pending sync_turn to finish.
+                if self._sync_thread and self._sync_thread.is_alive():
+                    self._sync_thread.join(timeout=5.0)
+
+                body = f"Session with {turn_count} turns.\n\n{last_assistant}" if last_assistant else f"Session with {turn_count} turns."
+                self._transport.call_tool("create_trace", {
+                    "title": f"session-summary: {title}",
+                    "type": "observation",
+                    "author": self._author,
+                    "tags": f"hermes-session-summary, session-{self._session_id[:12]}",
+                    "derived_from": session_trace_id,
+                    "body": body,
+                })
+                self._transport.call_tool("archive_trace", {
+                    "id": session_trace_id,
+                })
+            except Exception as e:
+                logger.debug("Noema on_session_end failed: %s", e)
+
+        if self._end_thread and self._end_thread.is_alive():
+            self._end_thread.join(timeout=5.0)
+        self._end_thread = threading.Thread(target=_end, daemon=True, name="noema-end")
+        self._end_thread.start()
+
+    def on_pre_compress(self, messages: List[Dict[str, Any]]) -> str:
+        if not self._transport or not self._session_trace_id:
+            return ""
+
+        timestamp = _now_iso()
+        session_trace_id = self._session_trace_id
+        turn_count = len([m for m in (messages or []) if m.get("role") == "user"])
+
+        # Build a compressed block from the messages being dropped.
+        parts = []
+        for msg in messages or []:
+            role = msg.get("role", "")
+            content = str(msg.get("content", ""))[:500]
+            if role in ("user", "assistant") and content.strip():
+                parts.append(f"**{role.title()}:** {content}")
+        block = "\n\n".join(parts)
+
+        def _compress():
+            try:
+                self._transport.call_tool("append_trace", {
+                    "id": session_trace_id,
+                    "content": (
+                        f"\n---\n## Context compression at {timestamp}\n\n"
+                        f"{turn_count} turns compressed.\n\n{block}"
+                    ),
+                })
+            except Exception as e:
+                logger.debug("Noema on_pre_compress append failed: %s", e)
+
+        thread = threading.Thread(target=_compress, daemon=True, name="noema-compress")
+        thread.start()
+
+        return (
+            f"Context compressed. Prior conversation preserved in Noema trace "
+            f"{session_trace_id}. Use noema_recall to retrieve if needed."
+        )
+
+    def on_memory_write(self, action: str, target: str, content: str) -> None:
+        if not self._transport:
+            return
+
+        def _mirror():
+            try:
+                if action == "add":
+                    # Extract a title from the first line or truncate.
+                    lines = content.strip().split("\n")
+                    title = lines[0][:80] if lines else "mirrored memory"
+                    self._transport.call_tool("create_trace", {
+                        "title": title,
+                        "type": "note",
+                        "author": self._author,
+                        "tags": "hermes-mirror",
+                        "body": content,
+                    })
+                elif action == "update":
+                    # Try to find and update a matching mirrored trace.
+                    results = self._transport.call_tool("search_traces", {
+                        "query": target[:200],
+                    })
+                    # Best-effort: if we can't find it, create a new one.
+                    if results and results != "No traces found.":
+                        # Extract the first trace ID from the results.
+                        trace_id = self._extract_first_trace_id(results)
+                        if trace_id:
+                            self._transport.call_tool("update_trace", {
+                                "id": trace_id,
+                                "body": content,
+                            })
+                            return
+                    # Fallback: create a new trace.
+                    self._transport.call_tool("create_trace", {
+                        "title": target[:80] or "mirrored memory",
+                        "type": "note",
+                        "author": self._author,
+                        "tags": "hermes-mirror",
+                        "body": content,
+                    })
+                elif action == "delete":
+                    results = self._transport.call_tool("search_traces", {
+                        "query": target[:200],
+                    })
+                    if results and results != "No traces found.":
+                        trace_id = self._extract_first_trace_id(results)
+                        if trace_id:
+                            self._transport.call_tool("archive_trace", {"id": trace_id})
+            except Exception as e:
+                logger.debug("Noema on_memory_write failed: %s", e)
+
+        if self._mirror_thread and self._mirror_thread.is_alive():
+            self._mirror_thread.join(timeout=3.0)
+        self._mirror_thread = threading.Thread(target=_mirror, daemon=True, name="noema-mirror")
+        self._mirror_thread.start()
+
+    def shutdown(self) -> None:
+        # Join all daemon threads.
+        for thread in (self._sync_thread, self._end_thread, self._mirror_thread):
+            if thread and thread.is_alive():
+                thread.join(timeout=5.0)
+        # Close the transport.
+        if self._transport:
+            self._transport.close()
+            self._transport = None
+
+    # ---- Config ----
+
+    def get_config_schema(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "key": "cortex_name",
+                "description": "Name of the Noema cortex to use",
+                "required": True,
+                "env_var": "NOEMA_CORTEX",
+            },
+            {
+                "key": "noema_binary",
+                "description": "Path to the noema binary (auto-detected from PATH if omitted)",
+                "required": False,
+                "env_var": "NOEMA_BINARY",
+            },
+            {
+                "key": "transport",
+                "description": "How to connect: 'stdio' (spawn subprocess) or 'http' (connect to running server)",
+                "required": False,
+                "default": "stdio",
+                "choices": ["stdio", "http"],
+            },
+            {
+                "key": "http_url",
+                "description": "Noema HTTP endpoint (e.g. https://10.0.0.1:3000). Required when transport=http",
+                "required": False,
+                "env_var": "NOEMA_HTTP_URL",
+            },
+            {
+                "key": "bearer_key",
+                "description": "Bearer key for keyed-mode auth",
+                "required": False,
+                "secret": True,
+                "env_var": "NOEMA_MCP_KEY",
+            },
+        ]
+
+    def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
+        sanitized = {k: v for k, v in (values or {}).items() if v is not None}
+        config_path = Path(hermes_home) / "noema.json"
+        config_path.write_text(
+            json.dumps(sanitized, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+    # ---- Internal helpers ----
+
+    def _create_session_trace(self) -> None:
+        """Create the session log trace on initialize.
+
+        If the trace already exists (same session re-initialized on the same
+        day), look it up and reuse it instead of failing.
+        """
+        title_label = self._session_title or self._session_id[:12]
+        session_tag = f"session-{self._session_id[:12]}"
+        body = (
+            f"Session ID: {self._session_id}\n"
+            f"Agent: {self._agent_identity}\n"
+            f"Platform: {self._platform}\n"
+            f"Started: {_now_iso()}"
+        )
+        try:
+            result = self._transport.call_tool("create_trace", {
+                "title": f"hermes-session: {title_label}",
+                "type": "context",
+                "author": self._author,
+                "tags": f"hermes-session, {session_tag}",
+                "body": body,
+            })
+            # Extract trace ID from "Trace created: <id>" response.
+            if result and result.startswith("Trace created: "):
+                self._session_trace_id = result.split("Trace created: ", 1)[1].strip()
+            else:
+                logger.warning("Unexpected create_trace response: %s", result)
+        except RuntimeError as e:
+            if "UNIQUE constraint" in str(e):
+                # Session re-initialized — find and reuse the existing trace.
+                logger.info("Session trace already exists, reusing")
+                self._recover_session_trace(session_tag)
+            else:
+                logger.warning("Failed to create session trace: %s", e)
+        except Exception as e:
+            logger.warning("Failed to create session trace: %s", e)
+
+    def _recover_session_trace(self, session_tag: str) -> None:
+        """Find an existing session trace by tag and reuse it."""
+        try:
+            result = self._transport.call_tool(
+                "search_traces", {"query": session_tag}
+            )
+            trace_id = self._extract_first_trace_id(result)
+            if trace_id:
+                self._session_trace_id = trace_id
+                logger.info("Recovered session trace: %s", trace_id)
+            else:
+                logger.warning("Could not find existing session trace for %s", session_tag)
+        except Exception as e:
+            logger.warning("Failed to recover session trace: %s", e)
+
+    @staticmethod
+    def _extract_first_trace_id(list_output: str) -> Optional[str]:
+        """Extract the first trace ID from list_traces/search_traces output.
+
+        Output format: [type] trace-id (YYYY-MM-DD) — author [tags]
+        """
+        for line in list_output.split("\n"):
+            line = line.strip()
+            if line.startswith("["):
+                # [type] trace-id (date) — ...
+                parts = line.split("]", 1)
+                if len(parts) > 1:
+                    rest = parts[1].strip()
+                    trace_id = rest.split(" ", 1)[0].strip()
+                    if trace_id:
+                        return trace_id
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Plugin registration
+# ---------------------------------------------------------------------------
+
+def register(ctx) -> None:
+    """Called by Hermes plugin discovery."""
+    ctx.register_memory_provider(NoemaMemoryProvider())

--- a/plugins/hermes/plugin.yaml
+++ b/plugins/hermes/plugin.yaml
@@ -1,0 +1,8 @@
+name: noema
+version: 0.1.0
+description: "Structured memory backed by a Noema Cortex — markdown traces with types, tags, lineage, and full-text search."
+hooks:
+  - sync_turn
+  - on_session_end
+  - on_pre_compress
+  - on_memory_write

--- a/plugins/hermes/tests/test_integration.py
+++ b/plugins/hermes/tests/test_integration.py
@@ -1,0 +1,358 @@
+"""Integration tests for the Noema Hermes plugin — requires the noema binary.
+
+These tests spawn a real `noema serve --transport stdio` subprocess against
+a throwaway cortex and exercise the full plugin lifecycle.
+
+Skip with: pytest -m "not integration"
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+
+import pytest
+
+from plugins.hermes.transport import find_binary, reset_binary_cache, StdioTransport
+from plugins.hermes import NoemaMemoryProvider
+
+# Mark every test in this module as integration.
+pytestmark = pytest.mark.integration
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+NOEMA_BINARY = None
+
+
+def _find_noema():
+    global NOEMA_BINARY
+    if NOEMA_BINARY is None:
+        reset_binary_cache()
+        NOEMA_BINARY = find_binary()
+    return NOEMA_BINARY
+
+
+@pytest.fixture(scope="module")
+def noema_binary():
+    binary = _find_noema()
+    if not binary:
+        pytest.skip("noema binary not found — skipping integration tests")
+    return binary
+
+
+@pytest.fixture()
+def cortex_dir(noema_binary):
+    """Create a throwaway cortex and return its path. Cleaned up after the test."""
+    tmpdir = tempfile.mkdtemp(prefix="noema-test-")
+    name = "hermes-test"
+    result = subprocess.run(
+        [noema_binary, "init", "--name", name, "--path", tmpdir],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, f"noema init failed: {result.stderr}"
+    yield name
+    shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Transport integration
+# ---------------------------------------------------------------------------
+
+class TestStdioTransportIntegration:
+    def test_start_and_handshake(self, noema_binary, cortex_dir):
+        t = StdioTransport(noema_binary, cortex_dir)
+        t.start()
+        assert t.is_alive
+        t.close()
+        assert not t.is_alive
+
+    def test_call_cortex_identity(self, noema_binary, cortex_dir):
+        t = StdioTransport(noema_binary, cortex_dir)
+        t.start()
+        try:
+            result = t.call_tool("cortex_identity")
+            identity = json.loads(result)
+            assert "name" in identity
+            assert "id" in identity
+            assert identity["name"] == cortex_dir
+        finally:
+            t.close()
+
+    def test_call_get_instructions(self, noema_binary, cortex_dir):
+        t = StdioTransport(noema_binary, cortex_dir)
+        t.start()
+        try:
+            result = t.call_tool("get_instructions")
+            assert "Trace" in result or "trace" in result
+            assert len(result) > 100  # Should be a substantial guide.
+        finally:
+            t.close()
+
+    def test_create_and_get_trace(self, noema_binary, cortex_dir):
+        t = StdioTransport(noema_binary, cortex_dir)
+        t.start()
+        try:
+            # Create a trace.
+            create_result = t.call_tool("create_trace", {
+                "title": "integration-test-trace",
+                "type": "note",
+                "body": "This is a test trace from the integration suite.",
+                "tags": "test, integration",
+            })
+            assert "Trace created:" in create_result
+            trace_id = create_result.split("Trace created: ")[1].strip()
+
+            # Get it back.
+            get_result = t.call_tool("get_trace", {"id": trace_id})
+            assert "integration-test-trace" in get_result
+            assert "This is a test trace" in get_result
+        finally:
+            t.close()
+
+    def test_search_traces(self, noema_binary, cortex_dir):
+        t = StdioTransport(noema_binary, cortex_dir)
+        t.start()
+        try:
+            # Create a trace with distinctive content.
+            t.call_tool("create_trace", {
+                "title": "zebra-unique-term",
+                "type": "fact",
+                "body": "Zebras have distinctive black and white stripes.",
+            })
+            # Search for it.
+            result = t.call_tool("search_traces", {"query": "zebra"})
+            assert "zebra" in result.lower()
+        finally:
+            t.close()
+
+    def test_append_trace(self, noema_binary, cortex_dir):
+        t = StdioTransport(noema_binary, cortex_dir)
+        t.start()
+        try:
+            # Create, then append.
+            create_result = t.call_tool("create_trace", {
+                "title": "append-target",
+                "type": "context",
+                "body": "Initial content.",
+            })
+            trace_id = create_result.split("Trace created: ")[1].strip()
+
+            t.call_tool("append_trace", {
+                "id": trace_id,
+                "content": "\n---\nAppended block.",
+            })
+
+            get_result = t.call_tool("get_trace", {"id": trace_id})
+            assert "Initial content." in get_result
+            assert "Appended block." in get_result
+        finally:
+            t.close()
+
+    def test_list_traces(self, noema_binary, cortex_dir):
+        t = StdioTransport(noema_binary, cortex_dir)
+        t.start()
+        try:
+            t.call_tool("create_trace", {
+                "title": "list-test",
+                "type": "decision",
+                "body": "Listing test.",
+            })
+            result = t.call_tool("list_traces")
+            assert "list-test" in result
+        finally:
+            t.close()
+
+    def test_archive_and_list(self, noema_binary, cortex_dir):
+        t = StdioTransport(noema_binary, cortex_dir)
+        t.start()
+        try:
+            create_result = t.call_tool("create_trace", {
+                "title": "archive-me",
+                "type": "note",
+                "body": "Will be archived.",
+            })
+            trace_id = create_result.split("Trace created: ")[1].strip()
+
+            t.call_tool("archive_trace", {"id": trace_id})
+
+            # Should not appear in default list.
+            result = t.call_tool("list_traces")
+            assert trace_id not in result
+        finally:
+            t.close()
+
+    def test_close_is_idempotent(self, noema_binary, cortex_dir):
+        t = StdioTransport(noema_binary, cortex_dir)
+        t.start()
+        t.close()
+        t.close()  # Should not raise.
+
+
+# ---------------------------------------------------------------------------
+# Full provider lifecycle
+# ---------------------------------------------------------------------------
+
+class TestProviderLifecycle:
+    def test_full_session(self, noema_binary, cortex_dir):
+        """Exercise the full Hermes lifecycle: init -> turns -> end -> shutdown."""
+        provider = NoemaMemoryProvider()
+        provider._config = {"cortex_name": cortex_dir, "transport": "stdio"}
+
+        # Initialize.
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("NOEMA_CORTEX", cortex_dir)
+            provider.initialize(
+                session_id="test-session-001",
+                agent_identity="researcher",
+                session_title="Integration test session",
+                platform="pytest",
+            )
+
+        assert provider._transport is not None
+        assert provider._transport.is_alive
+        assert provider._cortex_name == cortex_dir
+        assert provider._session_trace_id  # Should have created a session trace.
+        assert provider._instructions_cache  # Should have cached instructions.
+        assert provider._author == "hermes/researcher"
+
+        # System prompt block should return cached instructions.
+        prompt = provider.system_prompt_block()
+        assert len(prompt) > 100
+
+        # Tool schemas.
+        schemas = provider.get_tool_schemas()
+        assert len(schemas) == 6
+
+        # Simulate turns.
+        provider.on_turn_start(1, "What do you know about Go?")
+        provider.sync_turn(
+            "What do you know about Go?",
+            "Go is a statically typed language designed at Google.",
+        )
+        # Wait for the sync thread to complete.
+        if provider._sync_thread:
+            provider._sync_thread.join(timeout=5)
+
+        provider.on_turn_start(2, "Why did we choose it?")
+        provider.sync_turn(
+            "Why did we choose it?",
+            "We chose Go for pure-Go SQLite and fast iteration.",
+        )
+        if provider._sync_thread:
+            provider._sync_thread.join(timeout=5)
+
+        # Verify the session trace got appended.
+        session_content = provider._transport.call_tool(
+            "get_trace", {"id": provider._session_trace_id}
+        )
+        assert "Turn 1" in session_content
+        assert "Turn 2" in session_content
+        assert "Go" in session_content
+
+        # Tool calls.
+        result = json.loads(provider.handle_tool_call("noema_remember", {
+            "title": "Go is great",
+            "type": "decision",
+            "body": "We chose Go for its simplicity and tooling.",
+            "tags": "go, lang",
+        }))
+        assert "result" in result
+        assert "Trace created:" in result["result"]
+
+        # Search.
+        result = json.loads(provider.handle_tool_call("noema_search", {
+            "query": "Go simplicity",
+        }))
+        assert "result" in result
+
+        # Prefetch.
+        prefetch_result = provider.prefetch("Go language choice")
+        # May or may not find results depending on FTS indexing timing.
+        # Just verify it doesn't crash and returns a string.
+        assert isinstance(prefetch_result, str)
+
+        # Session end.
+        messages = [
+            {"role": "user", "content": "What do you know about Go?"},
+            {"role": "assistant", "content": "Go is a statically typed language."},
+            {"role": "user", "content": "Why did we choose it?"},
+            {"role": "assistant", "content": "We chose Go for pure-Go SQLite."},
+        ]
+        provider.on_session_end(messages)
+        if provider._end_thread:
+            provider._end_thread.join(timeout=10)
+
+        # Verify summary was created. List by type.
+        summary_result = provider._transport.call_tool(
+            "list_traces", {"type": "observation"}
+        )
+        assert "session-summary" in summary_result
+
+        # Verify session log was archived (shouldn't show in default list).
+        list_result = provider._transport.call_tool("list_traces")
+        assert provider._session_trace_id not in list_result
+
+        # Shutdown.
+        provider.shutdown()
+        assert provider._transport is None
+
+    def test_memory_write_add(self, noema_binary, cortex_dir):
+        """Test on_memory_write with add action."""
+        provider = NoemaMemoryProvider()
+        provider._config = {"cortex_name": cortex_dir, "transport": "stdio"}
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("NOEMA_CORTEX", cortex_dir)
+            provider.initialize(
+                session_id="test-mirror-001",
+                agent_identity="tester",
+            )
+
+        provider.on_memory_write("add", "test-memory", "This is a mirrored memory.")
+        if provider._mirror_thread:
+            provider._mirror_thread.join(timeout=5)
+
+        # Verify it was created.
+        result = provider._transport.call_tool(
+            "search_traces", {"query": "mirrored memory"}
+        )
+        assert "hermes-mirror" in result or "mirrored" in result.lower()
+
+        provider.shutdown()
+
+    def test_pre_compress(self, noema_binary, cortex_dir):
+        """Test on_pre_compress returns a breadcrumb and appends to session log."""
+        provider = NoemaMemoryProvider()
+        provider._config = {"cortex_name": cortex_dir, "transport": "stdio"}
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("NOEMA_CORTEX", cortex_dir)
+            provider.initialize(
+                session_id="test-compress-001",
+                agent_identity="tester",
+            )
+
+        messages = [
+            {"role": "user", "content": "First message"},
+            {"role": "assistant", "content": "First reply"},
+        ]
+
+        breadcrumb = provider.on_pre_compress(messages)
+        assert "Context compressed" in breadcrumb
+        assert provider._session_trace_id in breadcrumb
+        assert "noema_recall" in breadcrumb
+
+        # Wait for the background thread.
+        time.sleep(1)
+
+        # Verify the compression block was appended.
+        session_content = provider._transport.call_tool(
+            "get_trace", {"id": provider._session_trace_id}
+        )
+        assert "Context compression" in session_content
+
+        provider.shutdown()

--- a/plugins/hermes/tests/test_unit.py
+++ b/plugins/hermes/tests/test_unit.py
@@ -1,0 +1,598 @@
+"""Unit tests for the Noema Hermes plugin — no binary or network needed."""
+
+import json
+import os
+import stat
+import tempfile
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Import transport helpers directly.
+from plugins.hermes.transport import (
+    _jsonrpc_request,
+    _parse_jsonrpc_response,
+    _extract_text,
+    find_binary,
+    reset_binary_cache,
+    StdioTransport,
+    HttpTransport,
+)
+from plugins.hermes import (
+    __version__,
+    NoemaMemoryProvider,
+    ALL_TOOL_SCHEMAS,
+    _TOOL_MAP,
+    _tool_error,
+    _now_iso,
+    _load_config,
+)
+
+
+# ---------------------------------------------------------------------------
+# transport.py — JSON-RPC helpers
+# ---------------------------------------------------------------------------
+
+class TestJsonRpcRequest:
+    def test_basic_request(self):
+        raw = _jsonrpc_request("tools/call", {"name": "list_traces"}, 1)
+        payload = json.loads(raw.decode("utf-8"))
+        assert payload["jsonrpc"] == "2.0"
+        assert payload["id"] == 1
+        assert payload["method"] == "tools/call"
+        assert payload["params"] == {"name": "list_traces"}
+
+    def test_newline_terminated(self):
+        raw = _jsonrpc_request("initialize", {}, 42)
+        assert raw.endswith(b"\n")
+
+    def test_incrementing_ids(self):
+        r1 = json.loads(_jsonrpc_request("a", {}, 1))
+        r2 = json.loads(_jsonrpc_request("b", {}, 2))
+        assert r1["id"] == 1
+        assert r2["id"] == 2
+
+
+class TestParseJsonRpcResponse:
+    def test_success_response(self):
+        line = json.dumps({"jsonrpc": "2.0", "id": 1, "result": {"content": []}})
+        result = _parse_jsonrpc_response(line)
+        assert result == {"content": []}
+
+    def test_error_response_dict(self):
+        line = json.dumps({"jsonrpc": "2.0", "id": 1, "error": {"message": "not found"}})
+        with pytest.raises(RuntimeError, match="not found"):
+            _parse_jsonrpc_response(line)
+
+    def test_error_response_string(self):
+        line = json.dumps({"jsonrpc": "2.0", "id": 1, "error": "something broke"})
+        with pytest.raises(RuntimeError, match="something broke"):
+            _parse_jsonrpc_response(line)
+
+    def test_null_error_is_success(self):
+        line = json.dumps({"jsonrpc": "2.0", "id": 1, "result": {"ok": True}, "error": None})
+        result = _parse_jsonrpc_response(line)
+        assert result == {"ok": True}
+
+    def test_missing_result_returns_empty(self):
+        line = json.dumps({"jsonrpc": "2.0", "id": 1})
+        result = _parse_jsonrpc_response(line)
+        assert result == {}
+
+
+class TestExtractText:
+    def test_extracts_text_content(self):
+        result = {"content": [{"type": "text", "text": "hello world"}]}
+        assert _extract_text(result) == "hello world"
+
+    def test_skips_non_text_content(self):
+        result = {"content": [{"type": "image", "data": "..."}, {"type": "text", "text": "found"}]}
+        assert _extract_text(result) == "found"
+
+    def test_empty_content(self):
+        assert _extract_text({"content": []}) == ""
+        assert _extract_text({}) == ""
+
+    def test_missing_text_field(self):
+        result = {"content": [{"type": "text"}]}
+        assert _extract_text(result) == ""
+
+
+# ---------------------------------------------------------------------------
+# transport.py — binary discovery
+# ---------------------------------------------------------------------------
+
+class TestFindBinary:
+    def setup_method(self):
+        reset_binary_cache()
+
+    def teardown_method(self):
+        reset_binary_cache()
+
+    def test_explicit_override(self, tmp_path):
+        binary = tmp_path / "noema"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+        result = find_binary(str(binary))
+        assert result == str(binary)
+
+    def test_explicit_override_not_found(self, tmp_path):
+        result = find_binary(str(tmp_path / "nonexistent"))
+        assert result is None
+
+    def test_env_var_override(self, tmp_path):
+        binary = tmp_path / "noema"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+        reset_binary_cache()
+        with patch.dict(os.environ, {"NOEMA_BINARY": str(binary)}):
+            result = find_binary()
+            assert result == str(binary)
+
+    def test_path_lookup(self, tmp_path):
+        reset_binary_cache()
+        binary = tmp_path / "noema"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+        with patch.dict(os.environ, {}, clear=True):
+            with patch("plugins.hermes.transport.shutil.which", return_value=str(binary)):
+                result = find_binary()
+                assert result == str(binary)
+
+    def test_cache_persists(self, tmp_path):
+        binary = tmp_path / "noema"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+        reset_binary_cache()
+        result1 = find_binary(str(binary))
+        # Second call should use cache even without the override.
+        result2 = find_binary()
+        assert result1 == result2 == str(binary)
+
+    def test_cache_cleared(self, tmp_path):
+        binary = tmp_path / "noema"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+        find_binary(str(binary))
+        reset_binary_cache()
+        # After reset, with no PATH or override, should return None
+        # (assuming shutil.which won't find it in tmp_path).
+        with patch("plugins.hermes.transport.shutil.which", return_value=None):
+            result = find_binary()
+            # May find it in well-known locations; just verify cache was reset.
+            # The important thing is no exception.
+
+
+# ---------------------------------------------------------------------------
+# transport.py — StdioTransport
+# ---------------------------------------------------------------------------
+
+class TestStdioTransport:
+    def test_is_alive_before_start(self):
+        t = StdioTransport("/usr/bin/false", "test-cortex")
+        assert t.is_alive is False
+
+    def test_close_before_start(self):
+        t = StdioTransport("/usr/bin/false", "test-cortex")
+        t.close()  # Should not raise.
+
+    def test_send_raises_when_not_running(self):
+        t = StdioTransport("/usr/bin/false", "test-cortex")
+        with pytest.raises(RuntimeError, match="not running"):
+            t.call_tool("list_traces")
+
+
+# ---------------------------------------------------------------------------
+# transport.py — HttpTransport
+# ---------------------------------------------------------------------------
+
+class TestHttpTransport:
+    def test_url_normalization(self):
+        t = HttpTransport("http://localhost:3000")
+        assert t._url == "http://localhost:3000/mcp"
+
+    def test_url_already_has_mcp(self):
+        t = HttpTransport("http://localhost:3000/mcp")
+        assert t._url == "http://localhost:3000/mcp"
+
+    def test_url_trailing_slash(self):
+        t = HttpTransport("http://localhost:3000/")
+        assert t._url == "http://localhost:3000/mcp"
+
+    def test_is_alive_always_true(self):
+        t = HttpTransport("http://localhost:3000")
+        assert t.is_alive is True
+
+    def test_close_is_noop(self):
+        t = HttpTransport("http://localhost:3000")
+        t.close()  # Should not raise.
+
+    def test_bearer_key_stored(self):
+        t = HttpTransport("http://localhost:3000", bearer_key="secret123")
+        assert t._bearer_key == "secret123"
+
+
+# ---------------------------------------------------------------------------
+# __init__.py — version
+# ---------------------------------------------------------------------------
+
+class TestVersion:
+    def test_version_exists(self):
+        assert __version__
+        parts = __version__.split(".")
+        assert len(parts) == 3
+
+
+# ---------------------------------------------------------------------------
+# __init__.py — tool schemas
+# ---------------------------------------------------------------------------
+
+class TestToolSchemas:
+    def test_six_tools(self):
+        assert len(ALL_TOOL_SCHEMAS) == 6
+
+    def test_all_have_required_fields(self):
+        for schema in ALL_TOOL_SCHEMAS:
+            assert "name" in schema
+            assert "description" in schema
+            assert "parameters" in schema
+            assert schema["parameters"]["type"] == "object"
+
+    def test_tool_names(self):
+        names = {s["name"] for s in ALL_TOOL_SCHEMAS}
+        assert names == {
+            "noema_search", "noema_remember", "noema_recall",
+            "noema_list", "noema_update", "noema_lineage",
+        }
+
+    def test_remember_required_fields(self):
+        schema = next(s for s in ALL_TOOL_SCHEMAS if s["name"] == "noema_remember")
+        assert set(schema["parameters"]["required"]) == {"title", "type", "body"}
+
+    def test_search_required_fields(self):
+        schema = next(s for s in ALL_TOOL_SCHEMAS if s["name"] == "noema_search")
+        assert schema["parameters"]["required"] == ["query"]
+
+    def test_remember_type_enum(self):
+        schema = next(s for s in ALL_TOOL_SCHEMAS if s["name"] == "noema_remember")
+        enum = schema["parameters"]["properties"]["type"]["enum"]
+        assert "fact" in enum
+        assert "decision" in enum
+        assert "divergence" not in enum  # Agent can't create divergence traces.
+
+
+# ---------------------------------------------------------------------------
+# __init__.py — tool mapping
+# ---------------------------------------------------------------------------
+
+class TestToolMap:
+    def test_all_schemas_mapped(self):
+        schema_names = {s["name"] for s in ALL_TOOL_SCHEMAS}
+        mapped_names = set(_TOOL_MAP.keys())
+        assert schema_names == mapped_names
+
+    def test_mapping_values(self):
+        assert _TOOL_MAP["noema_search"] == "search_traces"
+        assert _TOOL_MAP["noema_remember"] == "create_trace"
+        assert _TOOL_MAP["noema_recall"] == "get_trace"
+        assert _TOOL_MAP["noema_list"] == "list_traces"
+        assert _TOOL_MAP["noema_update"] == "update_trace"
+        assert _TOOL_MAP["noema_lineage"] == "trace_lineage"
+
+
+# ---------------------------------------------------------------------------
+# __init__.py — helpers
+# ---------------------------------------------------------------------------
+
+class TestHelpers:
+    def test_tool_error_json(self):
+        result = json.loads(_tool_error("something broke"))
+        assert result == {"error": "something broke"}
+
+    def test_now_iso_format(self):
+        ts = _now_iso()
+        assert ts.endswith("Z")
+        assert "T" in ts
+
+    def test_extract_first_trace_id(self):
+        output = "[fact] 20260412-my-trace (2026-04-12) — agent [tag1]"
+        result = NoemaMemoryProvider._extract_first_trace_id(output)
+        assert result == "20260412-my-trace"
+
+    def test_extract_first_trace_id_multiline(self):
+        output = (
+            "Found 2 traces:\n"
+            "[decision] 20260412-chose-go (2026-04-12) — mark [go]\n"
+            "[fact] 20260412-sqlite-perf (2026-04-12) — mark [perf]"
+        )
+        result = NoemaMemoryProvider._extract_first_trace_id(output)
+        assert result == "20260412-chose-go"
+
+    def test_extract_first_trace_id_none(self):
+        assert NoemaMemoryProvider._extract_first_trace_id("No traces found.") is None
+        assert NoemaMemoryProvider._extract_first_trace_id("") is None
+
+
+# ---------------------------------------------------------------------------
+# __init__.py — config loading
+# ---------------------------------------------------------------------------
+
+class TestConfig:
+    def test_load_config(self, tmp_path):
+        config = {"cortex_name": "test", "transport": "stdio"}
+        (tmp_path / "noema.json").write_text(json.dumps(config))
+        result = _load_config(str(tmp_path))
+        assert result == config
+
+    def test_load_config_missing(self, tmp_path):
+        result = _load_config(str(tmp_path))
+        assert result == {}
+
+    def test_load_config_invalid_json(self, tmp_path):
+        (tmp_path / "noema.json").write_text("not json{{{")
+        result = _load_config(str(tmp_path))
+        assert result == {}
+
+    def test_save_config(self, tmp_path):
+        provider = NoemaMemoryProvider()
+        provider.save_config({"cortex_name": "my-cortex", "transport": "stdio"}, str(tmp_path))
+        saved = json.loads((tmp_path / "noema.json").read_text())
+        assert saved["cortex_name"] == "my-cortex"
+        assert saved["transport"] == "stdio"
+
+    def test_save_config_strips_none(self, tmp_path):
+        provider = NoemaMemoryProvider()
+        provider.save_config({"cortex_name": "x", "bearer_key": None}, str(tmp_path))
+        saved = json.loads((tmp_path / "noema.json").read_text())
+        assert "bearer_key" not in saved
+
+    def test_config_schema(self):
+        provider = NoemaMemoryProvider()
+        schema = provider.get_config_schema()
+        keys = [item["key"] for item in schema]
+        assert keys == ["cortex_name", "noema_binary", "transport", "http_url", "bearer_key"]
+        required = [item["key"] for item in schema if item.get("required")]
+        assert required == ["cortex_name"]
+        secret = [item["key"] for item in schema if item.get("secret")]
+        assert secret == ["bearer_key"]
+
+
+# ---------------------------------------------------------------------------
+# __init__.py — provider basics
+# ---------------------------------------------------------------------------
+
+class TestProviderBasics:
+    def test_name(self):
+        p = NoemaMemoryProvider()
+        assert p.name == "noema"
+
+    def test_is_available_no_cortex(self):
+        p = NoemaMemoryProvider()
+        with patch.dict(os.environ, {}, clear=True):
+            assert p.is_available() is False
+
+    def test_is_available_stdio_no_binary(self):
+        p = NoemaMemoryProvider()
+        p._config = {"cortex_name": "test", "transport": "stdio"}
+        reset_binary_cache()
+        with patch.dict(os.environ, {"NOEMA_CORTEX": "test"}, clear=True):
+            with patch("plugins.hermes.transport.shutil.which", return_value=None):
+                with patch("plugins.hermes.transport.Path.is_file", return_value=False):
+                    assert p.is_available() is False
+        reset_binary_cache()
+
+    def test_is_available_http_no_url(self):
+        p = NoemaMemoryProvider()
+        p._config = {"cortex_name": "test", "transport": "http"}
+        with patch.dict(os.environ, {"NOEMA_CORTEX": "test"}, clear=True):
+            assert p.is_available() is False
+
+    def test_is_available_http_with_url(self):
+        p = NoemaMemoryProvider()
+        p._config = {"cortex_name": "test", "transport": "http", "http_url": "http://localhost:3000"}
+        with patch.dict(os.environ, {"NOEMA_CORTEX": "test"}, clear=True):
+            assert p.is_available() is True
+
+    def test_get_tool_schemas_returns_copy(self):
+        p = NoemaMemoryProvider()
+        schemas = p.get_tool_schemas()
+        assert schemas == ALL_TOOL_SCHEMAS
+        assert schemas is not ALL_TOOL_SCHEMAS  # Should be a copy.
+
+    def test_handle_tool_call_unknown_tool(self):
+        p = NoemaMemoryProvider()
+        result = json.loads(p.handle_tool_call("noema_explode", {}))
+        assert "error" in result
+
+    def test_handle_tool_call_no_transport(self):
+        p = NoemaMemoryProvider()
+        result = json.loads(p.handle_tool_call("noema_search", {"query": "test"}))
+        assert "error" in result
+
+    def test_queue_prefetch_is_noop(self):
+        p = NoemaMemoryProvider()
+        p.queue_prefetch("test")  # Should not raise.
+
+    def test_on_turn_start_increments_counter(self):
+        p = NoemaMemoryProvider()
+        p.on_turn_start(5, "hello")
+        assert p._turn_count == 5
+
+    def test_shutdown_without_transport(self):
+        p = NoemaMemoryProvider()
+        p.shutdown()  # Should not raise.
+
+
+# ---------------------------------------------------------------------------
+# __init__.py — handle_tool_call routing (mocked transport)
+# ---------------------------------------------------------------------------
+
+class TestHandleToolCallRouting:
+    def setup_method(self):
+        self.provider = NoemaMemoryProvider()
+        self.provider._transport = MagicMock()
+        self.provider._author = "hermes/tester"
+        self.provider._transport.call_tool.return_value = "ok"
+
+    def test_search_routes_correctly(self):
+        self.provider.handle_tool_call("noema_search", {"query": "sqlite"})
+        self.provider._transport.call_tool.assert_called_once_with(
+            "search_traces", {"query": "sqlite"}
+        )
+
+    def test_remember_includes_author(self):
+        self.provider.handle_tool_call("noema_remember", {
+            "title": "test", "type": "fact", "body": "content",
+        })
+        call_args = self.provider._transport.call_tool.call_args
+        assert call_args[0][0] == "create_trace"
+        assert call_args[0][1]["author"] == "hermes/tester"
+
+    def test_remember_passes_tags(self):
+        self.provider.handle_tool_call("noema_remember", {
+            "title": "test", "type": "fact", "body": "content", "tags": "a, b",
+        })
+        call_args = self.provider._transport.call_tool.call_args
+        assert call_args[0][1]["tags"] == "a, b"
+
+    def test_recall_routes_correctly(self):
+        self.provider.handle_tool_call("noema_recall", {"id": "20260412-test"})
+        self.provider._transport.call_tool.assert_called_once_with(
+            "get_trace", {"id": "20260412-test"}
+        )
+
+    def test_list_passes_filters(self):
+        self.provider.handle_tool_call("noema_list", {"type": "decision", "tag": "go"})
+        call_args = self.provider._transport.call_tool.call_args
+        assert call_args[0][1] == {"type": "decision", "tag": "go"}
+
+    def test_update_routes_correctly(self):
+        self.provider.handle_tool_call("noema_update", {"id": "20260412-test", "body": "new"})
+        call_args = self.provider._transport.call_tool.call_args
+        assert call_args[0][0] == "update_trace"
+        assert call_args[0][1]["id"] == "20260412-test"
+        assert call_args[0][1]["body"] == "new"
+
+    def test_lineage_routes_correctly(self):
+        self.provider.handle_tool_call("noema_lineage", {"id": "20260412-test"})
+        self.provider._transport.call_tool.assert_called_once_with(
+            "trace_lineage", {"id": "20260412-test"}
+        )
+
+    def test_result_wrapped_in_json(self):
+        self.provider._transport.call_tool.return_value = "trace body here"
+        raw = self.provider.handle_tool_call("noema_recall", {"id": "x"})
+        result = json.loads(raw)
+        assert result == {"result": "trace body here"}
+
+    def test_transport_error_returns_error_json(self):
+        self.provider._transport.call_tool.side_effect = RuntimeError("connection lost")
+        self.provider._transport.is_alive = True
+        raw = self.provider.handle_tool_call("noema_search", {"query": "x"})
+        result = json.loads(raw)
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# __init__.py — prefetch (mocked transport)
+# ---------------------------------------------------------------------------
+
+class TestPrefetch:
+    def test_empty_query(self):
+        p = NoemaMemoryProvider()
+        p._transport = MagicMock()
+        assert p.prefetch("") == ""
+        assert p.prefetch("   ") == ""
+
+    def test_no_results(self):
+        p = NoemaMemoryProvider()
+        p._transport = MagicMock()
+        p._transport.call_tool.return_value = "No traces found."
+        assert p.prefetch("test query") == ""
+
+    def test_formats_results(self):
+        p = NoemaMemoryProvider()
+        p._transport = MagicMock()
+        p._transport.call_tool.return_value = "[fact] 20260412-test (2026-04-12) — agent [tag]"
+        result = p.prefetch("test query")
+        assert "## Relevant Memories (from Noema)" in result
+        assert "20260412-test" in result
+        assert "noema_search" in result
+
+    def test_filters_session_logs(self):
+        p = NoemaMemoryProvider()
+        p._transport = MagicMock()
+        p._transport.call_tool.return_value = (
+            "[context] 20260412-hermes-session (2026-04-12) — hermes/agent [hermes-session]\n"
+            "[fact] 20260412-real-trace (2026-04-12) — agent [useful]"
+        )
+        result = p.prefetch("test")
+        assert "hermes-session" not in result or "hermes-session-summary" in result
+        assert "20260412-real-trace" in result
+
+    def test_keeps_session_summaries(self):
+        p = NoemaMemoryProvider()
+        p._transport = MagicMock()
+        p._transport.call_tool.return_value = (
+            "[observation] 20260412-session-summary (2026-04-12) — hermes/agent [hermes-session-summary]"
+        )
+        result = p.prefetch("test")
+        assert "hermes-session-summary" in result
+
+    def test_truncates_long_query(self):
+        p = NoemaMemoryProvider()
+        p._transport = MagicMock()
+        p._transport.call_tool.return_value = "No traces found."
+        p.prefetch("x" * 1000)
+        call_args = p._transport.call_tool.call_args
+        assert len(call_args[0][1]["query"]) == 500
+
+    def test_transport_error_returns_empty(self):
+        p = NoemaMemoryProvider()
+        p._transport = MagicMock()
+        p._transport.call_tool.side_effect = RuntimeError("boom")
+        assert p.prefetch("test") == ""
+
+
+# ---------------------------------------------------------------------------
+# __init__.py — session trace creation (mocked transport)
+# ---------------------------------------------------------------------------
+
+class TestSessionTrace:
+    def test_session_trace_created(self):
+        p = NoemaMemoryProvider()
+        p._transport = MagicMock()
+        p._transport.call_tool.return_value = "Trace created: 20260412-hermes-session-abc"
+        p._session_id = "session-abc123"
+        p._agent_identity = "researcher"
+        p._author = "hermes/researcher"
+        p._session_title = "Research session"
+        p._platform = "cli"
+
+        p._create_session_trace()
+
+        call_args = p._transport.call_tool.call_args
+        assert call_args[0][0] == "create_trace"
+        args = call_args[0][1]
+        assert args["title"] == "hermes-session: Research session"
+        assert args["type"] == "context"
+        assert args["author"] == "hermes/researcher"
+        assert "hermes-session" in args["tags"]
+        assert p._session_trace_id == "20260412-hermes-session-abc"
+
+    def test_session_trace_uses_id_fallback(self):
+        p = NoemaMemoryProvider()
+        p._transport = MagicMock()
+        p._transport.call_tool.return_value = "Trace created: 20260412-hermes-session-x"
+        p._session_id = "abcdefghijklmnop"
+        p._session_title = ""
+        p._author = "hermes/unknown"
+        p._platform = "cli"
+        p._agent_identity = "unknown"
+
+        p._create_session_trace()
+
+        call_args = p._transport.call_tool.call_args
+        assert "abcdefghijkl" in call_args[0][1]["title"]

--- a/plugins/hermes/transport.py
+++ b/plugins/hermes/transport.py
@@ -1,0 +1,307 @@
+"""Noema MCP transport layer for the Hermes memory provider plugin.
+
+Two transports are supported:
+
+- StdioTransport: spawns `noema serve --transport stdio` as a subprocess
+  and communicates via JSON-RPC 2.0 over stdin/stdout pipes.
+- HttpTransport: connects to an already-running `noema serve --transport http`
+  endpoint via POST /mcp with JSON-RPC 2.0 payloads.
+
+Both expose the same call_tool(name, args) -> dict interface. A threading.Lock
+guards all I/O so concurrent calls from daemon threads are safe.
+"""
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+import threading
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from urllib.request import Request, urlopen
+from urllib.error import URLError
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Binary discovery
+# ---------------------------------------------------------------------------
+
+_binary_cache: Optional[str] = None
+_binary_lock = threading.Lock()
+
+
+def find_binary(override: Optional[str] = None) -> Optional[str]:
+    """Locate the noema binary. Resolution order:
+    1. Explicit override (config or NOEMA_BINARY env)
+    2. shutil.which("noema") — standard PATH lookup
+    3. Well-known install locations
+    """
+    global _binary_cache
+    with _binary_lock:
+        if _binary_cache is not None:
+            return _binary_cache if _binary_cache != "" else None
+
+    # Explicit override.
+    path = override or os.environ.get("NOEMA_BINARY", "")
+    if path:
+        if os.path.isfile(path) and os.access(path, os.X_OK):
+            with _binary_lock:
+                _binary_cache = path
+            return path
+        logger.warning("Configured noema binary %s not found or not executable", path)
+        with _binary_lock:
+            _binary_cache = ""
+        return None
+
+    # PATH lookup.
+    found = shutil.which("noema")
+    if found:
+        with _binary_lock:
+            _binary_cache = found
+        return found
+
+    # Well-known locations.
+    home = Path.home()
+    candidates = [
+        home / "go" / "bin" / "noema",
+        Path("/usr/local/bin/noema"),
+        home / ".local" / "bin" / "noema",
+    ]
+    for c in candidates:
+        if c.is_file() and os.access(str(c), os.X_OK):
+            with _binary_lock:
+                _binary_cache = str(c)
+            return str(c)
+
+    with _binary_lock:
+        _binary_cache = ""
+    return None
+
+
+def reset_binary_cache() -> None:
+    """Clear the cached binary path (useful after config changes)."""
+    global _binary_cache
+    with _binary_lock:
+        _binary_cache = None
+
+
+# ---------------------------------------------------------------------------
+# JSON-RPC helpers
+# ---------------------------------------------------------------------------
+
+def _jsonrpc_request(method: str, params: dict, req_id: int) -> bytes:
+    """Build a JSON-RPC 2.0 request as a newline-terminated byte string."""
+    payload = {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "method": method,
+        "params": params,
+    }
+    return json.dumps(payload).encode("utf-8") + b"\n"
+
+
+def _parse_jsonrpc_response(line: str) -> dict:
+    """Parse a JSON-RPC 2.0 response, returning the result or raising on error."""
+    resp = json.loads(line)
+    if "error" in resp and resp["error"] is not None:
+        err = resp["error"]
+        msg = err.get("message", str(err)) if isinstance(err, dict) else str(err)
+        raise RuntimeError(f"JSON-RPC error: {msg}")
+    return resp.get("result", {})
+
+
+def _extract_text(result: dict) -> str:
+    """Extract text content from an MCP CallToolResult."""
+    content = result.get("content", [])
+    for item in content:
+        if isinstance(item, dict) and item.get("type") == "text":
+            return item.get("text", "")
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# MCP initialize handshake
+# ---------------------------------------------------------------------------
+
+_INIT_PARAMS = {
+    "protocolVersion": "2025-03-26",
+    "capabilities": {},
+    "clientInfo": {
+        "name": "noema-hermes-plugin",
+        "version": "0.1.0",
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# StdioTransport
+# ---------------------------------------------------------------------------
+
+class StdioTransport:
+    """Spawn `noema serve --transport stdio` and communicate via pipes."""
+
+    def __init__(self, binary: str, cortex_name: str):
+        self._binary = binary
+        self._cortex_name = cortex_name
+        self._process: Optional[subprocess.Popen] = None
+        self._lock = threading.Lock()
+        self._req_id = 0
+
+    def start(self) -> None:
+        """Spawn the subprocess and perform the MCP initialize handshake."""
+        cmd = [self._binary, "serve", "--transport", "stdio", "--cortex", self._cortex_name]
+        self._process = subprocess.Popen(
+            cmd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=False,
+        )
+        self._handshake()
+
+    def _handshake(self) -> None:
+        """Send MCP initialize + initialized notification."""
+        # initialize request
+        resp = self._send("initialize", _INIT_PARAMS)
+        logger.debug("MCP initialize response: %s", resp)
+        # initialized notification (no id, no response expected)
+        notif = json.dumps({
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized",
+        }).encode("utf-8") + b"\n"
+        with self._lock:
+            self._process.stdin.write(notif)
+            self._process.stdin.flush()
+
+    def _send(self, method: str, params: dict) -> dict:
+        """Send a JSON-RPC request and read the response. Thread-safe.
+
+        Skips non-JSON lines (e.g. server log output on startup) by
+        reading until a line starting with '{' is found.
+        """
+        with self._lock:
+            if self._process is None or self._process.poll() is not None:
+                raise RuntimeError("Noema subprocess is not running")
+            self._req_id += 1
+            req = _jsonrpc_request(method, params, self._req_id)
+            self._process.stdin.write(req)
+            self._process.stdin.flush()
+            while True:
+                line = self._process.stdout.readline()
+                if not line:
+                    raise RuntimeError("Noema subprocess returned no output (EOF)")
+                text = line.decode("utf-8").strip()
+                if text.startswith("{"):
+                    return _parse_jsonrpc_response(text)
+                logger.debug("Skipping non-JSON output: %s", text)
+
+    def call_tool(self, name: str, arguments: Optional[Dict[str, Any]] = None) -> str:
+        """Call a Noema MCP tool. Returns the text content of the result."""
+        params = {"name": name}
+        if arguments:
+            params["arguments"] = arguments
+        result = self._send("tools/call", params)
+        return _extract_text(result)
+
+    @property
+    def is_alive(self) -> bool:
+        return self._process is not None and self._process.poll() is None
+
+    def close(self) -> None:
+        """Terminate the subprocess."""
+        if self._process is None:
+            return
+        try:
+            self._process.terminate()
+            self._process.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            self._process.kill()
+            self._process.wait(timeout=2)
+        except Exception:
+            pass
+        self._process = None
+
+
+# ---------------------------------------------------------------------------
+# HttpTransport
+# ---------------------------------------------------------------------------
+
+class HttpTransport:
+    """Connect to an already-running Noema HTTP MCP endpoint."""
+
+    def __init__(self, url: str, bearer_key: Optional[str] = None):
+        self._url = url.rstrip("/")
+        if not self._url.endswith("/mcp"):
+            self._url += "/mcp"
+        self._bearer_key = bearer_key
+        self._session_id: Optional[str] = None
+        self._lock = threading.Lock()
+        self._req_id = 0
+
+    def start(self) -> None:
+        """Perform the MCP initialize handshake over HTTP."""
+        resp = self._send("initialize", _INIT_PARAMS)
+        logger.debug("MCP initialize response: %s", resp)
+        # Send initialized notification.
+        self._send_notification("notifications/initialized")
+
+    def _build_request(self, body: bytes) -> Request:
+        """Build an HTTP request with standard headers."""
+        req = Request(self._url, data=body, method="POST")
+        req.add_header("Content-Type", "application/json")
+        if self._bearer_key:
+            req.add_header("Authorization", f"Bearer {self._bearer_key}")
+        if self._session_id:
+            req.add_header("Mcp-Session-Id", self._session_id)
+        return req
+
+    def _send(self, method: str, params: dict) -> dict:
+        """Send a JSON-RPC request over HTTP. Thread-safe."""
+        with self._lock:
+            self._req_id += 1
+            body = json.dumps({
+                "jsonrpc": "2.0",
+                "id": self._req_id,
+                "method": method,
+                "params": params,
+            }).encode("utf-8")
+            req = self._build_request(body)
+            with urlopen(req, timeout=30) as resp:
+                # Capture session ID from first response.
+                sid = resp.headers.get("Mcp-Session-Id")
+                if sid:
+                    self._session_id = sid
+                data = resp.read().decode("utf-8")
+                return _parse_jsonrpc_response(data)
+
+    def _send_notification(self, method: str) -> None:
+        """Send a JSON-RPC notification (no id, no response expected)."""
+        with self._lock:
+            body = json.dumps({
+                "jsonrpc": "2.0",
+                "method": method,
+            }).encode("utf-8")
+            req = self._build_request(body)
+            try:
+                with urlopen(req, timeout=10) as resp:
+                    resp.read()
+            except Exception:
+                pass  # Notifications are best-effort.
+
+    def call_tool(self, name: str, arguments: Optional[Dict[str, Any]] = None) -> str:
+        """Call a Noema MCP tool. Returns the text content of the result."""
+        params = {"name": name}
+        if arguments:
+            params["arguments"] = arguments
+        result = self._send("tools/call", params)
+        return _extract_text(result)
+
+    @property
+    def is_alive(self) -> bool:
+        return True  # HTTP is connectionless; we can't check without a call.
+
+    def close(self) -> None:
+        """No-op for HTTP (the server is independently managed)."""
+        pass


### PR DESCRIPTION
## Summary

- **FTS5 search fix:** Hyphens and colons in search queries were interpreted as FTS5 operators (NOT, column-prefix), causing "no such column" SQL errors. `SanitizeFTS5Query` now quotes tokens containing these characters while preserving AND/OR/NOT, quoted phrases, and prefix wildcards.
- **Hermes memory provider plugin:** Python plugin at `plugins/hermes/` implementing the Hermes `MemoryProvider` ABC. Gives any Hermes agent structured, persistent memory backed by a Noema Cortex via MCP. Includes six agent-facing tools, session lifecycle management, prefetch, memory mirroring, and both stdio/HTTP transports.
- **Release packaging:** GoReleaser bundles the plugin as `noema-hermes-plugin.tar.gz` in release assets.
- **Stdio transport fix:** Startup log lines moved to stderr so they don't corrupt JSON-RPC on the stdio transport.

## Test plan

- [x] `go test ./...` — all green
- [x] `go vet ./...` — clean
- [x] FTS5 fix: unit tests for `SanitizeFTS5Query`, integration tests for hyphenated and colon queries
- [x] Plugin: unit tests (`test_unit.py`) and integration tests (`test_integration.py`)
- [x] testbot playbook Part 1 (20 scenarios): 20/20 PASS
- [x] testbot playbook Part 2 (12 scenarios): 12/12 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)