### PR TITLE
security: harden MCP server, federation, and query sanitizer

### DIFF
--- a/internal/cli/cmd_serve.go
+++ b/internal/cli/cmd_serve.go
@@ -188,7 +188,9 @@ func serveCmd() *cobra.Command {
 					srv := &http.Server{
 						Addr:              addr,
 						Handler:           mux,
+						ReadTimeout:       60 * time.Second,
 						ReadHeaderTimeout: 30 * time.Second,
+						WriteTimeout:      120 * time.Second,
 						IdleTimeout:       120 * time.Second,
 					}
 					servers = append(servers, srv)

--- a/internal/cortex/cortex.go
+++ b/internal/cortex/cortex.go
@@ -116,7 +116,7 @@ func SanitizeFTS5Query(q string) string {
 		case t == "AND" || t == "OR" || t == "NOT":
 			out = append(out, t)
 		case strings.HasPrefix(t, "\""):
-			out = append(out, t) // already quoted
+			out = append(out, t) // already quoted (may be part of multi-token phrase)
 		case strings.HasSuffix(t, "*"):
 			out = append(out, t) // prefix search
 		case strings.ContainsAny(t, "-:"):
@@ -125,7 +125,18 @@ func SanitizeFTS5Query(q string) string {
 			out = append(out, t)
 		}
 	}
-	return strings.Join(out, " ")
+	result := strings.Join(out, " ")
+
+	// Safety net: if the result has an odd number of quote marks, the
+	// string has unbalanced quotes that would cause an FTS5 syntax
+	// error (and leak the raw query in the error message). Strip all
+	// quotes to fall back to default FTS5 tokenization. Legitimate
+	// quoted phrases always have matched pairs, so this only fires on
+	// malformed input.
+	if strings.Count(result, "\"")%2 != 0 {
+		result = strings.ReplaceAll(result, "\"", "")
+	}
+	return result
 }
 
 type Cortex struct {
@@ -2313,14 +2324,19 @@ func (c *Cortex) storeRemoteEvent(e event.Event) error {
 	return tx.Commit()
 }
 
-// MergeClock merges a remote vector clock into the local clock.
+// MergeClock merges a remote vector clock into the local clock. The
+// merge is capped at federation.MaxVClockEntries to prevent a malicious
+// peer from inflating the clock with synthetic cortex IDs.
 func (c *Cortex) MergeClock(remote federation.VClock) error {
 	state := federation.NewState(c.DB.DB)
 	local, err := state.GetClock()
 	if err != nil {
 		return err
 	}
-	merged := federation.Merge(local, remote)
+	merged, err := federation.MergeCapped(local, remote)
+	if err != nil {
+		return err
+	}
 	return state.SetClock(merged)
 }
 

--- a/internal/cortex/cortex_test.go
+++ b/internal/cortex/cortex_test.go
@@ -463,6 +463,11 @@ func TestSanitizeFTS5Query(t *testing.T) {
 		{"\"already quoted\"", "\"already quoted\""},
 		{"", ""},
 		{"no-hyphens-here AND plain", "\"no-hyphens-here\" AND plain"},
+		// Unbalanced quotes: stripped to prevent FTS5 syntax errors.
+		// Odd quote count → all quotes removed → safe default tokenization.
+		{"\"unterminated", "unterminated"},
+		{"\"injected) UNION SELECT --", "injected) UNION SELECT --"},
+		{"\"has\"embedded\"quotes", "hasembeddedquotes"},
 	}
 	for _, tt := range tests {
 		got := cortex.SanitizeFTS5Query(tt.input)

--- a/internal/event/ulid.go
+++ b/internal/event/ulid.go
@@ -61,6 +61,25 @@ func encodeRandom(buf []byte, rnd [10]byte) {
 	}
 }
 
+// IsValidULID reports whether s is a well-formed 26-character Crockford
+// base32 ULID. It does not check whether the timestamp or random portion
+// is semantically valid — only the length and character set.
+func IsValidULID(s string) bool {
+	if len(s) != 26 {
+		return false
+	}
+	for _, c := range s {
+		if (c < '0' || c > '9') && (c < 'A' || c > 'Z') {
+			return false
+		}
+		// Crockford base32 excludes I, L, O, U.
+		if c == 'I' || c == 'L' || c == 'O' || c == 'U' {
+			return false
+		}
+	}
+	return true
+}
+
 func incrementRnd() {
 	for i := 9; i >= 0; i-- {
 		lastRnd[i]++

--- a/internal/event/ulid_test.go
+++ b/internal/event/ulid_test.go
@@ -28,6 +28,38 @@ func TestNewULID_Uniqueness(t *testing.T) {
 	}
 }
 
+func TestIsValidULID(t *testing.T) {
+	valid := []string{
+		NewULID(),
+		"01ARZ3NDEKTSV4RRFFQ69G5FAV", // canonical example
+		"00000000000000000000000000", // all zeros
+		"7ZZZZZZZZZZZZZZZZZZZZZZZZZ", // max value
+	}
+	for _, id := range valid {
+		if !IsValidULID(id) {
+			t.Errorf("IsValidULID(%q) = false, want true", id)
+		}
+	}
+
+	invalid := []string{
+		"",
+		"too-short",
+		"01ARZ3NDEKTSV4RRFFQ69G5FA",  // 25 chars
+		"01ARZ3NDEKTSV4RRFFQ69G5FAVX", // 27 chars
+		"01ARZ3NDEKTSV4RRFFQ69G5FAi",  // lowercase i
+		"01ARZ3NDEKTSV4RRFFQ69G5FAO",  // excluded O
+		"01ARZ3NDEKTSV4RRFFQ69G5FAL",  // excluded L
+		"01ARZ3NDEKTSV4RRFFQ69G5FAU",  // excluded U
+		"01ARZ3NDEKTSV4RRFFQ69G5FAI",  // excluded I
+		"../../../etc/passwd/000000",   // path traversal attempt
+	}
+	for _, id := range invalid {
+		if IsValidULID(id) {
+			t.Errorf("IsValidULID(%q) = true, want false", id)
+		}
+	}
+}
+
 func TestNewULID_LexicographicOrder(t *testing.T) {
 	// Generate two ULIDs in sequence; the second must be >= the first.
 	// They share the same millisecond most of the time, so we check >=.

--- a/internal/federation/vclock.go
+++ b/internal/federation/vclock.go
@@ -1,5 +1,15 @@
 package federation
 
+import "fmt"
+
+// MaxVClockEntries caps the number of distinct cortex IDs in a merged
+// vector clock. A legitimate federation ring rarely exceeds a handful of
+// peers; a clock with hundreds of entries is a strong signal of a clock
+// inflation attack (a malicious peer injecting synthetic cortex IDs into
+// its event payloads). The cap prevents unbounded growth of the
+// federation_state row that is serialized on every mutation.
+const MaxVClockEntries = 256
+
 // VClock is a vector clock: one counter per known peer.
 type VClock map[string]uint64
 
@@ -29,6 +39,20 @@ func Merge(a, b VClock) VClock {
 		}
 	}
 	return result
+}
+
+// MergeCapped is like Merge but returns an error when the merged clock
+// would exceed MaxVClockEntries. Use this on the federation ingest path
+// to prevent a malicious peer from inflating the local clock with
+// synthetic cortex IDs.
+func MergeCapped(a, b VClock) (VClock, error) {
+	merged := Merge(a, b)
+	if len(merged) > MaxVClockEntries {
+		return nil, fmt.Errorf(
+			"vector clock too large (%d entries, max %d): possible clock inflation attack",
+			len(merged), MaxVClockEntries)
+	}
+	return merged, nil
 }
 
 // Compare returns the causal relationship between two clocks:

--- a/internal/federation/vclock_test.go
+++ b/internal/federation/vclock_test.go
@@ -1,6 +1,10 @@
 package federation
 
-import "testing"
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
 
 func TestVClock_Increment(t *testing.T) {
 	vc := VClock{"a": 5, "b": 3}
@@ -41,6 +45,34 @@ func TestMerge_DisjointKeys(t *testing.T) {
 	m := Merge(a, b)
 	if m["a"] != 5 || m["b"] != 3 {
 		t.Errorf("Merge = %v, want {a:5, b:3}", m)
+	}
+}
+
+func TestMergeCapped_UnderLimit(t *testing.T) {
+	a := VClock{"a": 1, "b": 2}
+	b := VClock{"c": 3}
+	merged, err := MergeCapped(a, b)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(merged) != 3 {
+		t.Errorf("len = %d, want 3", len(merged))
+	}
+}
+
+func TestMergeCapped_OverLimit(t *testing.T) {
+	a := make(VClock, MaxVClockEntries)
+	for i := range MaxVClockEntries {
+		a[fmt.Sprintf("peer-%d", i)] = uint64(i)
+	}
+	// b adds one more distinct key, pushing past the cap.
+	b := VClock{"attacker-injected": 1}
+	_, err := MergeCapped(a, b)
+	if err == nil {
+		t.Fatal("expected error for oversized clock, got nil")
+	}
+	if !strings.Contains(err.Error(), "too large") {
+		t.Errorf("error %q does not mention 'too large'", err.Error())
 	}
 }
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
 	"github.com/Fail-Safe/Noema/internal/cortex"
+	"github.com/Fail-Safe/Noema/internal/event"
 	"github.com/Fail-Safe/Noema/internal/federation"
 	"github.com/Fail-Safe/Noema/internal/trace"
 )
@@ -447,6 +449,10 @@ func NewServer(cx *cortex.Cortex, noemaVersion string, federationMode string) *s
 				"this cortex is in subscribe mode and does not serve events"), nil
 		}
 		since := req.GetString("since", "")
+		if since != "" && !event.IsValidULID(since) {
+			return mcp.NewToolResultError(
+				"since must be a valid ULID cursor (26-char Crockford base32)"), nil
+		}
 		limit := req.GetInt("limit", 100)
 		if limit <= 0 || limit > 1000 {
 			limit = 100
@@ -567,6 +573,16 @@ func NewServer(cx *cortex.Cortex, noemaVersion string, federationMode string) *s
 		endpoint, err := req.RequireString("endpoint")
 		if err != nil {
 			return nil, err
+		}
+
+		// Validate that the endpoint is a reachable HTTP(S) URL.
+		// Accepting arbitrary schemes (file://, javascript:, etc.)
+		// risks confusion if the value is later copy-pasted into
+		// federation config or rendered in status output.
+		u, parseErr := url.ParseRequestURI(endpoint)
+		if parseErr != nil || (u.Scheme != "http" && u.Scheme != "https") {
+			return mcp.NewToolResultError(
+				"endpoint must be a valid http:// or https:// URL"), nil
 		}
 
 		m, err := cortex.ReadManifest(cx.Dir)

--- a/tests/security-mcp-pentest-playbook.md
+++ b/tests/security-mcp-pentest-playbook.md
@@ -1,0 +1,317 @@
+# Security MCP Pentest Playbook
+
+**Target**: Noema MCP HTTP server
+**Transport**: Streamable HTTP with TLS
+**Scope**: Auth, CORS, input validation, federation, MCP protocol
+
+## Setup
+
+Before running scenarios, start a clean test server:
+
+```bash
+cd /workspace/testing
+rm -rf cortex/testcortex
+./files/noema init --name testcortex --path cortex/
+
+# Write access key
+printf 'test-bearer-token-12345\n' > cortex/testcortex/.access.secret
+chmod 600 cortex/testcortex/.access.secret
+
+# Add access block to cortex.md
+cat >> cortex/testcortex/cortex.md << 'MANIFEST'
+
+access:
+  shared_key_file: .access.secret
+MANIFEST
+
+# Start server in background
+NOEMA_MCP_KEY=test-bearer-token-12345 ./files/noema serve \
+  --cortex testcortex --transport http \
+  --host 127.0.0.1 --port 3000 \
+  --tls-cert /home/mark/.certs/fullchain.cer \
+  --tls-key /home/mark/.certs/home-dns.com.key &
+SERVER_PID=$!
+sleep 2
+```
+
+Set shared variables:
+
+```bash
+URL="https://127.0.0.1:3000/mcp"
+K="-k"  # trust self-signed cert
+AUTH="Authorization: Bearer test-bearer-token-12345"
+CT="Content-Type: application/json"
+```
+
+Helper for MCP tool calls:
+
+```bash
+mcp_call() {
+  local method="$1" params="$2"
+  curl $K -s -o /dev/null -w "%{http_code}" -X POST "$URL" \
+    -H "$CT" -H "$AUTH" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":\"1\",\"method\":\"$method\",\"params\":$params}"
+}
+mcp_body() {
+  local method="$1" params="$2"
+  curl $K -s -X POST "$URL" \
+    -H "$CT" -H "$AUTH" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":\"1\",\"method\":\"$method\",\"params\":$params}"
+}
+```
+
+---
+
+## Category A: Authentication
+
+**S01 — Missing Authorization header**
+```bash
+CODE=$(curl $K -s -o /dev/null -w "%{http_code}" -X POST "$URL" \
+  -H "$CT" \
+  -d '{"jsonrpc":"2.0","id":"1","method":"tools/list","params":{}}')
+[ "$CODE" = "401" ] && echo "[PASS] S01" || echo "[FAIL] S01 got $CODE"
+```
+Expected: 401
+
+**S02 — Empty bearer token**
+```bash
+CODE=$(curl $K -s -o /dev/null -w "%{http_code}" -X POST "$URL" \
+  -H "$CT" -H "Authorization: Bearer " \
+  -d '{"jsonrpc":"2.0","id":"1","method":"tools/list","params":{}}')
+[ "$CODE" = "401" ] && echo "[PASS] S02" || echo "[FAIL] S02 got $CODE"
+```
+Expected: 401
+
+**S03 — Wrong bearer token**
+```bash
+CODE=$(curl $K -s -o /dev/null -w "%{http_code}" -X POST "$URL" \
+  -H "$CT" -H "Authorization: Bearer wrong-token" \
+  -d '{"jsonrpc":"2.0","id":"1","method":"tools/list","params":{}}')
+[ "$CODE" = "401" ] && echo "[PASS] S03" || echo "[FAIL] S03 got $CODE"
+```
+Expected: 401
+
+**S04 — Token in query string (not supported)**
+```bash
+CODE=$(curl $K -s -o /dev/null -w "%{http_code}" -X POST "$URL?token=test-bearer-token-12345" \
+  -H "$CT" \
+  -d '{"jsonrpc":"2.0","id":"1","method":"tools/list","params":{}}')
+[ "$CODE" = "401" ] && echo "[PASS] S04" || echo "[FAIL] S04 got $CODE"
+```
+Expected: 401
+
+**S05 — Valid bearer token succeeds**
+```bash
+CODE=$(curl $K -s -o /dev/null -w "%{http_code}" -X POST "$URL" \
+  -H "$CT" -H "$AUTH" \
+  -d '{"jsonrpc":"2.0","id":"1","method":"tools/list","params":{}}')
+[ "$CODE" = "200" ] && echo "[PASS] S05" || echo "[FAIL] S05 got $CODE"
+```
+Expected: 200
+
+**S06 — Lowercase "bearer" scheme rejected**
+```bash
+CODE=$(curl $K -s -o /dev/null -w "%{http_code}" -X POST "$URL" \
+  -H "$CT" -H "Authorization: bearer test-bearer-token-12345" \
+  -d '{"jsonrpc":"2.0","id":"1","method":"tools/list","params":{}}')
+[ "$CODE" = "401" ] && echo "[PASS] S06" || echo "[FAIL] S06 got $CODE"
+```
+Expected: 401
+
+**S07 — Token not leaked in 401 response body**
+```bash
+BODY=$(curl $K -s -X POST "$URL" \
+  -H "$CT" -H "Authorization: Bearer my-secret-token-probe" \
+  -d '{"jsonrpc":"2.0","id":"1","method":"tools/list","params":{}}')
+echo "$BODY" | grep -q "my-secret-token-probe" && echo "[FAIL] S07 token leaked" || echo "[PASS] S07"
+```
+Expected: token not present in response
+
+---
+
+## Category B: CORS
+
+**S08 — OPTIONS preflight succeeds without auth**
+```bash
+CODE=$(curl $K -s -o /dev/null -w "%{http_code}" -X OPTIONS "$URL" \
+  -H "Origin: https://evil.example.com" \
+  -H "Access-Control-Request-Method: POST" \
+  -H "Access-Control-Request-Headers: authorization,content-type")
+[ "$CODE" = "204" ] && echo "[PASS] S08" || echo "[FAIL] S08 got $CODE"
+```
+Expected: 204
+
+**S09 — CORS headers on preflight response**
+```bash
+HEADERS=$(curl $K -s -D - -o /dev/null -X OPTIONS "$URL" \
+  -H "Origin: https://evil.example.com" \
+  -H "Access-Control-Request-Method: POST" \
+  -H "Access-Control-Request-Headers: authorization,content-type")
+echo "$HEADERS" | grep -qi "access-control-allow-origin" && echo "[PASS] S09" || echo "[FAIL] S09"
+```
+Expected: Access-Control-Allow-Origin header present
+
+**S10 — CORS headers present on 401**
+```bash
+HEADERS=$(curl $K -s -D - -o /dev/null -X POST "$URL" \
+  -H "Origin: https://evil.example.com" -H "$CT" \
+  -d '{"jsonrpc":"2.0","id":"1","method":"tools/list","params":{}}')
+echo "$HEADERS" | grep -qi "access-control-allow-origin" && echo "[PASS] S10" || echo "[FAIL] S10"
+```
+Expected: CORS headers present even on auth failure
+
+---
+
+## Category C: Input Validation
+
+**S11 — Path traversal in trace ID**
+```bash
+BODY=$(mcp_body "call_tool" '{"name":"get_trace","arguments":{"id":"../../../etc/passwd"}}')
+echo "$BODY" | grep -qi "error\|not found\|invalid" && echo "[PASS] S11" || echo "[FAIL] S11"
+```
+Expected: error or not found, never file contents
+
+**S12 — Path traversal in trace title**
+```bash
+BODY=$(mcp_body "call_tool" '{"name":"create_trace","arguments":{"title":"../../etc/cron","type":"note","body":"test"}}')
+# Verify no file written outside cortex
+ls /workspace/testing/cortex/testcortex/traces/ | head -5
+[ ! -f "/workspace/testing/etc/cron.md" ] && echo "[PASS] S12" || echo "[FAIL] S12 file escaped cortex"
+```
+Expected: file stays within traces/ directory
+
+**S13 — SQL injection in search query**
+```bash
+BODY=$(mcp_body "call_tool" '{"name":"search_traces","arguments":{"query":"foo\"; DROP TABLE traces; --"}}')
+# Verify database is intact by listing traces
+BODY2=$(mcp_body "call_tool" '{"name":"list_traces","arguments":{}}')
+echo "$BODY2" | grep -qi "error" && echo "[FAIL] S13 DB may be damaged" || echo "[PASS] S13"
+```
+Expected: search completes normally, database intact
+
+**S14 — Null bytes in trace title**
+```bash
+BODY=$(mcp_body "call_tool" "{\"name\":\"create_trace\",\"arguments\":{\"title\":\"test\\u0000evil\",\"type\":\"note\",\"body\":\"test\"}}")
+echo "$BODY" | grep -qi "error\|invalid" && echo "[PASS] S14 rejected null" || echo "[INFO] S14 accepted (check trace ID format)"
+```
+Expected: rejected or sanitized
+
+**S15 — Invalid trace type**
+```bash
+BODY=$(mcp_body "call_tool" '{"name":"create_trace","arguments":{"title":"test","type":"MALICIOUS_TYPE","body":"test"}}')
+echo "$BODY" | grep -qi "error\|invalid\|unknown" && echo "[PASS] S15" || echo "[FAIL] S15 accepted bad type"
+```
+Expected: rejected with validation error
+
+**S16 — Oversized trace body (5 MB)**
+```bash
+BIGBODY=$(python3 -c "print('A' * 5242880)")
+CODE=$(curl $K -s -o /dev/null -w "%{http_code}" -X POST "$URL" \
+  -H "$CT" -H "$AUTH" \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":\"1\",\"method\":\"call_tool\",\"params\":{\"name\":\"create_trace\",\"arguments\":{\"title\":\"big\",\"type\":\"note\",\"body\":\"$BIGBODY\"}}}")
+echo "S16: HTTP $CODE (should not crash server)"
+# Verify server still responds
+CODE2=$(mcp_call "tools/list" '{}')
+[ "$CODE2" = "200" ] && echo "[PASS] S16 server survived" || echo "[FAIL] S16 server down"
+```
+Expected: server handles gracefully and stays alive
+
+---
+
+## Category D: Federation
+
+**S17 — Self-name collision in announce_peer**
+```bash
+# Get local cortex name
+IDENTITY=$(mcp_body "call_tool" '{"name":"cortex_identity","arguments":{}}')
+echo "Local identity: $IDENTITY"
+
+BODY=$(mcp_body "call_tool" '{"name":"announce_peer","arguments":{"name":"testcortex","endpoint":"https://evil.example.com"}}')
+echo "$BODY" | grep -qi "error\|collision\|matches\|own name" && echo "[PASS] S17" || echo "[FAIL] S17 self-collision not detected"
+```
+Expected: rejected with name collision error
+
+**S18 — Valid peer announcement**
+```bash
+BODY=$(mcp_body "call_tool" '{"name":"announce_peer","arguments":{"name":"legit-peer","endpoint":"https://legit-peer.example.com"}}')
+echo "$BODY" | grep -qi "acknowledged\|Acknowledged" && echo "[PASS] S18" || echo "[FAIL] S18"
+```
+Expected: acknowledged
+
+---
+
+## Category E: MCP Protocol
+
+**S19 — Malformed JSON**
+```bash
+CODE=$(curl $K -s -o /dev/null -w "%{http_code}" -X POST "$URL" \
+  -H "$CT" -H "$AUTH" \
+  -d '{this is not json}')
+echo "S19: HTTP $CODE"
+[ "$CODE" = "400" ] || [ "$CODE" = "200" ] && echo "[PASS] S19" || echo "[FAIL] S19"
+```
+Expected: 400 or JSON-RPC error response
+
+**S20 — Missing method field**
+```bash
+BODY=$(curl $K -s -X POST "$URL" \
+  -H "$CT" -H "$AUTH" \
+  -d '{"jsonrpc":"2.0","id":"1","params":{}}')
+echo "$BODY" | grep -qi "error" && echo "[PASS] S20" || echo "[FAIL] S20"
+```
+Expected: JSON-RPC error
+
+**S21 — Unknown method name**
+```bash
+BODY=$(curl $K -s -X POST "$URL" \
+  -H "$CT" -H "$AUTH" \
+  -d '{"jsonrpc":"2.0","id":"1","method":"call_tool","params":{"name":"drop_database","arguments":{}}}')
+echo "$BODY" | grep -qi "error\|not found\|unknown" && echo "[PASS] S21" || echo "[FAIL] S21"
+```
+Expected: error
+
+**S22 — Missing required tool params**
+```bash
+BODY=$(mcp_body "call_tool" '{"name":"get_trace","arguments":{}}')
+echo "$BODY" | grep -qi "error\|required\|missing" && echo "[PASS] S22" || echo "[FAIL] S22"
+```
+Expected: error about missing id parameter
+
+**S23 — Non-/mcp path returns 404**
+```bash
+CODE=$(curl $K -s -o /dev/null -w "%{http_code}" -X POST "https://127.0.0.1:3000/admin" \
+  -H "$CT" -H "$AUTH")
+[ "$CODE" = "404" ] && echo "[PASS] S23" || echo "[FAIL] S23 got $CODE"
+```
+Expected: 404
+
+**S24 — GET on /mcp without session**
+```bash
+CODE=$(curl $K -s -o /dev/null -w "%{http_code}" -X GET "$URL" \
+  -H "$AUTH")
+echo "S24: HTTP $CODE (GET without session)"
+# mcp-go may return 400 or 405 for GET without Mcp-Session-Id
+[ "$CODE" != "200" ] && echo "[PASS] S24" || echo "[INFO] S24 returned 200 (check if streaming)"
+```
+Expected: non-200 or SSE stream
+
+---
+
+## Teardown
+
+```bash
+kill $SERVER_PID 2>/dev/null
+rm -rf /workspace/testing/cortex/testcortex
+echo "Teardown complete"
+```
+
+---
+
+## Verdict Summary
+
+Record results as:
+- **[PASS]** — scenario behaved as expected
+- **[FAIL]** — unexpected behavior, potential vulnerability
+- **[SKIP]** — could not execute (missing prereq, server config)
+
+Save results to `/workspace/testing/results/security-mcp-pentest-YYYYMMDD-HHMMSS.md`


### PR DESCRIPTION
## Summary
Five fixes from a static security review targeting the HTTP transport, federation protocol, and search query sanitizer:

- **Slowloris mitigation**: add `ReadTimeout` (60s) and `WriteTimeout` (120s) to all HTTP listeners
- **announce_peer URL validation**: reject non-http/https endpoint schemes
- **Vector clock size cap**: `MergeCapped` rejects merges exceeding 256 entries to prevent clock inflation attacks
- **FTS5 unbalanced quote safety**: strip all quotes when count is odd, preventing syntax errors that leak raw queries
- **sync_events cursor validation**: `since` parameter must be a valid 26-char Crockford base32 ULID

Also includes a 24-scenario security pentest playbook for runtime testing.

## Test plan
- [x] `TestMergeCapped_UnderLimit` / `TestMergeCapped_OverLimit` — vector clock cap
- [x] `TestIsValidULID` — ULID validation (valid + invalid cases)
- [x] `TestSanitizeFTS5Query` — unbalanced quote cases added
- [x] Full test suite passes (`go test ./...`)
- [x] Runtime pentest playbook (24 scenarios)

🤖 Generated with [Claude Code](https://claude.com/claude-code)