### PR TITLE
chore: sync next with main (catch up on 9 commits)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,5 @@
 .vscode/
 
 # Local dev
+.claude/layout.md
 push-binary.sh
-docs/design/

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@
 # Local MCP config (machine-specific paths)
 .mcp.json
 
+# Caches
+**/__pycache__
+.pytest_cache
+
 # Editor
 *.swp
 *.swo

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -29,6 +29,8 @@ project_name: noema
 before:
   hooks:
     - go mod tidy
+    # Bundle the Hermes memory provider plugin as a release asset.
+    - tar -czf noema-hermes-plugin.tar.gz -C plugins hermes
 
 builds:
   - id: noema
@@ -119,6 +121,8 @@ release:
     until v1.0. Cortex data on disk is forward-compatible via
     non-destructive migrations; on-disk `cortex.md` version bumps that
     require a manual step ship with an explicit `noema migrate` command.**
+  extra_files:
+    - glob: ./noema-hermes-plugin.tar.gz
   footer: |
     ---
     **Install:** see [README — Installation](https://github.com/Fail-Safe/Noema#installation).

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -126,7 +126,7 @@ release:
 
 # Homebrew publishing — dual strategy: formula + cask.
 #
-# Both blocks target the same tap repo (Fail-Safe/homebrew-noema) and the
+# Both blocks target the same tap repo (Fail-Safe/homebrew-tap) and the
 # same bearer token (HOMEBREW_TAP_TOKEN in the Noema repo's Actions
 # secrets). The two blocks write to different subdirectories of the tap:
 # Formula/noema.rb for `brews:`, Casks/noema.rb for `homebrew_casks:`.
@@ -169,7 +169,7 @@ brews:
   - name: noema
     repository:
       owner: Fail-Safe
-      name: homebrew-noema
+      name: homebrew-tap
       branch: main
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     directory: Formula
@@ -196,7 +196,7 @@ homebrew_casks:
       - noema
     repository:
       owner: Fail-Safe
-      name: homebrew-noema
+      name: homebrew-tap
       branch: main
       token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
     directory: Casks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,16 @@ CLI: `noema verify` checks all trace file hashes against their frontmatter `cont
 
 The MCP server (`internal/mcp/server.go`) exposes the full Cortex surface: `get_instructions`, `list_traces`, `get_trace`, `create_trace`, `update_trace`, `append_trace`, `delete_trace`, `recover_trace`, `archive_trace`, `unarchive_trace`, `search_traces`, `trace_history`, `trace_lineage`, `resolve_divergence`, `cortex_identity`, `sync_events`, `federation_status`, and `announce_peer`. The `get_instructions` tool returns a live reference guide for the active Cortex; agents should call it first in any new session. `cortex_identity` returns the stable ULID + display name + manifest version and is called by federation peers on every sync to verify the remote endpoint still belongs to the cortex they paired with.
 
+### Hermes Memory Provider Plugin
+
+A Python plugin at `plugins/hermes/` implements the Hermes `MemoryProvider` ABC, letting any [Hermes](https://hermes-agent.nousresearch.com/) agent use a Noema Cortex as its memory backend. The plugin communicates with Noema via MCP (JSON-RPC 2.0 over stdio or HTTP) — it does not import any Go code.
+
+**Files:** `__init__.py` (NoemaMemoryProvider + register()), `transport.py` (StdioTransport, HttpTransport), `plugin.yaml` (metadata), `README.md` (setup).
+
+**Agent-facing tools:** `noema_search`, `noema_remember`, `noema_recall`, `noema_list`, `noema_update`, `noema_lineage` — mapped to `search_traces`, `create_trace`, `get_trace`, `list_traces`, `update_trace`, `trace_lineage` respectively.
+
+**Internal tools used:** `get_instructions` (system prompt), `cortex_identity` (connectivity check), `append_trace` (session log), `archive_trace` (session end).
+
 ### DB Schema Migrations
 
 Schema changes must always be transparent and non-destructive. Rules:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,13 +146,13 @@ Federation is opt-in via a `federation:` block in `cortex.md` (peers + interval)
 | `publish` | No | Yes | Blocked (read-only for remote peers) |
 | `subscribe` | Yes | Blocked | Yes |
 
-In publish mode, mutating MCP tools (`create_trace`, `update_trace`, `delete_trace`, `recover_trace`, `archive_trace`, `unarchive_trace`, `resolve_divergence`) return a clear error on the HTTP transport. The local stdio transport retains full write access so operators can manage content locally. In subscribe mode, `sync_events` returns an error so remote peers cannot pull events from this cortex.
+In publish mode, mutating MCP tools (`create_trace`, `update_trace`, `append_trace`, `delete_trace`, `recover_trace`, `archive_trace`, `unarchive_trace`, `resolve_divergence`) return a clear error on the HTTP transport. The local stdio transport retains full write access so operators can manage content locally. In subscribe mode, `sync_events` returns an error so remote peers cannot pull events from this cortex.
 
 Each peer can also declare `mode: paused` to temporarily skip syncing without losing cursor/identity state. CLI commands: `noema federation set-mode <sync|publish|subscribe>`, `noema federation pause-peer <name>`, `noema federation resume-peer <name>`.
 
 The full design rationale, edge cases, and phase breakdown live in `docs/design/federation-plan.md`.
 
-**Content hashing and source-locking.** Every trace mutation (`Add`, `Update`) computes a SHA-256 hash of the body (`sha256:<hex>`) and stores it in the `content_hash` frontmatter field and DB column. The hash travels through federation events so peers receive it. Three frontmatter fields support integrity:
+**Content hashing and source-locking.** Every trace mutation (`Add`, `Update`, `Append`) computes a SHA-256 hash of the body (`sha256:<hex>`) and stores it in the `content_hash` frontmatter field and DB column. The hash travels through federation events so peers receive it. Three frontmatter fields support integrity:
 
 - `content_hash` — current body hash, recomputed on every write
 - `source_hash` — the origin's `content_hash` at publish time, carried through federation
@@ -166,7 +166,7 @@ CLI: `noema verify` checks all trace file hashes against their frontmatter `cont
 
 ### MCP Tools
 
-The MCP server (`internal/mcp/server.go`) exposes the full Cortex surface: `get_instructions`, `list_traces`, `get_trace`, `create_trace`, `update_trace`, `delete_trace`, `recover_trace`, `archive_trace`, `unarchive_trace`, `search_traces`, `trace_history`, `trace_lineage`, `resolve_divergence`, `cortex_identity`, `sync_events`, `federation_status`, and `announce_peer`. The `get_instructions` tool returns a live reference guide for the active Cortex; agents should call it first in any new session. `cortex_identity` returns the stable ULID + display name + manifest version and is called by federation peers on every sync to verify the remote endpoint still belongs to the cortex they paired with.
+The MCP server (`internal/mcp/server.go`) exposes the full Cortex surface: `get_instructions`, `list_traces`, `get_trace`, `create_trace`, `update_trace`, `append_trace`, `delete_trace`, `recover_trace`, `archive_trace`, `unarchive_trace`, `search_traces`, `trace_history`, `trace_lineage`, `resolve_divergence`, `cortex_identity`, `sync_events`, `federation_status`, and `announce_peer`. The `get_instructions` tool returns a live reference guide for the active Cortex; agents should call it first in any new session. `cortex_identity` returns the stable ULID + display name + manifest version and is called by federation peers on every sync to verify the remote endpoint still belongs to the cortex they paired with.
 
 ### DB Schema Migrations
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+Also read .claude/layout.md when it exists.
+
 ## Project
 
 **Noema** — "The intentional memory layer for your AI agents."
@@ -29,7 +31,8 @@ go vet ./...           # static analysis
 ## Branch Strategy
 
 - `main` is the stable/release branch
-- Use a `dev` or `next` branch for active feature work; PRs go feature-branch → `main`
+- Use a `feature` or `bug` branch for active work; PRs go feature/bug-branch → `next`
+- Use a `next` branch for staging/testing upcoming (beta) work; PRs go `next` → `main`
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -618,6 +618,30 @@ Each agent identifies itself via the `author` field when creating Traces. Filter
 
 ---
 
+## Hermes Integration
+
+Noema ships a [Hermes](https://hermes-agent.nousresearch.com/) memory provider plugin in `plugins/hermes/`. It implements the Hermes `MemoryProvider` ABC so any Hermes agent can use a Noema Cortex as its memory backend — structured traces with types, tags, lineage, and full-text search, all through the standard Hermes lifecycle hooks.
+
+**Quick setup:**
+
+```bash
+# Download the plugin from the latest release
+curl -LO https://github.com/Fail-Safe/Noema/releases/latest/download/noema-hermes-plugin.tar.gz
+mkdir -p <hermes-install>/plugins/memory/noema
+tar -xzf noema-hermes-plugin.tar.gz -C <hermes-install>/plugins/memory/noema/
+
+# Configure
+hermes memory setup    # select "noema", provide your cortex name
+```
+
+The plugin exposes six tools to the agent (`noema_search`, `noema_remember`, `noema_recall`, `noema_list`, `noema_update`, `noema_lineage`), manages a session log trace across turns, creates a summary trace at session end, and mirrors Hermes built-in memory writes as Noema traces.
+
+By default the plugin spawns `noema serve --transport stdio` as a subprocess — no network config needed. For remote cortexes or multi-agent setups, set `transport=http` to connect to an already-running HTTP endpoint.
+
+See [`plugins/hermes/README.md`](plugins/hermes/README.md) for full configuration and usage details.
+
+---
+
 ## License
 
 MIT — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@
   </picture>
 </p>
 
+<p align="center">
+  <a href="https://github.com/Fail-Safe/Noema/actions/workflows/ci.yml"><img src="https://github.com/Fail-Safe/Noema/actions/workflows/ci.yml/badge.svg?branch=main" alt="CI"></a>
+  <a href="https://github.com/Fail-Safe/Noema/releases/latest"><img src="https://img.shields.io/github/v/release/Fail-Safe/Noema" alt="Latest Release"></a>
+  <a href="https://github.com/Fail-Safe/Noema/blob/main/go.mod"><img src="https://img.shields.io/github/go-mod/go-version/Fail-Safe/Noema" alt="Go Version"></a>
+  <a href="https://github.com/Fail-Safe/Noema/blob/main/LICENSE"><img src="https://img.shields.io/github/license/Fail-Safe/Noema" alt="License"></a>
+</p>
+
 **The intentional memory layer for your AI agents.**
 
 Noema gives AI agents — and the humans working alongside them — a persistent, structured place to record what they know, decide, observe, and intend. Every memory is a plain markdown file. The index is a local SQLite database. Nothing lives in the cloud; nothing requires an API key.
@@ -248,6 +255,7 @@ Noema can run as an [MCP](https://modelcontextprotocol.io) server, giving any MC
 | `get_trace` | Fetch a trace's full body, origin, and lineage |
 | `create_trace` | Create a new trace (supports `derived_from`, `origin`) |
 | `update_trace` | Update any subset of fields on an existing trace |
+| `append_trace` | Append content to an existing trace without reading it first (fire-and-forget logging) |
 | `search_traces` | FTS5 full-text search |
 | `archive_trace` / `unarchive_trace` | Archive a trace or restore it |
 | `delete_trace` / `recover_trace` | Soft-delete (move to trash) or restore from trash |

--- a/README.md
+++ b/README.md
@@ -45,19 +45,19 @@ A Trace has a **type** that describes its intent:
 
 ### With Homebrew (macOS + Linux)
 
-The fastest path. One command taps `Fail-Safe/homebrew-noema` and
+The fastest path. One command taps `Fail-Safe/homebrew-tap` and
 installs the cross-platform formula covering `darwin/{amd64,arm64}`
 and `linux/{amd64,arm64}`:
 
 ```bash
-brew install Fail-Safe/noema/noema
+brew install Fail-Safe/tap/noema
 ```
 
 On macOS a cask is also published for users who prefer the cask
 ecosystem:
 
 ```bash
-brew install --cask Fail-Safe/noema/noema
+brew install --cask Fail-Safe/tap/noema
 ```
 
 > The formula path is the default on macOS — when a tap contains both a
@@ -68,7 +68,7 @@ brew install --cask Fail-Safe/noema/noema
 Prefer the two-step form? It works the same:
 
 ```bash
-brew tap Fail-Safe/noema
+brew tap Fail-Safe/tap
 brew install noema          # formula (macOS + Linux)
 brew install --cask noema   # cask (macOS only)
 ```

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Please do not open a public GitHub Issue for security vulnerabilities.**
+
+Instead, use GitHub's private vulnerability reporting:
+
+1. Go to [Report a vulnerability](https://github.com/Fail-Safe/Noema/security/advisories/new)
+2. Fill in a description of the issue, steps to reproduce, and any affected versions
+3. Submit — this creates a private advisory visible only to you and the maintainers
+
+You will receive a response acknowledging the report within 72 hours. Fixes for confirmed vulnerabilities are prioritized and shipped as patch releases.
+
+## Scope
+
+Noema is pre-1.0 software. The following areas are in scope for security reports:
+
+- Path traversal or file-system escapes (e.g. via crafted trace IDs or federation events)
+- Authentication bypass on the keyed HTTP transport
+- Federation event replay attacks (hash forgery, source-lock abuse, payload injection)
+- SQL injection or FTS5 query injection
+- TLS configuration weaknesses in the MCP HTTP server
+- Denial of service via unbounded input (query length, payload size, connection exhaustion)
+
+Out of scope:
+
+- Vulnerabilities that require local filesystem access to the cortex directory (Noema trusts the local operator)
+- Issues in dependencies — please report those upstream, but feel free to flag them here if Noema's usage makes the issue exploitable
+
+## Supported Versions
+
+Only the latest release is actively supported with security patches. Upgrade to the latest version before reporting.

--- a/internal/cli/cmd_migrate_test.go
+++ b/internal/cli/cmd_migrate_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"database/sql"
 	"encoding/json"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -14,6 +15,20 @@ import (
 	"github.com/Fail-Safe/Noema/internal/trace"
 )
 
+// sandboxConfigHome redirects HOME and XDG_CONFIG_HOME to a temp directory
+// so that config.Save() writes into the test's sandbox instead of the real
+// user config. Without this, tests that call runCortexIDMigration overwrite
+// ~/Library/Application Support/noema/config.yaml (macOS) or
+// ~/.config/noema/config.yaml (Linux) with test data.
+func sandboxConfigHome(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	// Ensure the noema config directory exists so Save() doesn't fail.
+	os.MkdirAll(filepath.Join(home, ".config", "noema"), 0o750)
+}
+
 // setupV1Cortex builds a fresh v2 cortex (the only kind cortex.Create knows
 // how to write) and then degrades it back to v1 in place: clears the manifest
 // id, drops the version to 1, blanks every cortex_id column, and replaces the
@@ -21,6 +36,7 @@ import (
 // stand-in for a cortex written by an older binary.
 func setupV1Cortex(t *testing.T, name string) (dir string, traceID string) {
 	t.Helper()
+	sandboxConfigHome(t)
 	parent := t.TempDir()
 	if _, err := cortex.Create(name, parent); err != nil {
 		t.Fatalf("Create: %v", err)
@@ -167,6 +183,7 @@ func TestMigrateCortexID_HappyPath(t *testing.T) {
 }
 
 func TestMigrateCortexID_Idempotent(t *testing.T) {
+	sandboxConfigHome(t)
 	const name = "already-migrated"
 	parent := t.TempDir()
 	if _, err := cortex.Create(name, parent); err != nil {

--- a/internal/cli/cmd_serve.go
+++ b/internal/cli/cmd_serve.go
@@ -188,7 +188,9 @@ func serveCmd() *cobra.Command {
 					srv := &http.Server{
 						Addr:              addr,
 						Handler:           mux,
+						ReadTimeout:       60 * time.Second,
 						ReadHeaderTimeout: 30 * time.Second,
+						WriteTimeout:      120 * time.Second,
 						IdleTimeout:       120 * time.Second,
 					}
 					servers = append(servers, srv)

--- a/internal/cli/cmd_serve.go
+++ b/internal/cli/cmd_serve.go
@@ -154,8 +154,10 @@ func serveCmd() *cobra.Command {
 				mux.Handle("/mcp", wrapped)
 
 				httpSrv := &http.Server{
-					Addr:    addr,
-					Handler: mux,
+					Addr:              addr,
+					Handler:           mux,
+					ReadHeaderTimeout: 30 * time.Second,
+					IdleTimeout:       120 * time.Second,
 				}
 
 				scheme := "http"

--- a/internal/cli/cmd_serve.go
+++ b/internal/cli/cmd_serve.go
@@ -25,7 +25,7 @@ import (
 func serveCmd() *cobra.Command {
 	var (
 		transport         string
-		host              string
+		hosts             []string
 		port              int
 		tlsCert           string
 		tlsKey            string
@@ -40,13 +40,34 @@ func serveCmd() *cobra.Command {
 		Aliases: []string{"server"},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if printConfig {
-				return runPrintMCPConfig(cmd.OutOrStdout(), transport, host, port, tlsCert, tlsKey)
+				return runPrintMCPConfig(cmd.OutOrStdout(), transport, hosts, port, tlsCert, tlsKey)
 			}
 			if printSystemdUnit {
-				return runPrintSystemdUnit(cmd.OutOrStdout(), transport, host, port, tlsCert, tlsKey)
+				return runPrintSystemdUnit(cmd.OutOrStdout(), transport, hosts, port, tlsCert, tlsKey)
 			}
 			if printLaunchdPlist {
-				return runPrintLaunchdPlist(cmd.OutOrStdout(), transport, host, port, tlsCert, tlsKey)
+				return runPrintLaunchdPlist(cmd.OutOrStdout(), transport, hosts, port, tlsCert, tlsKey)
+			}
+
+			// HTTP-only flags (--host/--port/--tls-cert/--tls-key) are
+			// meaningless in stdio mode, and silently ignoring them is
+			// exactly the footgun that eats operator time: you pass
+			// --host/--port expecting a listener, the process sits
+			// reading JSON-RPC from stdin, and netstat shows nothing.
+			// Check this BEFORE resolveCortex so the error fires even
+			// when the cortex is in some broken state — the flag mistake
+			// is independent of cortex health and diagnosing it first
+			// saves the operator from chasing the wrong problem.
+			if transport == "stdio" || transport == "" {
+				f := cmd.Flags()
+				if err := guardStdioFlags(
+					f.Changed("host"),
+					f.Changed("port"),
+					f.Changed("tls-cert"),
+					f.Changed("tls-key"),
+				); err != nil {
+					return err
+				}
 			}
 
 			cx, err := resolveCortex()
@@ -91,7 +112,7 @@ func serveCmd() *cobra.Command {
 						cortex.AccessKeyEnvVar, accessKey.Path)
 				}
 
-				if err := validateHTTPServe(host, tlsCert, tlsKey, cx.Name, cortexFlag != ""); err != nil {
+				if err := validateHTTPServe(hosts, tlsCert, tlsKey, cx.Name, cortexFlag != ""); err != nil {
 					return err
 				}
 				useTLS := tlsCert != "" && tlsKey != ""
@@ -125,13 +146,6 @@ func serveCmd() *cobra.Command {
 					fmt.Fprintf(os.Stderr, "[serve] access=open\n")
 				}
 
-				// IPv6 addresses need brackets in listen addresses.
-				hostForAddr := host
-				if ip := net.ParseIP(host); ip != nil && ip.To4() == nil {
-					hostForAddr = "[" + host + "]"
-				}
-				addr := fmt.Sprintf("%s:%d", hostForAddr, port)
-
 				// Build the MCP handler. No WithEndpointPath — our
 				// own mux routes /mcp. No WithTLSCert — we drive
 				// ListenAndServeTLS ourselves so the middleware chain
@@ -153,22 +167,47 @@ func serveCmd() *cobra.Command {
 				mux := http.NewServeMux()
 				mux.Handle("/mcp", wrapped)
 
-				httpSrv := &http.Server{
-					Addr:              addr,
-					Handler:           mux,
-					ReadHeaderTimeout: 30 * time.Second,
-					IdleTimeout:       120 * time.Second,
-				}
-
 				scheme := "http"
 				if useTLS {
 					scheme = "https"
 				}
-				fmt.Fprintf(os.Stderr, "Starting Streamable HTTP server on %s://%s/mcp\n", scheme, addr)
-				if useTLS {
-					err = httpSrv.ListenAndServeTLS(tlsCert, tlsKey)
-				} else {
-					err = httpSrv.ListenAndServe()
+
+				// Start one HTTP listener per --host address. All
+				// share the same mux (same auth, same handler). The
+				// first fatal error from any listener stops the
+				// process; remaining listeners are closed on the way
+				// out. This lets a single `noema serve` bind to both
+				// a private ring address and a LAN address.
+				var servers []*http.Server
+				for _, h := range hosts {
+					hostForAddr := h
+					if ip := net.ParseIP(h); ip != nil && ip.To4() == nil {
+						hostForAddr = "[" + h + "]"
+					}
+					addr := fmt.Sprintf("%s:%d", hostForAddr, port)
+					srv := &http.Server{
+						Addr:              addr,
+						Handler:           mux,
+						ReadHeaderTimeout: 30 * time.Second,
+						IdleTimeout:       120 * time.Second,
+					}
+					servers = append(servers, srv)
+					fmt.Fprintf(os.Stderr, "Starting Streamable HTTP server on %s://%s/mcp\n", scheme, addr)
+				}
+
+				errCh := make(chan error, len(servers))
+				for _, srv := range servers {
+					go func() {
+						if useTLS {
+							errCh <- srv.ListenAndServeTLS(tlsCert, tlsKey)
+						} else {
+							errCh <- srv.ListenAndServe()
+						}
+					}()
+				}
+				err = <-errCh
+				for _, srv := range servers {
+					srv.Close()
 				}
 			case "sse":
 				err = fmt.Errorf(
@@ -187,7 +226,7 @@ func serveCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&transport, "transport", "stdio", "transport: stdio or http (Streamable HTTP, MCP 2025-03-26)")
-	cmd.Flags().StringVar(&host, "host", "", "listen address for HTTP transport (required, e.g. 127.0.0.1 or LAN IP)")
+	cmd.Flags().StringArrayVar(&hosts, "host", nil, "listen address for HTTP transport (repeatable, e.g. --host 10.0.0.1 --host 192.168.1.1)")
 	cmd.Flags().IntVar(&port, "port", 3000, "port for HTTP transport")
 	cmd.Flags().StringVar(&tlsCert, "tls-cert", "", "path to TLS certificate file (enables HTTPS)")
 	cmd.Flags().StringVar(&tlsKey, "tls-key", "", "path to TLS private key file")
@@ -250,6 +289,50 @@ func requireTLSForKeyedMode(access cortex.AccessKey, useTLS bool) error {
 	)
 }
 
+// guardStdioFlags returns an error when any HTTP-only flag was explicitly
+// passed on the command line while transport is stdio. It exists because
+// the default transport is stdio, and an operator who forgets --transport
+// http will see their --host/--port/--tls-* flags silently ignored — the
+// process then sits reading JSON-RPC from stdin while netstat shows no
+// listener, which is a miserable diagnostic loop. Failing at startup
+// with the list of offending flags short-circuits that loop.
+//
+// Parameters are bools (cobra's Flags().Changed()) rather than the raw
+// values so the check is about *explicit operator intent*, not about
+// the flag values themselves: --port has a non-zero default (3000), so a
+// value check would fire on every stdio invocation. Only flags the user
+// actually typed count as a conflict.
+func guardStdioFlags(hostSet, portSet, tlsCertSet, tlsKeySet bool) error {
+	var flags []string
+	if hostSet {
+		flags = append(flags, "--host")
+	}
+	if portSet {
+		flags = append(flags, "--port")
+	}
+	if tlsCertSet {
+		flags = append(flags, "--tls-cert")
+	}
+	if tlsKeySet {
+		flags = append(flags, "--tls-key")
+	}
+	if len(flags) == 0 {
+		return nil
+	}
+	verb := "is"
+	if len(flags) > 1 {
+		verb = "are"
+	}
+	return fmt.Errorf(
+		"%s %s only meaningful with --transport http.\n"+
+			"  noema serve defaults to stdio, which reads JSON-RPC from stdin\n"+
+			"  and has no network endpoint to bind. Re-run with --transport http,\n"+
+			"  or remove the flag(s).",
+		strings.Join(flags, ", "),
+		verb,
+	)
+}
+
 // validateHTTPServe enforces the flag invariants for `noema serve --transport
 // http`. It is split out from RunE so the explicit-cortex requirement (the
 // most common federation footgun) can be unit-tested without standing up an
@@ -264,25 +347,31 @@ func requireTLSForKeyedMode(access cortex.AccessKey, useTLS bool) error {
 // specific identity. The peer-side handshake catches the resulting mismatch
 // but only logs the failure on the OTHER host, which is the diagnostic
 // asymmetry this guard exists to prevent.
-func validateHTTPServe(host, tlsCert, tlsKey, cortexName string, cortexExplicit bool) error {
-	if host == "" {
+func validateHTTPServe(hosts []string, tlsCert, tlsKey, cortexName string, cortexExplicit bool) error {
+	if len(hosts) == 0 {
 		return fmt.Errorf("--host is required for HTTP transport (e.g. --host 10.0.0.1 or --host 127.0.0.1)")
 	}
-	if ip := net.ParseIP(host); ip != nil && ip.IsUnspecified() {
-		return fmt.Errorf("binding to %s is not allowed — it may expose your cortex to the network.\n  Use an explicit address: --host 127.0.0.1 (local only) or --host <your-lan-ip> (federation)", host)
+	for _, host := range hosts {
+		if ip := net.ParseIP(host); ip != nil && ip.IsUnspecified() {
+			return fmt.Errorf("binding to %s is not allowed — it may expose your cortex to the network.\n  Use an explicit address: --host 127.0.0.1 (local only) or --host <your-lan-ip> (federation)", host)
+		}
 	}
 	if (tlsCert == "") != (tlsKey == "") {
 		return fmt.Errorf("--tls-cert and --tls-key must be provided together")
 	}
 	if !cortexExplicit {
+		var hostFlags string
+		for _, h := range hosts {
+			hostFlags += " --host " + h
+		}
 		return fmt.Errorf(
 			"refusing to start HTTP server on cortex %q without an explicit --cortex flag.\n"+
 				"  The HTTP transport exposes this cortex's event stream to the network.\n"+
 				"  Inheriting the cortex from NOEMA_CORTEX or the config default makes it\n"+
 				"  easy to bind the wrong one — and on a host where peers are pinned to a\n"+
 				"  specific identity, that produces silent failures on the peer side.\n"+
-				"  Re-run with: noema serve --cortex %s --transport http --host %s",
-			cortexName, cortexName, host,
+				"  Re-run with: noema serve --cortex %s --transport http%s",
+			cortexName, cortexName, hostFlags,
 		)
 	}
 	return nil
@@ -293,10 +382,10 @@ func validateHTTPServe(host, tlsCert, tlsKey, cortexName string, cortexExplicit 
 // truth for --print-systemd-unit and --print-launchd-plist so both emit
 // identical arguments, and so the unit/plist reflects every flag the
 // operator actually passed on the command line that generated it.
-func buildServeArgs(cortexName, transport, host string, port int, tlsCert, tlsKey string) []string {
+func buildServeArgs(cortexName, transport string, hosts []string, port int, tlsCert, tlsKey string) []string {
 	args := []string{"serve", "--cortex", cortexName, "--transport", transport}
-	if host != "" {
-		args = append(args, "--host", host)
+	for _, h := range hosts {
+		args = append(args, "--host", h)
 	}
 	if port != 0 {
 		args = append(args, "--port", fmt.Sprintf("%d", port))
@@ -317,14 +406,14 @@ func buildServeArgs(cortexName, transport, host string, port int, tlsCert, tlsKe
 // service environment anyway. All HTTP flag invariants are validated via
 // validateHTTPServe so a broken config is caught at preview time rather
 // than on first `systemctl start`.
-func runPrintSystemdUnit(out io.Writer, transport, host string, port int, tlsCert, tlsKey string) error {
+func runPrintSystemdUnit(out io.Writer, transport string, hosts []string, port int, tlsCert, tlsKey string) error {
 	if cortexFlag == "" {
 		return fmt.Errorf("--print-systemd-unit requires an explicit --cortex flag (the unit file pins one cortex to supervise)")
 	}
 	if transport != "http" {
 		return fmt.Errorf("--print-systemd-unit requires --transport http (stdio has no network endpoint to supervise)")
 	}
-	if err := validateHTTPServe(host, tlsCert, tlsKey, cortexFlag, true); err != nil {
+	if err := validateHTTPServe(hosts, tlsCert, tlsKey, cortexFlag, true); err != nil {
 		return err
 	}
 
@@ -341,7 +430,7 @@ func runPrintSystemdUnit(out io.Writer, transport, host string, port int, tlsCer
 		Cortex:    cortexFlag,
 		User:      u.Username,
 		Exe:       exe,
-		ServeArgs: buildServeArgs(cortexFlag, transport, host, port, tlsCert, tlsKey),
+		ServeArgs: buildServeArgs(cortexFlag, transport, hosts, port, tlsCert, tlsKey),
 	})
 	_, err = io.WriteString(out, unit)
 	return err
@@ -359,14 +448,14 @@ func runPrintSystemdUnit(out io.Writer, transport, host string, port int, tlsCer
 // that trip that rule. Writing instructions to stderr keeps the plist
 // well-formed while still showing operators the install steps when they
 // run the command interactively.
-func runPrintLaunchdPlist(out io.Writer, transport, host string, port int, tlsCert, tlsKey string) error {
+func runPrintLaunchdPlist(out io.Writer, transport string, hosts []string, port int, tlsCert, tlsKey string) error {
 	if cortexFlag == "" {
 		return fmt.Errorf("--print-launchd-plist requires an explicit --cortex flag (the plist pins one cortex to supervise)")
 	}
 	if transport != "http" {
 		return fmt.Errorf("--print-launchd-plist requires --transport http (stdio has no network endpoint to supervise)")
 	}
-	if err := validateHTTPServe(host, tlsCert, tlsKey, cortexFlag, true); err != nil {
+	if err := validateHTTPServe(hosts, tlsCert, tlsKey, cortexFlag, true); err != nil {
 		return err
 	}
 
@@ -379,7 +468,7 @@ func runPrintLaunchdPlist(out io.Writer, transport, host string, port int, tlsCe
 		return fmt.Errorf("resolving user home dir: %w", err)
 	}
 
-	serveArgs := buildServeArgs(cortexFlag, transport, host, port, tlsCert, tlsKey)
+	serveArgs := buildServeArgs(cortexFlag, transport, hosts, port, tlsCert, tlsKey)
 	label := "com.fail-safe.noema." + cortexFlag
 
 	// Install hint to stderr so `--print-launchd-plist > foo.plist`
@@ -589,7 +678,7 @@ func xmlEscape(s string) string {
 // http --host 10.0.0.1 ...` invocation produces the exact config a
 // remote client would need, including the URL scheme that matches the
 // --tls-cert/--tls-key pair.
-func runPrintMCPConfig(out io.Writer, transport, host string, port int, tlsCert, tlsKey string) error {
+func runPrintMCPConfig(out io.Writer, transport string, hosts []string, port int, tlsCert, tlsKey string) error {
 	exe, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("resolving executable path: %w", err)
@@ -618,9 +707,13 @@ func runPrintMCPConfig(out io.Writer, transport, host string, port int, tlsCert,
 		// the .mcp.json snippet is emitted for a client that's talking
 		// TO a server, not launching one, so there's no network-
 		// exposure risk in printing an http config without --cortex.
-		if host == "" {
+		if len(hosts) == 0 {
 			return fmt.Errorf("--print-config --transport http requires --host (the address a client will dial, e.g. 10.0.0.1 or my.lan)")
 		}
+		// Use the first host for the client URL. When multiple hosts
+		// are configured (e.g. a TB ring + LAN), the client config
+		// points at whichever the operator listed first.
+		host := hosts[0]
 		if ip := net.ParseIP(host); ip != nil && ip.IsUnspecified() {
 			return fmt.Errorf("--host %s is a wildcard bind address; pass the address clients should dial instead", host)
 		}

--- a/internal/cli/cmd_serve.go
+++ b/internal/cli/cmd_serve.go
@@ -60,7 +60,7 @@ func serveCmd() *cobra.Command {
 			// first log line instead of finding out via peer drift hours
 			// later. The ULID is the federation key — print it explicitly,
 			// not just the human-readable name.
-			fmt.Printf("[serve] cortex %q (id=%s) at %s\n", cx.Name, cx.ID, cx.Dir)
+			fmt.Fprintf(os.Stderr, "[serve] cortex %q (id=%s) at %s\n", cx.Name, cx.ID, cx.Dir)
 
 			var syncer *federation.Syncer
 			switch transport {
@@ -87,7 +87,7 @@ func serveCmd() *cobra.Command {
 					return fmt.Errorf("loading MCP access key: %w", accessErr)
 				}
 				if accessKey.EnvOverride() {
-					fmt.Printf("[serve] %s overrides access.shared_key_file at %s\n",
+					fmt.Fprintf(os.Stderr, "[serve] %s overrides access.shared_key_file at %s\n",
 						cortex.AccessKeyEnvVar, accessKey.Path)
 				}
 
@@ -109,7 +109,7 @@ func serveCmd() *cobra.Command {
 				if m.Federation != nil && len(m.Federation.Peers) > 0 && fedMode != cortex.FederationModePublish {
 					syncer = startSyncer(cx, accessKey.Value, m.Federation)
 				}
-				fmt.Printf("[serve] federation mode: %s\n", fedMode)
+				fmt.Fprintf(os.Stderr, "[serve] federation mode: %s\n", fedMode)
 
 				// HTTP transport: apply federation mode guards.
 				s := mcpserver.NewServer(cx, version(), fedMode)
@@ -119,10 +119,10 @@ func serveCmd() *cobra.Command {
 				// running the same key without speaking the secret
 				// itself.
 				if accessKey.Keyed() {
-					fmt.Printf("[serve] access=keyed source=%s fingerprint=%s\n",
+					fmt.Fprintf(os.Stderr, "[serve] access=keyed source=%s fingerprint=%s\n",
 						accessKey.Source, accessKey.Fingerprint)
 				} else {
-					fmt.Printf("[serve] access=open\n")
+					fmt.Fprintf(os.Stderr, "[serve] access=open\n")
 				}
 
 				// IPv6 addresses need brackets in listen addresses.
@@ -164,7 +164,7 @@ func serveCmd() *cobra.Command {
 				if useTLS {
 					scheme = "https"
 				}
-				fmt.Printf("Starting Streamable HTTP server on %s://%s/mcp\n", scheme, addr)
+				fmt.Fprintf(os.Stderr, "Starting Streamable HTTP server on %s://%s/mcp\n", scheme, addr)
 				if useTLS {
 					err = httpSrv.ListenAndServeTLS(tlsCert, tlsKey)
 				} else {
@@ -227,7 +227,7 @@ func startSyncer(cx *cortex.Cortex, sharedKey string, fc *cortex.FederationConfi
 	syncer := federation.NewSyncer(cx, state, cfg)
 	syncer.Start()
 
-	fmt.Printf("Federation syncer started (%d peers, interval %s)\n", len(peers), cfg.EffectiveInterval())
+	fmt.Fprintf(os.Stderr, "Federation syncer started (%d peers, interval %s)\n", len(peers), cfg.EffectiveInterval())
 	return syncer
 }
 

--- a/internal/cli/cmd_serve_test.go
+++ b/internal/cli/cmd_serve_test.go
@@ -21,7 +21,7 @@ func TestValidateHTTPServe(t *testing.T) {
 
 	cases := []struct {
 		name           string
-		host           string
+		hosts          []string
 		tlsCert        string
 		tlsKey         string
 		cortexExplicit bool
@@ -29,44 +29,44 @@ func TestValidateHTTPServe(t *testing.T) {
 	}{
 		{
 			name:           "happy path no TLS",
-			host:           "127.0.0.1",
+			hosts:          []string{"127.0.0.1"},
 			cortexExplicit: true,
 		},
 		{
 			name:           "happy path with TLS",
-			host:           "ai-1.example.com",
+			hosts:          []string{"ai-1.example.com"},
 			tlsCert:        "/etc/ssl/cert.pem",
 			tlsKey:         "/etc/ssl/key.pem",
 			cortexExplicit: true,
 		},
 		{
 			name:           "missing host",
-			host:           "",
+			hosts:          nil,
 			cortexExplicit: true,
 			wantErrSubstr:  "--host is required for HTTP transport",
 		},
 		{
 			name:           "0.0.0.0 unspecified IPv4",
-			host:           "0.0.0.0",
+			hosts:          []string{"0.0.0.0"},
 			cortexExplicit: true,
 			wantErrSubstr:  "binding to 0.0.0.0 is not allowed",
 		},
 		{
 			name:           "IPv6 unspecified",
-			host:           "::",
+			hosts:          []string{"::"},
 			cortexExplicit: true,
 			wantErrSubstr:  "is not allowed",
 		},
 		{
 			name:           "TLS cert without key",
-			host:           "127.0.0.1",
+			hosts:          []string{"127.0.0.1"},
 			tlsCert:        "/etc/ssl/cert.pem",
 			cortexExplicit: true,
 			wantErrSubstr:  "--tls-cert and --tls-key must be provided together",
 		},
 		{
 			name:           "TLS key without cert",
-			host:           "127.0.0.1",
+			hosts:          []string{"127.0.0.1"},
 			tlsKey:         "/etc/ssl/key.pem",
 			cortexExplicit: true,
 			wantErrSubstr:  "--tls-cert and --tls-key must be provided together",
@@ -77,7 +77,7 @@ func TestValidateHTTPServe(t *testing.T) {
 			// TLS look fine, the implicit binding is a federation
 			// footgun and must be rejected.
 			name:           "implicit cortex on HTTP",
-			host:           "ai-1.example.com",
+			hosts:          []string{"ai-1.example.com"},
 			tlsCert:        "/etc/ssl/cert.pem",
 			tlsKey:         "/etc/ssl/key.pem",
 			cortexExplicit: false,
@@ -90,15 +90,29 @@ func TestValidateHTTPServe(t *testing.T) {
 			// find a different identity. The guard must fire regardless
 			// of the bound cortex's federation config.
 			name:           "implicit cortex on HTTP includes cortex name in error",
-			host:           "ai-1-tb.home-dns.com",
+			hosts:          []string{"ai-1-tb.home-dns.com"},
 			cortexExplicit: false,
 			wantErrSubstr:  "\"ai-1\"",
+		},
+		{
+			// Multi-host: all hosts must be valid. The second host is
+			// a wildcard that should be rejected even though the first
+			// host is fine.
+			name:           "multi-host rejects wildcard in any position",
+			hosts:          []string{"10.0.0.1", "0.0.0.0"},
+			cortexExplicit: true,
+			wantErrSubstr:  "binding to 0.0.0.0 is not allowed",
+		},
+		{
+			name:           "multi-host happy path",
+			hosts:          []string{"10.0.0.1", "192.168.45.3"},
+			cortexExplicit: true,
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := validateHTTPServe(tc.host, tc.tlsCert, tc.tlsKey, cortexName, tc.cortexExplicit)
+			err := validateHTTPServe(tc.hosts, tc.tlsCert, tc.tlsKey, cortexName, tc.cortexExplicit)
 			if tc.wantErrSubstr == "" {
 				if err != nil {
 					t.Fatalf("expected nil, got: %v", err)
@@ -110,6 +124,85 @@ func TestValidateHTTPServe(t *testing.T) {
 			}
 			if !strings.Contains(err.Error(), tc.wantErrSubstr) {
 				t.Errorf("error %q does not contain %q", err.Error(), tc.wantErrSubstr)
+			}
+		})
+	}
+}
+
+// --------- guardStdioFlags ---------
+
+// TestGuardStdioFlags pins the footgun short-circuit: an operator who
+// forgets --transport http and passes HTTP-only flags should hit a loud
+// error at startup rather than a silent stdio process that swallows
+// stdin forever. The guard keys off cobra's Flags().Changed() — i.e.
+// *explicit* flag presence — so default-valued --port=3000 is not a
+// conflict on its own.
+func TestGuardStdioFlags(t *testing.T) {
+	cases := []struct {
+		name                                         string
+		hostSet, portSet, tlsCertSet, tlsKeySet bool
+		wantErrSubstrs                               []string // empty = expect nil
+	}{
+		{
+			name: "nothing set — fine",
+		},
+		{
+			name:           "only --host set",
+			hostSet:        true,
+			wantErrSubstrs: []string{"--host", "is only meaningful", "--transport http"},
+		},
+		{
+			name:           "only --port set",
+			portSet:        true,
+			wantErrSubstrs: []string{"--port", "is only meaningful", "--transport http"},
+		},
+		{
+			name:           "only --tls-cert set",
+			tlsCertSet:     true,
+			wantErrSubstrs: []string{"--tls-cert", "is only meaningful", "--transport http"},
+		},
+		{
+			name:           "only --tls-key set",
+			tlsKeySet:      true,
+			wantErrSubstrs: []string{"--tls-key", "is only meaningful", "--transport http"},
+		},
+		{
+			// Plural flip: when two or more flags conflict, the error
+			// says "are only meaningful" not "is only meaningful".
+			// Trivial, but a user-facing grammar bug reads as sloppy.
+			name:           "multiple flags — plural verb",
+			hostSet:        true,
+			portSet:        true,
+			wantErrSubstrs: []string{"--host, --port", "are only meaningful"},
+		},
+		{
+			// All four flags. The error must list them all so the
+			// operator can see the full conflict in one shot.
+			name:           "all four flags",
+			hostSet:        true,
+			portSet:        true,
+			tlsCertSet:     true,
+			tlsKeySet:      true,
+			wantErrSubstrs: []string{"--host", "--port", "--tls-cert", "--tls-key", "are only meaningful"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := guardStdioFlags(tc.hostSet, tc.portSet, tc.tlsCertSet, tc.tlsKeySet)
+			if len(tc.wantErrSubstrs) == 0 {
+				if err != nil {
+					t.Fatalf("expected nil, got: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			for _, want := range tc.wantErrSubstrs {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error %q does not contain %q", err.Error(), want)
+				}
 			}
 		})
 	}
@@ -127,14 +220,14 @@ func TestBuildServeArgs_OmitsEmptyOptionals(t *testing.T) {
 	// should NOT appear; callers using the real serve command always
 	// have port=3000 by default, but the print functions can be called
 	// with arbitrary values and must not emit --port 0.
-	got := buildServeArgs("agentbrain", "http", "", 0, "", "")
+	got := buildServeArgs("agentbrain", "http", nil, 0, "", "")
 	want := []string{"serve", "--cortex", "agentbrain", "--transport", "http"}
 	if !equalSlices(got, want) {
 		t.Errorf("minimal args: got %v, want %v", got, want)
 	}
 
-	// Full: every optional flag set.
-	got = buildServeArgs("agentbrain", "http", "10.0.0.5", 3000, "/etc/ssl/cert.pem", "/etc/ssl/key.pem")
+	// Full: every optional flag set, single host.
+	got = buildServeArgs("agentbrain", "http", []string{"10.0.0.5"}, 3000, "/etc/ssl/cert.pem", "/etc/ssl/key.pem")
 	want = []string{
 		"serve", "--cortex", "agentbrain", "--transport", "http",
 		"--host", "10.0.0.5",
@@ -143,7 +236,19 @@ func TestBuildServeArgs_OmitsEmptyOptionals(t *testing.T) {
 		"--tls-key", "/etc/ssl/key.pem",
 	}
 	if !equalSlices(got, want) {
-		t.Errorf("full args: got %v, want %v", got, want)
+		t.Errorf("full args (single host): got %v, want %v", got, want)
+	}
+
+	// Multi-host: each host gets its own --host flag.
+	got = buildServeArgs("agentbrain", "http", []string{"10.0.0.5", "192.168.45.3"}, 3000, "", "")
+	want = []string{
+		"serve", "--cortex", "agentbrain", "--transport", "http",
+		"--host", "10.0.0.5",
+		"--host", "192.168.45.3",
+		"--port", "3000",
+	}
+	if !equalSlices(got, want) {
+		t.Errorf("multi-host args: got %v, want %v", got, want)
 	}
 }
 
@@ -356,7 +461,7 @@ func TestRunPrintSystemdUnit_RejectsMissingCortex(t *testing.T) {
 	t.Cleanup(func() { cortexFlag = prev })
 
 	var out bytes.Buffer
-	err := runPrintSystemdUnit(&out, "http", "127.0.0.1", 3000, "", "")
+	err := runPrintSystemdUnit(&out, "http", []string{"127.0.0.1"}, 3000, "", "")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -377,7 +482,7 @@ func TestRunPrintSystemdUnit_RejectsStdioTransport(t *testing.T) {
 	t.Cleanup(func() { cortexFlag = prev })
 
 	var out bytes.Buffer
-	err := runPrintSystemdUnit(&out, "stdio", "", 0, "", "")
+	err := runPrintSystemdUnit(&out, "stdio", nil, 0, "", "")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -396,7 +501,7 @@ func TestRunPrintSystemdUnit_PropagatesHTTPValidationErrors(t *testing.T) {
 	t.Cleanup(func() { cortexFlag = prev })
 
 	var out bytes.Buffer
-	err := runPrintSystemdUnit(&out, "http", "0.0.0.0", 3000, "", "")
+	err := runPrintSystemdUnit(&out, "http", []string{"0.0.0.0"}, 3000, "", "")
 	if err == nil {
 		t.Fatal("expected error on 0.0.0.0 bind, got nil")
 	}
@@ -417,7 +522,7 @@ func TestRunPrintSystemdUnit_HappyPath(t *testing.T) {
 	t.Cleanup(func() { cortexFlag = prev })
 
 	var out bytes.Buffer
-	if err := runPrintSystemdUnit(&out, "http", "127.0.0.1", 3000, "", ""); err != nil {
+	if err := runPrintSystemdUnit(&out, "http", []string{"127.0.0.1"}, 3000, "", ""); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	s := out.String()
@@ -437,7 +542,7 @@ func TestRunPrintLaunchdPlist_RejectsMissingCortex(t *testing.T) {
 	t.Cleanup(func() { cortexFlag = prev })
 
 	var out bytes.Buffer
-	err := runPrintLaunchdPlist(&out, "http", "127.0.0.1", 3000, "", "")
+	err := runPrintLaunchdPlist(&out, "http", []string{"127.0.0.1"}, 3000, "", "")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -454,7 +559,7 @@ func TestRunPrintLaunchdPlist_RejectsStdioTransport(t *testing.T) {
 	t.Cleanup(func() { cortexFlag = prev })
 
 	var out bytes.Buffer
-	err := runPrintLaunchdPlist(&out, "stdio", "", 0, "", "")
+	err := runPrintLaunchdPlist(&out, "stdio", nil, 0, "", "")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -472,7 +577,7 @@ func TestRunPrintLaunchdPlist_HappyPath(t *testing.T) {
 	t.Cleanup(func() { cortexFlag = prev })
 
 	var out bytes.Buffer
-	if err := runPrintLaunchdPlist(&out, "http", "127.0.0.1", 3000, "", ""); err != nil {
+	if err := runPrintLaunchdPlist(&out, "http", []string{"127.0.0.1"}, 3000, "", ""); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	s := out.String()
@@ -684,7 +789,7 @@ func TestRunPrintMCPConfig_StdioShape(t *testing.T) {
 	t.Cleanup(func() { cortexFlag = prev })
 
 	var buf bytes.Buffer
-	if err := runPrintMCPConfig(&buf, "stdio", "", 0, "", ""); err != nil {
+	if err := runPrintMCPConfig(&buf, "stdio", nil, 0, "", ""); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -734,7 +839,7 @@ func TestRunPrintMCPConfig_StdioShape(t *testing.T) {
 // without leaking the key.
 func TestRunPrintMCPConfig_HTTPShape(t *testing.T) {
 	var buf bytes.Buffer
-	if err := runPrintMCPConfig(&buf, "http", "10.0.0.1", 3443, "/tls.crt", "/tls.key"); err != nil {
+	if err := runPrintMCPConfig(&buf, "http", []string{"10.0.0.1"}, 3443, "/tls.crt", "/tls.key"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -774,7 +879,7 @@ func TestRunPrintMCPConfig_HTTPShape(t *testing.T) {
 // request would fail on TLS handshake before the 401 even runs.
 func TestRunPrintMCPConfig_HTTPNoTLS(t *testing.T) {
 	var buf bytes.Buffer
-	if err := runPrintMCPConfig(&buf, "http", "127.0.0.1", 3000, "", ""); err != nil {
+	if err := runPrintMCPConfig(&buf, "http", []string{"127.0.0.1"}, 3000, "", ""); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !strings.Contains(buf.String(), "http://127.0.0.1:3000/mcp") {
@@ -790,7 +895,7 @@ func TestRunPrintMCPConfig_HTTPNoTLS(t *testing.T) {
 // would silently produce a ":3000/mcp" URL that's meaningless.
 func TestRunPrintMCPConfig_HTTPRejectsMissingHost(t *testing.T) {
 	var buf bytes.Buffer
-	err := runPrintMCPConfig(&buf, "http", "", 3000, "", "")
+	err := runPrintMCPConfig(&buf, "http", nil, 3000, "", "")
 	if err == nil {
 		t.Fatal("expected error for http without --host, got nil")
 	}
@@ -806,7 +911,7 @@ func TestRunPrintMCPConfig_HTTPRejectsMissingHost(t *testing.T) {
 // args into --print-config doesn't get a useless config file.
 func TestRunPrintMCPConfig_HTTPRejectsWildcardHost(t *testing.T) {
 	var buf bytes.Buffer
-	err := runPrintMCPConfig(&buf, "http", "0.0.0.0", 3000, "", "")
+	err := runPrintMCPConfig(&buf, "http", []string{"0.0.0.0"}, 3000, "", "")
 	if err == nil {
 		t.Fatal("expected error for 0.0.0.0 host, got nil")
 	}
@@ -817,7 +922,7 @@ func TestRunPrintMCPConfig_HTTPRejectsWildcardHost(t *testing.T) {
 // url.Parse rejects, so MCP clients would fail at config load.
 func TestRunPrintMCPConfig_HTTPIPv6Brackets(t *testing.T) {
 	var buf bytes.Buffer
-	if err := runPrintMCPConfig(&buf, "http", "fe80::1", 3000, "", ""); err != nil {
+	if err := runPrintMCPConfig(&buf, "http", []string{"fe80::1"}, 3000, "", ""); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if !strings.Contains(buf.String(), "http://[fe80::1]:3000/mcp") {
@@ -833,7 +938,7 @@ func TestRunPrintMCPConfig_HTTPIPv6Brackets(t *testing.T) {
 // --cortex" error would be technically correct but would put the operator
 // right back in the same diagnostic loop the guard exists to short-circuit.
 func TestValidateHTTPServe_ImplicitCortexErrorMessage(t *testing.T) {
-	err := validateHTTPServe("ai-1.example.com", "", "", "ai-1", false)
+	err := validateHTTPServe([]string{"ai-1.example.com"}, "", "", "ai-1", false)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}

--- a/internal/cortex/cortex.go
+++ b/internal/cortex/cortex.go
@@ -116,7 +116,7 @@ func SanitizeFTS5Query(q string) string {
 		case t == "AND" || t == "OR" || t == "NOT":
 			out = append(out, t)
 		case strings.HasPrefix(t, "\""):
-			out = append(out, t) // already quoted
+			out = append(out, t) // already quoted (may be part of multi-token phrase)
 		case strings.HasSuffix(t, "*"):
 			out = append(out, t) // prefix search
 		case strings.ContainsAny(t, "-:"):
@@ -125,7 +125,18 @@ func SanitizeFTS5Query(q string) string {
 			out = append(out, t)
 		}
 	}
-	return strings.Join(out, " ")
+	result := strings.Join(out, " ")
+
+	// Safety net: if the result has an odd number of quote marks, the
+	// string has unbalanced quotes that would cause an FTS5 syntax
+	// error (and leak the raw query in the error message). Strip all
+	// quotes to fall back to default FTS5 tokenization. Legitimate
+	// quoted phrases always have matched pairs, so this only fires on
+	// malformed input.
+	if strings.Count(result, "\"")%2 != 0 {
+		result = strings.ReplaceAll(result, "\"", "")
+	}
+	return result
 }
 
 type Cortex struct {
@@ -2313,14 +2324,19 @@ func (c *Cortex) storeRemoteEvent(e event.Event) error {
 	return tx.Commit()
 }
 
-// MergeClock merges a remote vector clock into the local clock.
+// MergeClock merges a remote vector clock into the local clock. The
+// merge is capped at federation.MaxVClockEntries to prevent a malicious
+// peer from inflating the clock with synthetic cortex IDs.
 func (c *Cortex) MergeClock(remote federation.VClock) error {
 	state := federation.NewState(c.DB.DB)
 	local, err := state.GetClock()
 	if err != nil {
 		return err
 	}
-	merged := federation.Merge(local, remote)
+	merged, err := federation.MergeCapped(local, remote)
+	if err != nil {
+		return err
+	}
 	return state.SetClock(merged)
 }
 

--- a/internal/cortex/cortex.go
+++ b/internal/cortex/cortex.go
@@ -101,6 +101,33 @@ var ErrSourceLocked = errors.New("trace is source-locked")
 // denial of service via expensive wildcard or deeply nested expressions.
 const MaxSearchQueryLen = 1000
 
+// SanitizeFTS5Query quotes each whitespace-delimited token so that FTS5
+// treats hyphens, colons, and other operator characters as literals.
+// Tokens that are already quoted or use explicit FTS5 operators (AND, OR,
+// NOT, prefix*) are passed through unchanged to preserve power-user syntax.
+func SanitizeFTS5Query(q string) string {
+	tokens := strings.Fields(q)
+	if len(tokens) == 0 {
+		return q
+	}
+	out := make([]string, 0, len(tokens))
+	for _, t := range tokens {
+		switch {
+		case t == "AND" || t == "OR" || t == "NOT":
+			out = append(out, t)
+		case strings.HasPrefix(t, "\""):
+			out = append(out, t) // already quoted
+		case strings.HasSuffix(t, "*"):
+			out = append(out, t) // prefix search
+		case strings.ContainsAny(t, "-:"):
+			out = append(out, "\""+t+"\"")
+		default:
+			out = append(out, t)
+		}
+	}
+	return strings.Join(out, " ")
+}
+
 type Cortex struct {
 	ID              string // ULID, stable across renames; the federation identity key
 	Name            string // human-readable display label
@@ -694,11 +721,12 @@ func (c *Cortex) Search(query string, opts ListOptions) ([]Row, error) {
 	if len(query) > MaxSearchQueryLen {
 		return nil, fmt.Errorf("search query too long (%d chars, max %d)", len(query), MaxSearchQueryLen)
 	}
+	ftsQuery := SanitizeFTS5Query(query)
 	q := `
 		SELECT t.id, t.title, t.type, t.author, t.origin, t.archived_at, t.trashed_at, t.created_at, t.updated_at, t.content_hash, t.source_locked, t.source_hash
 		FROM traces t
 		WHERE t.id IN (SELECT id FROM traces_fts WHERE traces_fts MATCH ?)`
-	args := []any{query}
+	args := []any{ftsQuery}
 
 	switch {
 	case opts.Trashed:

--- a/internal/cortex/cortex.go
+++ b/internal/cortex/cortex.go
@@ -1017,6 +1017,62 @@ func (c *Cortex) Update(id string) error {
 	return tx.Commit()
 }
 
+// Append adds content to the end of an existing trace's body. It reads the
+// current file, appends the new content (with a newline separator if the
+// existing body doesn't already end with one), recomputes the content hash,
+// and emits a standard "update" event. Designed for fire-and-forget logging
+// where agents append to a running trace without consuming its full body.
+func (c *Cortex) Append(id, content string) error {
+	if err := c.CheckSourceLock(id); err != nil {
+		return err
+	}
+	r, err := c.Get(id)
+	if err != nil {
+		return err
+	}
+	path := c.filePath(r)
+	t, err := trace.ParseFile(path)
+	if err != nil {
+		return err
+	}
+
+	// Append with a newline separator if the body doesn't already end with one.
+	if t.Body != "" && !strings.HasSuffix(t.Body, "\n") {
+		t.Body += "\n"
+	}
+	t.Body += content
+
+	t.Updated = time.Now().UTC().Format(time.RFC3339)
+	t.ContentHash = trace.ContentHash(t.Body)
+	if err := t.Write(path); err != nil {
+		return fmt.Errorf("rewriting trace file for append: %w", err)
+	}
+
+	tx, err := c.DB.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	_, err = tx.Exec(
+		`UPDATE traces SET updated_at=?, content_hash=? WHERE id=?`,
+		t.Updated, t.ContentHash, id,
+	)
+	if err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`DELETE FROM traces_fts WHERE id = ?`, id); err != nil {
+		return err
+	}
+	if _, err := tx.Exec(`INSERT INTO traces_fts (id, title, body) VALUES (?, ?, ?)`, id, t.Title, t.Body); err != nil {
+		return err
+	}
+	if err := c.emitEvent(tx, event.ActionUpdate, id, t.Updated, marshalTraceData(t)); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
 func (c *Cortex) scanRows(rows *sql.Rows) ([]Row, error) { //nolint:govet
 	var result []Row
 	for rows.Next() {

--- a/internal/cortex/cortex.go
+++ b/internal/cortex/cortex.go
@@ -97,6 +97,10 @@ func (pe PeerEntry) EffectiveMode() string {
 // source-locked trace from a foreign origin.
 var ErrSourceLocked = errors.New("trace is source-locked")
 
+// MaxSearchQueryLen caps the length of FTS5 search queries to prevent
+// denial of service via expensive wildcard or deeply nested expressions.
+const MaxSearchQueryLen = 1000
+
 type Cortex struct {
 	ID              string // ULID, stable across renames; the federation identity key
 	Name            string // human-readable display label
@@ -687,6 +691,9 @@ func (c *Cortex) List(opts ListOptions) ([]Row, error) {
 }
 
 func (c *Cortex) Search(query string, opts ListOptions) ([]Row, error) {
+	if len(query) > MaxSearchQueryLen {
+		return nil, fmt.Errorf("search query too long (%d chars, max %d)", len(query), MaxSearchQueryLen)
+	}
 	q := `
 		SELECT t.id, t.title, t.type, t.author, t.origin, t.archived_at, t.trashed_at, t.created_at, t.updated_at, t.content_hash, t.source_locked, t.source_hash
 		FROM traces t
@@ -1666,6 +1673,11 @@ func setClockTx(tx *sql.Tx, vc federation.VClock) error {
 // ReplayEvent materializes a remote event locally without emitting a new event.
 // The remote event is stored in the local log with its original ID and origin.
 func (c *Cortex) ReplayEvent(e event.Event) error {
+	// Guard: reject trace IDs that could escape the cortex directory.
+	if !trace.IsValidID(e.TraceID) {
+		return fmt.Errorf("rejecting remote event %s: %w: %q", e.ID, trace.ErrInvalidTraceID, e.TraceID)
+	}
+
 	// Idempotency: skip if already in local log.
 	existing, err := event.ForTrace(c.DB.DB, e.TraceID)
 	if err != nil {
@@ -1722,6 +1734,19 @@ func (c *Cortex) replayCreate(e event.Event) error {
 		return fmt.Errorf("parsing create event data: %w", err)
 	}
 
+	// Verify content hash integrity: the peer-supplied hash must match the
+	// actual body. Without this check a compromised peer could send tampered
+	// content with the original hash, and noema verify would report it clean.
+	if data.ContentHash != "" {
+		if got := trace.ContentHash(data.Body); got != data.ContentHash {
+			return fmt.Errorf("content hash mismatch on create event %s for trace %s: expected %s, got %s", e.ID, e.TraceID, data.ContentHash, got)
+		}
+	}
+
+	// Only honor source_locked from genuinely foreign events. A peer should
+	// not be able to lock traces that originate from the local cortex.
+	sourceLocked := data.SourceLocked && e.CortexID != c.ID
+
 	t := &trace.Trace{
 		Frontmatter: trace.Frontmatter{
 			ID:           e.TraceID,
@@ -1735,7 +1760,7 @@ func (c *Cortex) replayCreate(e event.Event) error {
 			Updated:      e.Timestamp,
 			ContentHash:  data.ContentHash,
 			SourceHash:   data.SourceHash,
-			SourceLocked: data.SourceLocked,
+			SourceLocked: sourceLocked,
 		},
 		Body: data.Body,
 	}
@@ -1825,6 +1850,13 @@ func (c *Cortex) replayUpdate(e event.Event) error {
 		return fmt.Errorf("trace %s not found for replay update: %w", e.TraceID, err)
 	}
 
+	// Verify content hash integrity before applying the update.
+	if data.ContentHash != "" {
+		if got := trace.ContentHash(data.Body); got != data.ContentHash {
+			return fmt.Errorf("content hash mismatch on update event %s for trace %s: expected %s, got %s", e.ID, e.TraceID, data.ContentHash, got)
+		}
+	}
+
 	// Conflict detection: compare vector clocks with last local mutation.
 	if len(e.VClock) > 0 {
 		localEvents, _ := event.ForTrace(c.DB.DB, e.TraceID)
@@ -1836,6 +1868,8 @@ func (c *Cortex) replayUpdate(e event.Event) error {
 			}
 		}
 	}
+
+	sourceLocked := data.SourceLocked && e.CortexID != c.ID
 
 	t := &trace.Trace{
 		Frontmatter: trace.Frontmatter{
@@ -1850,7 +1884,7 @@ func (c *Cortex) replayUpdate(e event.Event) error {
 			Updated:      e.Timestamp,
 			ContentHash:  data.ContentHash,
 			SourceHash:   data.SourceHash,
-			SourceLocked: data.SourceLocked,
+			SourceLocked: sourceLocked,
 		},
 		Body: data.Body,
 	}

--- a/internal/cortex/cortex_test.go
+++ b/internal/cortex/cortex_test.go
@@ -463,6 +463,11 @@ func TestSanitizeFTS5Query(t *testing.T) {
 		{"\"already quoted\"", "\"already quoted\""},
 		{"", ""},
 		{"no-hyphens-here AND plain", "\"no-hyphens-here\" AND plain"},
+		// Unbalanced quotes: stripped to prevent FTS5 syntax errors.
+		// Odd quote count → all quotes removed → safe default tokenization.
+		{"\"unterminated", "unterminated"},
+		{"\"injected) UNION SELECT --", "injected) UNION SELECT --"},
+		{"\"has\"embedded\"quotes", "hasembeddedquotes"},
 	}
 	for _, tt := range tests {
 		got := cortex.SanitizeFTS5Query(tt.input)

--- a/internal/cortex/cortex_test.go
+++ b/internal/cortex/cortex_test.go
@@ -408,6 +408,70 @@ func TestSearch_MalformedQuery(t *testing.T) {
 	}
 }
 
+func TestSearch_HyphenatedTerms(t *testing.T) {
+	cx := setup(t)
+
+	tr := trace.New("format-test-create", "note", "hermes/testbot", []string{"hermes-contract-test"}, "Testing create response format.")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	// Search by hyphenated title — previously caused "no such column" FTS5 error.
+	rows, err := cx.Search("format-test-create", cortex.ListOptions{})
+	if err != nil {
+		t.Fatalf("Search with hyphenated query: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d results for hyphenated query, want 1", len(rows))
+	}
+	if rows[0].ID != tr.ID {
+		t.Errorf("result = %q, want %q", rows[0].ID, tr.ID)
+	}
+}
+
+func TestSearch_ColonInQuery(t *testing.T) {
+	cx := setup(t)
+
+	tr := trace.New("hermes-session: my-session", "context", "hermes/agent", nil, "Session log content.")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	// Colons are FTS5 column-prefix syntax — must be quoted.
+	rows, err := cx.Search("hermes-session:", cortex.ListOptions{})
+	if err != nil {
+		t.Fatalf("Search with colon query: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d results for colon query, want 1", len(rows))
+	}
+}
+
+func TestSanitizeFTS5Query(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"simple query", "simple query"},
+		{"format-test-create", "\"format-test-create\""},
+		{"hermes-session: log", "\"hermes-session:\" log"},
+		{"single-binary deployment", "\"single-binary\" deployment"},
+		{"word AND other", "word AND other"},
+		{"word OR other", "word OR other"},
+		{"NOT bad", "NOT bad"},
+		{"prefix*", "prefix*"},
+		{"\"already quoted\"", "\"already quoted\""},
+		{"", ""},
+		{"no-hyphens-here AND plain", "\"no-hyphens-here\" AND plain"},
+	}
+	for _, tt := range tests {
+		got := cortex.SanitizeFTS5Query(tt.input)
+		if got != tt.want {
+			t.Errorf("SanitizeFTS5Query(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
 // ---- Archive / Unarchive ----
 
 func TestArchiveUnarchive(t *testing.T) {

--- a/internal/cortex/cortex_test.go
+++ b/internal/cortex/cortex_test.go
@@ -2019,3 +2019,196 @@ func TestValidateFederation_NilFederation(t *testing.T) {
 		t.Errorf("nil federation should pass validation: %v", err)
 	}
 }
+
+// ---- Security: path traversal ----
+
+func TestReplayEvent_RejectsPathTraversal(t *testing.T) {
+	cx := setup(t)
+
+	maliciousIDs := []string{
+		"../../etc/passwd",
+		"20260405-../../etc/shadow",
+		"20260405-hello/world",
+		"20260405-hello\\world",
+		"../db/noema",
+	}
+
+	for _, id := range maliciousIDs {
+		data, _ := json.Marshal(map[string]any{
+			"title": "Evil", "type": "note", "body": "pwned",
+		})
+		e := event.Event{
+			ID:        event.NewULID(),
+			Action:    event.ActionCreate,
+			TraceID:   id,
+			Origin:    "evil-peer",
+			Timestamp: "2026-04-05T12:00:00Z",
+			Data:      data,
+		}
+		err := cx.ReplayEvent(e)
+		if err == nil {
+			t.Errorf("ReplayEvent with TraceID %q should have been rejected", id)
+		}
+		if !strings.Contains(err.Error(), "invalid trace ID") {
+			t.Errorf("expected invalid trace ID error for %q, got: %v", id, err)
+		}
+	}
+}
+
+// ---- Security: content hash verification ----
+
+func TestReplayEvent_RejectsContentHashMismatch(t *testing.T) {
+	cx := setup(t)
+
+	body := "legitimate content"
+	wrongHash := trace.ContentHash("tampered content")
+
+	data, _ := json.Marshal(map[string]any{
+		"title":        "Tampered",
+		"type":         "note",
+		"body":         body,
+		"content_hash": wrongHash,
+	})
+	e := event.Event{
+		ID:        event.NewULID(),
+		Action:    event.ActionCreate,
+		TraceID:   "20260405-tampered-trace",
+		Origin:    "evil-peer",
+		Timestamp: "2026-04-05T12:00:00Z",
+		Data:      data,
+	}
+
+	err := cx.ReplayEvent(e)
+	if err == nil {
+		t.Fatal("ReplayEvent should reject event with mismatched content_hash")
+	}
+	if !strings.Contains(err.Error(), "content hash mismatch") {
+		t.Errorf("expected content hash mismatch error, got: %v", err)
+	}
+
+	// Verify no file was written.
+	if _, err := os.Stat(cx.TraceFile("20260405-tampered-trace", false)); err == nil {
+		t.Error("tampered trace file should not exist on disk")
+	}
+}
+
+func TestReplayEvent_AcceptsMatchingContentHash(t *testing.T) {
+	cx := setup(t)
+
+	body := "legitimate content"
+	hash := trace.ContentHash(body)
+
+	data, _ := json.Marshal(map[string]any{
+		"title":        "Legit",
+		"type":         "note",
+		"body":         body,
+		"content_hash": hash,
+	})
+	e := event.Event{
+		ID:        event.NewULID(),
+		Action:    event.ActionCreate,
+		TraceID:   "20260405-legit-trace",
+		Origin:    "good-peer",
+		Timestamp: "2026-04-05T12:00:00Z",
+		Data:      data,
+	}
+
+	if err := cx.ReplayEvent(e); err != nil {
+		t.Fatalf("ReplayEvent should accept matching hash: %v", err)
+	}
+}
+
+// ---- Security: source-lock restriction ----
+
+func TestReplayEvent_IgnoresSourceLockFromSameCortex(t *testing.T) {
+	cx := setup(t)
+
+	data, _ := json.Marshal(map[string]any{
+		"title":         "Locked by self",
+		"type":          "note",
+		"body":          "Should not actually lock.",
+		"source_locked": true,
+	})
+	e := event.Event{
+		ID:        event.NewULID(),
+		Action:    event.ActionCreate,
+		TraceID:   "20260405-self-locked",
+		Origin:    cx.Name,
+		CortexID:  cx.ID, // same as local cortex
+		Timestamp: "2026-04-05T12:00:00Z",
+		Data:      data,
+	}
+
+	if err := cx.ReplayEvent(e); err != nil {
+		t.Fatalf("ReplayEvent: %v", err)
+	}
+
+	row, err := cx.Get("20260405-self-locked")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if row.SourceLocked {
+		t.Error("source_locked should be false when CortexID matches local cortex")
+	}
+}
+
+func TestReplayEvent_HonorsSourceLockFromForeignCortex(t *testing.T) {
+	cx := setup(t)
+
+	data, _ := json.Marshal(map[string]any{
+		"title":         "Locked by peer",
+		"type":          "note",
+		"body":          "Should be locked.",
+		"source_locked": true,
+	})
+	e := event.Event{
+		ID:        event.NewULID(),
+		Action:    event.ActionCreate,
+		TraceID:   "20260405-peer-locked",
+		Origin:    "foreign-peer",
+		CortexID:  "01JTESTFOREIGN000000000000", // different from local
+		Timestamp: "2026-04-05T12:00:00Z",
+		Data:      data,
+	}
+
+	if err := cx.ReplayEvent(e); err != nil {
+		t.Fatalf("ReplayEvent: %v", err)
+	}
+
+	row, err := cx.Get("20260405-peer-locked")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !row.SourceLocked {
+		t.Error("source_locked should be true when CortexID differs from local cortex")
+	}
+}
+
+// ---- Security: FTS5 query length cap ----
+
+func TestSearch_RejectsOversizedQuery(t *testing.T) {
+	cx := setup(t)
+
+	longQuery := strings.Repeat("a", cortex.MaxSearchQueryLen+1)
+	_, err := cx.Search(longQuery, cortex.ListOptions{})
+	if err == nil {
+		t.Fatal("Search should reject query exceeding MaxSearchQueryLen")
+	}
+	if !strings.Contains(err.Error(), "too long") {
+		t.Errorf("expected 'too long' error, got: %v", err)
+	}
+}
+
+func TestSearch_AcceptsQueryAtMaxLength(t *testing.T) {
+	cx := setup(t)
+
+	// This will fail the FTS5 MATCH (no results), but should not be rejected
+	// by the length check.
+	query := strings.Repeat("a", cortex.MaxSearchQueryLen)
+	_, err := cx.Search(query, cortex.ListOptions{})
+	// FTS5 may return an error for a nonsensical query, but it should not
+	// be our "too long" error.
+	if err != nil && strings.Contains(err.Error(), "too long") {
+		t.Errorf("query at max length should not be rejected: %v", err)
+	}
+}

--- a/internal/cortex/cortex_test.go
+++ b/internal/cortex/cortex_test.go
@@ -812,6 +812,148 @@ func TestUpdate(t *testing.T) {
 	}
 }
 
+// ---- Append ----
+
+func TestAppend(t *testing.T) {
+	cx := setup(t)
+
+	tr := trace.New("Append target", "note", "agent-1", []string{"log"}, "Line one.")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	if err := cx.Append(tr.ID, "Line two."); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	// Verify the file on disk has the appended content.
+	path := cx.TraceFile(tr.ID, false)
+	parsed, err := trace.ParseFile(path)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	want := "Line one.\nLine two."
+	if parsed.Body != want {
+		t.Errorf("Body = %q, want %q", parsed.Body, want)
+	}
+
+	// FTS5 should find the appended content.
+	results, err := cx.Search("line two", cortex.ListOptions{})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(results) != 1 || results[0].ID != tr.ID {
+		t.Errorf("FTS not updated: search returned %v", results)
+	}
+
+	// Content hash should be recomputed.
+	row, err := cx.Get(tr.ID)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	wantHash := trace.ContentHash(want)
+	if row.ContentHash != wantHash {
+		t.Errorf("ContentHash = %q, want %q", row.ContentHash, wantHash)
+	}
+}
+
+func TestAppend_ToEmptyBody(t *testing.T) {
+	cx := setup(t)
+
+	tr := trace.New("Empty body append", "note", "", nil, "")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	if err := cx.Append(tr.ID, "First entry."); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	path := cx.TraceFile(tr.ID, false)
+	parsed, err := trace.ParseFile(path)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	if parsed.Body != "First entry." {
+		t.Errorf("Body = %q, want %q", parsed.Body, "First entry.")
+	}
+}
+
+func TestAppend_MultipleAppends(t *testing.T) {
+	cx := setup(t)
+
+	tr := trace.New("Multi append", "note", "", nil, "A")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	for _, line := range []string{"B", "C", "D"} {
+		if err := cx.Append(tr.ID, line); err != nil {
+			t.Fatalf("Append %q: %v", line, err)
+		}
+	}
+
+	path := cx.TraceFile(tr.ID, false)
+	parsed, err := trace.ParseFile(path)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	want := "A\nB\nC\nD"
+	if parsed.Body != want {
+		t.Errorf("Body = %q, want %q", parsed.Body, want)
+	}
+}
+
+func TestAppend_EmitsUpdateEvent(t *testing.T) {
+	cx := setup(t)
+
+	tr := trace.New("Event test", "note", "", nil, "Initial.")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	if err := cx.Append(tr.ID, "Appended."); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	events, err := cx.Events(tr.ID)
+	if err != nil {
+		t.Fatalf("History: %v", err)
+	}
+	// Should have create + update.
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(events))
+	}
+	if events[1].Action != "update" {
+		t.Errorf("second event action = %q, want %q", events[1].Action, "update")
+	}
+}
+
+func TestAppend_RespectsSourceLock(t *testing.T) {
+	cx := setup(t)
+
+	tr := trace.New("Locked trace", "note", "", nil, "Body.")
+	tr.Origin = "remote-peer"
+	tr.SourceLocked = true
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	err := cx.Append(tr.ID, "Should fail.")
+	if err == nil {
+		t.Fatal("expected source lock error, got nil")
+	}
+}
+
+func TestAppend_NotFound(t *testing.T) {
+	cx := setup(t)
+
+	err := cx.Append("99999999-nonexistent", "content")
+	if err == nil {
+		t.Fatal("expected error for missing trace, got nil")
+	}
+}
+
 // ---- Origin ----
 
 func TestOrigin_DefaultsToCortexName(t *testing.T) {

--- a/internal/event/ulid.go
+++ b/internal/event/ulid.go
@@ -61,6 +61,25 @@ func encodeRandom(buf []byte, rnd [10]byte) {
 	}
 }
 
+// IsValidULID reports whether s is a well-formed 26-character Crockford
+// base32 ULID. It does not check whether the timestamp or random portion
+// is semantically valid — only the length and character set.
+func IsValidULID(s string) bool {
+	if len(s) != 26 {
+		return false
+	}
+	for _, c := range s {
+		if (c < '0' || c > '9') && (c < 'A' || c > 'Z') {
+			return false
+		}
+		// Crockford base32 excludes I, L, O, U.
+		if c == 'I' || c == 'L' || c == 'O' || c == 'U' {
+			return false
+		}
+	}
+	return true
+}
+
 func incrementRnd() {
 	for i := 9; i >= 0; i-- {
 		lastRnd[i]++

--- a/internal/event/ulid_test.go
+++ b/internal/event/ulid_test.go
@@ -28,6 +28,38 @@ func TestNewULID_Uniqueness(t *testing.T) {
 	}
 }
 
+func TestIsValidULID(t *testing.T) {
+	valid := []string{
+		NewULID(),
+		"01ARZ3NDEKTSV4RRFFQ69G5FAV", // canonical example
+		"00000000000000000000000000", // all zeros
+		"7ZZZZZZZZZZZZZZZZZZZZZZZZZ", // max value
+	}
+	for _, id := range valid {
+		if !IsValidULID(id) {
+			t.Errorf("IsValidULID(%q) = false, want true", id)
+		}
+	}
+
+	invalid := []string{
+		"",
+		"too-short",
+		"01ARZ3NDEKTSV4RRFFQ69G5FA",  // 25 chars
+		"01ARZ3NDEKTSV4RRFFQ69G5FAVX", // 27 chars
+		"01ARZ3NDEKTSV4RRFFQ69G5FAi",  // lowercase i
+		"01ARZ3NDEKTSV4RRFFQ69G5FAO",  // excluded O
+		"01ARZ3NDEKTSV4RRFFQ69G5FAL",  // excluded L
+		"01ARZ3NDEKTSV4RRFFQ69G5FAU",  // excluded U
+		"01ARZ3NDEKTSV4RRFFQ69G5FAI",  // excluded I
+		"../../../etc/passwd/000000",   // path traversal attempt
+	}
+	for _, id := range invalid {
+		if IsValidULID(id) {
+			t.Errorf("IsValidULID(%q) = true, want false", id)
+		}
+	}
+}
+
 func TestNewULID_LexicographicOrder(t *testing.T) {
 	// Generate two ULIDs in sequence; the second must be >= the first.
 	// They share the same millisecond most of the time, so we check >=.

--- a/internal/federation/syncer.go
+++ b/internal/federation/syncer.go
@@ -277,6 +277,13 @@ func (s *Syncer) syncPeer(peer PeerConfig) error {
 		return nil
 	}
 
+	// Guard against a hostile peer returning an oversized payload.
+	// 100 events * 1 MB body each = 100 MB is a generous upper bound.
+	const maxSyncResponseBytes = 100 * 1024 * 1024 // 100 MiB
+	if len(text) > maxSyncResponseBytes {
+		return fmt.Errorf("sync_events response too large (%d bytes, max %d)", len(text), maxSyncResponseBytes)
+	}
+
 	var events []event.Event
 	if err := json.Unmarshal([]byte(text), &events); err != nil {
 		return fmt.Errorf("parsing sync_events response: %w", err)

--- a/internal/federation/vclock.go
+++ b/internal/federation/vclock.go
@@ -1,5 +1,15 @@
 package federation
 
+import "fmt"
+
+// MaxVClockEntries caps the number of distinct cortex IDs in a merged
+// vector clock. A legitimate federation ring rarely exceeds a handful of
+// peers; a clock with hundreds of entries is a strong signal of a clock
+// inflation attack (a malicious peer injecting synthetic cortex IDs into
+// its event payloads). The cap prevents unbounded growth of the
+// federation_state row that is serialized on every mutation.
+const MaxVClockEntries = 256
+
 // VClock is a vector clock: one counter per known peer.
 type VClock map[string]uint64
 
@@ -29,6 +39,20 @@ func Merge(a, b VClock) VClock {
 		}
 	}
 	return result
+}
+
+// MergeCapped is like Merge but returns an error when the merged clock
+// would exceed MaxVClockEntries. Use this on the federation ingest path
+// to prevent a malicious peer from inflating the local clock with
+// synthetic cortex IDs.
+func MergeCapped(a, b VClock) (VClock, error) {
+	merged := Merge(a, b)
+	if len(merged) > MaxVClockEntries {
+		return nil, fmt.Errorf(
+			"vector clock too large (%d entries, max %d): possible clock inflation attack",
+			len(merged), MaxVClockEntries)
+	}
+	return merged, nil
 }
 
 // Compare returns the causal relationship between two clocks:

--- a/internal/federation/vclock_test.go
+++ b/internal/federation/vclock_test.go
@@ -1,6 +1,10 @@
 package federation
 
-import "testing"
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
 
 func TestVClock_Increment(t *testing.T) {
 	vc := VClock{"a": 5, "b": 3}
@@ -41,6 +45,34 @@ func TestMerge_DisjointKeys(t *testing.T) {
 	m := Merge(a, b)
 	if m["a"] != 5 || m["b"] != 3 {
 		t.Errorf("Merge = %v, want {a:5, b:3}", m)
+	}
+}
+
+func TestMergeCapped_UnderLimit(t *testing.T) {
+	a := VClock{"a": 1, "b": 2}
+	b := VClock{"c": 3}
+	merged, err := MergeCapped(a, b)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(merged) != 3 {
+		t.Errorf("len = %d, want 3", len(merged))
+	}
+}
+
+func TestMergeCapped_OverLimit(t *testing.T) {
+	a := make(VClock, MaxVClockEntries)
+	for i := range MaxVClockEntries {
+		a[fmt.Sprintf("peer-%d", i)] = uint64(i)
+	}
+	// b adds one more distinct key, pushing past the cap.
+	b := VClock{"attacker-injected": 1}
+	_, err := MergeCapped(a, b)
+	if err == nil {
+		t.Fatal("expected error for oversized clock, got nil")
+	}
+	if !strings.Contains(err.Error(), "too large") {
+		t.Errorf("error %q does not mention 'too large'", err.Error())
 	}
 }
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -318,6 +318,25 @@ func NewServer(cx *cortex.Cortex, noemaVersion string, federationMode string) *s
 		return mcp.NewToolResultText(fmt.Sprintf("Trace %s updated.", id)), nil
 	}))
 
+	s.AddTool(mcp.NewTool("append_trace",
+		mcp.WithDescription("Append content to an existing trace's body without reading the full trace first. Ideal for fire-and-forget logging, running journals, or any case where an agent needs to add to a trace without consuming its current content."),
+		mcp.WithString("id", mcp.Description("Trace ID"), mcp.Required()),
+		mcp.WithString("content", mcp.Description("Content to append to the trace body"), mcp.Required()),
+	), readOnlyGuard(func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		id, err := req.RequireString("id")
+		if err != nil {
+			return nil, err
+		}
+		content, err := req.RequireString("content")
+		if err != nil {
+			return nil, err
+		}
+		if err := cx.Append(id, content); err != nil {
+			return nil, err
+		}
+		return mcp.NewToolResultText(fmt.Sprintf("Content appended to trace %s.", id)), nil
+	}))
+
 	// ---- Event Log & Lineage tools ----
 
 	s.AddTool(mcp.NewTool("trace_history",
@@ -661,6 +680,9 @@ Choose the type that best reflects the intent of the memory:
                                    or in a tag (e.g. tags=event-2026-04-02) instead
   update_trace id [title] [type] [author] [tags] [derived_from] [body]
                                  → update any subset of fields
+  append_trace id content        → append content to an existing trace's body
+                                   without reading the full trace first; ideal
+                                   for running logs and fire-and-forget writes
   search_traces query [all]      → FTS5 full-text search
   archive_trace id               → move to archive (reversible)
   unarchive_trace id             → restore from archive

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
 	"github.com/Fail-Safe/Noema/internal/cortex"
+	"github.com/Fail-Safe/Noema/internal/event"
 	"github.com/Fail-Safe/Noema/internal/federation"
 	"github.com/Fail-Safe/Noema/internal/trace"
 )
@@ -447,6 +449,10 @@ func NewServer(cx *cortex.Cortex, noemaVersion string, federationMode string) *s
 				"this cortex is in subscribe mode and does not serve events"), nil
 		}
 		since := req.GetString("since", "")
+		if since != "" && !event.IsValidULID(since) {
+			return mcp.NewToolResultError(
+				"since must be a valid ULID cursor (26-char Crockford base32)"), nil
+		}
 		limit := req.GetInt("limit", 100)
 		if limit <= 0 || limit > 1000 {
 			limit = 100
@@ -567,6 +573,16 @@ func NewServer(cx *cortex.Cortex, noemaVersion string, federationMode string) *s
 		endpoint, err := req.RequireString("endpoint")
 		if err != nil {
 			return nil, err
+		}
+
+		// Validate that the endpoint is a reachable HTTP(S) URL.
+		// Accepting arbitrary schemes (file://, javascript:, etc.)
+		// risks confusion if the value is later copy-pasted into
+		// federation config or rendered in status output.
+		u, parseErr := url.ParseRequestURI(endpoint)
+		if parseErr != nil || (u.Scheme != "http" && u.Scheme != "https") {
+			return mcp.NewToolResultError(
+				"endpoint must be a valid http:// or https:// URL"), nil
 		}
 
 		m, err := cortex.ReadManifest(cx.Dir)

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -110,6 +110,13 @@ func TestRenderInstructions_ManifestVersionReflectsInput(t *testing.T) {
 // the Tools section could quietly drop the warning and the doubled-
 // prefix bug would re-emerge from agent habit even though the code-
 // level defense would still catch it.
+func TestRenderInstructions_IncludesAppendTrace(t *testing.T) {
+	out := renderInstructions(cortex.Manifest{Name: "test", Version: 2}, "dev")
+	if !strings.Contains(out, "append_trace") {
+		t.Errorf("instructions should mention append_trace\nfull output:\n%s", out)
+	}
+}
+
 func TestRenderInstructions_WarnsAgainstDateInTitle(t *testing.T) {
 	out := renderInstructions(cortex.Manifest{Name: "test", Version: 2}, "dev")
 
@@ -325,6 +332,7 @@ func TestPublishMode_BlocksMutatingTools(t *testing.T) {
 	}{
 		{"create_trace", map[string]any{"title": "x", "type": "note", "body": "y"}},
 		{"update_trace", map[string]any{"id": "nonexistent", "title": "x"}},
+		{"append_trace", map[string]any{"id": "nonexistent", "content": "x"}},
 		{"delete_trace", map[string]any{"id": "nonexistent"}},
 		{"recover_trace", map[string]any{"id": "nonexistent"}},
 		{"archive_trace", map[string]any{"id": "nonexistent"}},

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -3,14 +3,32 @@ package trace
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 	"unicode"
 
 	"gopkg.in/yaml.v3"
 )
+
+// ErrInvalidTraceID is returned when a trace ID contains characters that
+// could escape the cortex directory (path traversal). Only IDs matching
+// the YYYYMMDD-slug format produced by NewID are accepted.
+var ErrInvalidTraceID = errors.New("invalid trace ID")
+
+// validTraceID matches the format produced by NewID: 8 digits, a hyphen,
+// then 1–65 characters of lowercase alphanumerics and hyphens.
+var validTraceID = regexp.MustCompile(`^[0-9]{8}-[a-z0-9][a-z0-9-]{0,64}$`)
+
+// IsValidID reports whether id is a well-formed trace ID safe for use in
+// filesystem paths. It rejects any ID containing path separators, dot
+// segments, or characters outside the NewID slug alphabet.
+func IsValidID(id string) bool {
+	return validTraceID.MatchString(id)
+}
 
 type Type string
 

--- a/internal/trace/trace_test.go
+++ b/internal/trace/trace_test.go
@@ -268,3 +268,38 @@ func TestNew(t *testing.T) {
 		t.Error("Created/Updated timestamps must be set")
 	}
 }
+
+// ---- IsValidID ----
+
+func TestIsValidID(t *testing.T) {
+	valid := []string{
+		"20260329-why-we-chose-go",
+		"20260401-a",
+		"20260401-a-b-c",
+		"20260401-abc123",
+	}
+	for _, id := range valid {
+		if !trace.IsValidID(id) {
+			t.Errorf("IsValidID(%q) = false, want true", id)
+		}
+	}
+
+	invalid := []string{
+		"",
+		"no-date-prefix",
+		"../etc/passwd",
+		"20260329-../../etc/passwd",
+		"20260329-hello/world",
+		"20260329-hello\\world",
+		"20260329-",
+		"20260329-UPPERCASE",
+		"20260329-hello world",
+		"2026032-short-date",
+		"20260329-" + strings.Repeat("a", 66), // exceeds max slug length
+	}
+	for _, id := range invalid {
+		if trace.IsValidID(id) {
+			t.Errorf("IsValidID(%q) = true, want false", id)
+		}
+	}
+}

--- a/plugins/hermes/README.md
+++ b/plugins/hermes/README.md
@@ -1,0 +1,119 @@
+# Noema Memory Provider for Hermes
+
+A [Hermes](https://hermes-agent.nousresearch.com/) memory provider plugin that
+gives any Hermes agent structured, persistent memory backed by a
+[Noema](https://github.com/Fail-Safe/Noema) Cortex.
+
+Every memory is a plain markdown file (a "Trace") with typed frontmatter —
+searchable via FTS5, linked through derivation lineage, and federable across
+Cortexes.
+
+## Installation
+
+1. Install the Noema binary:
+
+   ```
+   brew install Fail-Safe/tap/noema
+   ```
+
+2. Create a Cortex if you don't already have one:
+
+   ```
+   noema init --name my-cortex
+   ```
+
+3. Download the plugin and copy it into your Hermes plugins folder:
+
+   ```
+   # Download from the latest GitHub Release
+   curl -LO https://github.com/Fail-Safe/Noema/releases/latest/download/noema-hermes-plugin.tar.gz
+   mkdir -p <hermes-install>/plugins/memory/noema
+   tar -xzf noema-hermes-plugin.tar.gz -C <hermes-install>/plugins/memory/noema/
+   ```
+
+   Or, if you cloned the Noema repo:
+
+   ```
+   cp -r plugins/hermes/ <hermes-install>/plugins/memory/noema/
+   ```
+
+4. Run the Hermes memory setup wizard:
+
+   ```
+   hermes memory setup
+   ```
+
+   Select **noema** when prompted and provide your cortex name.
+
+## Configuration
+
+| Key | Required | Secret | Env var | Default | Description |
+|-----|----------|--------|---------|---------|-------------|
+| `cortex_name` | Yes | No | `NOEMA_CORTEX` | — | Noema cortex to use |
+| `noema_binary` | No | No | `NOEMA_BINARY` | auto-detect | Path to noema binary |
+| `transport` | No | No | — | `stdio` | `stdio` or `http` |
+| `http_url` | No | No | `NOEMA_HTTP_URL` | — | MCP endpoint URL (HTTP transport only) |
+| `bearer_key` | No | Yes | `NOEMA_MCP_KEY` | — | Bearer key for keyed mode |
+
+Config is saved to `{hermes_home}/noema.json`.
+
+### Transport modes
+
+**stdio** (default) — the plugin spawns `noema serve --transport stdio` as a
+subprocess. No network configuration needed. The process lifecycle is fully
+managed: started on `initialize()`, terminated on `shutdown()`.
+
+**http** — the plugin connects to an already-running `noema serve --transport http`
+endpoint. Use this for remote Cortexes or multi-agent setups sharing one server.
+Set `http_url` to the server's base URL (e.g., `http://localhost:3000`).
+
+## Agent tools
+
+Six Noema tools are exposed to the Hermes agent:
+
+| Hermes tool | Noema tool | Purpose |
+|-------------|------------|---------|
+| `noema_search` | `search_traces` | Full-text search across traces |
+| `noema_remember` | `create_trace` | Create a new memory trace |
+| `noema_recall` | `get_trace` | Read a specific trace by ID |
+| `noema_list` | `list_traces` | Browse/filter by type, tag, author |
+| `noema_update` | `update_trace` | Modify an existing trace |
+| `noema_lineage` | `trace_lineage` | Follow derivation chains |
+
+## Session lifecycle
+
+The plugin automatically manages session state:
+
+- **On initialize** — creates a session log trace (`type: context`) and caches
+  the Cortex instructions for system prompt injection.
+- **Each turn** — appends the user/assistant exchange to the session log
+  (non-blocking, runs in a background thread).
+- **On context compression** — appends the compressed context to the session log
+  and returns a breadcrumb pointing back to the trace.
+- **On session end** — creates a summary trace (`type: observation`) derived
+  from the session log, then archives the session log.
+
+## Prefetch
+
+On each turn, `prefetch()` searches the Cortex with the user's message and
+returns the top 5 matching traces (excluding verbose session logs). FTS5 on
+local SQLite is sub-millisecond, so no cache warming is needed.
+
+## Memory mirroring
+
+When Hermes writes to its built-in memory via `on_memory_write()`, the plugin
+mirrors the operation as a Noema trace tagged `hermes-mirror`:
+
+- `add` creates a new trace (`type: note`)
+- `update` updates the matching mirrored trace
+- `delete` archives the mirrored trace (never hard-deletes)
+
+## Requirements
+
+- Python 3.9+
+- Noema binary (v0.6.0+) installed and accessible
+- A Noema Cortex initialized with `noema init`
+
+## License
+
+MIT — same as Noema.

--- a/plugins/hermes/__init__.py
+++ b/plugins/hermes/__init__.py
@@ -1,0 +1,729 @@
+"""Noema memory provider plugin for Hermes.
+
+Gives any Hermes agent structured, persistent memory backed by a Noema Cortex.
+Traces (markdown files with typed frontmatter) are searched, created, and
+appended through the standard Hermes lifecycle hooks.
+
+Usage:
+    1. Copy this directory into <hermes>/plugins/memory/noema/
+    2. Run `hermes memory setup` and select noema
+    3. Set NOEMA_CORTEX=<cortex-name> (or configure via the setup wizard)
+
+See README.md for full setup instructions.
+"""
+
+__version__ = "0.1.0"
+
+import json
+import logging
+import os
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+try:
+    from agent.memory_provider import MemoryProvider
+except ImportError:
+    # Allow importing outside of Hermes for testing.
+    class MemoryProvider:  # type: ignore[no-redef]
+        pass
+
+from .transport import StdioTransport, HttpTransport, find_binary, reset_binary_cache
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Tool schemas (OpenAI function-calling format)
+# ---------------------------------------------------------------------------
+
+SEARCH_SCHEMA = {
+    "name": "noema_search",
+    "description": (
+        "Search your memory for relevant traces. Returns matching memories "
+        "ranked by relevance (FTS5 full-text search)."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Search query — keywords or natural phrases.",
+            },
+        },
+        "required": ["query"],
+    },
+}
+
+REMEMBER_SCHEMA = {
+    "name": "noema_remember",
+    "description": (
+        "Create a new memory trace. Choose a type that reflects the intent: "
+        "fact, decision, preference, context, skill, intent, observation, or note."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "title": {
+                "type": "string",
+                "description": (
+                    "Short descriptive title. Do NOT include a date — "
+                    "the ID generator prepends today's date automatically."
+                ),
+            },
+            "type": {
+                "type": "string",
+                "description": "Memory type.",
+                "enum": [
+                    "fact", "decision", "preference", "context",
+                    "skill", "intent", "observation", "note",
+                ],
+            },
+            "body": {
+                "type": "string",
+                "description": "Full content of the memory (markdown).",
+            },
+            "tags": {
+                "type": "string",
+                "description": "Comma-separated keyword tags.",
+            },
+            "derived_from": {
+                "type": "string",
+                "description": "Comma-separated trace IDs this memory was derived from.",
+            },
+        },
+        "required": ["title", "type", "body"],
+    },
+}
+
+RECALL_SCHEMA = {
+    "name": "noema_recall",
+    "description": "Read a specific memory trace by ID, including its full body.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "id": {
+                "type": "string",
+                "description": "Trace ID (e.g. 20260412-my-trace).",
+            },
+        },
+        "required": ["id"],
+    },
+}
+
+LIST_SCHEMA = {
+    "name": "noema_list",
+    "description": "List memory traces, optionally filtered by type, author, tag, or origin.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "type": {"type": "string", "description": "Filter by trace type."},
+            "author": {"type": "string", "description": "Filter by author."},
+            "tag": {"type": "string", "description": "Filter by tag."},
+            "origin": {"type": "string", "description": "Filter by origin cortex."},
+        },
+        "required": [],
+    },
+}
+
+UPDATE_SCHEMA = {
+    "name": "noema_update",
+    "description": "Update fields of an existing memory trace. Only provided fields are changed.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "id": {"type": "string", "description": "Trace ID to update."},
+            "title": {"type": "string", "description": "New title."},
+            "type": {
+                "type": "string",
+                "description": "New type.",
+                "enum": [
+                    "fact", "decision", "preference", "context",
+                    "skill", "intent", "observation", "note",
+                ],
+            },
+            "body": {"type": "string", "description": "New body content."},
+            "tags": {"type": "string", "description": "New tags (comma-separated, replaces existing)."},
+        },
+        "required": ["id"],
+    },
+}
+
+LINEAGE_SCHEMA = {
+    "name": "noema_lineage",
+    "description": "Show the derivation graph for a trace: what it was derived from and what derives from it.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "id": {"type": "string", "description": "Trace ID."},
+        },
+        "required": ["id"],
+    },
+}
+
+ALL_TOOL_SCHEMAS = [
+    SEARCH_SCHEMA, REMEMBER_SCHEMA, RECALL_SCHEMA,
+    LIST_SCHEMA, UPDATE_SCHEMA, LINEAGE_SCHEMA,
+]
+
+# Map Hermes tool names to Noema MCP tool names.
+_TOOL_MAP = {
+    "noema_search": "search_traces",
+    "noema_remember": "create_trace",
+    "noema_recall": "get_trace",
+    "noema_list": "list_traces",
+    "noema_update": "update_trace",
+    "noema_lineage": "trace_lineage",
+}
+
+# Max chars to keep from user/assistant content in the session log.
+_TURN_MAX_CHARS = 2000
+
+
+def _tool_error(msg: str) -> str:
+    return json.dumps({"error": msg})
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# Config loading
+# ---------------------------------------------------------------------------
+
+def _load_config(hermes_home: str) -> dict:
+    """Load noema.json from the Hermes home directory."""
+    config_path = Path(hermes_home) / "noema.json"
+    if config_path.exists():
+        try:
+            return json.loads(config_path.read_text(encoding="utf-8"))
+        except Exception:
+            logger.debug("Failed to parse %s", config_path, exc_info=True)
+    return {}
+
+
+def _load_config_from_hermes_home() -> dict:
+    """Locate and load noema.json without an explicit hermes_home path.
+
+    Resolution: HERMES_HOME env -> ~/.hermes (default).
+    Called by is_available() which runs before initialize() provides hermes_home.
+    """
+    try:
+        hermes_home = os.environ.get("HERMES_HOME", "")
+        if not hermes_home:
+            hermes_home = str(Path.home() / ".hermes")
+        return _load_config(hermes_home)
+    except Exception:
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# NoemaMemoryProvider
+# ---------------------------------------------------------------------------
+
+class NoemaMemoryProvider(MemoryProvider):
+    """Hermes memory provider backed by a Noema Cortex."""
+
+    def __init__(self):
+        self._config: dict = {}
+        self._transport = None
+        self._cortex_name: str = ""
+        self._cortex_id: str = ""
+        self._instructions_cache: str = ""
+        self._session_id: str = ""
+        self._session_trace_id: str = ""
+        self._agent_identity: str = "unknown"
+        self._session_title: str = ""
+        self._platform: str = ""
+        self._turn_count: int = 0
+        self._author: str = "hermes/unknown"
+
+        # Thread tracking for non-blocking hooks.
+        self._sync_thread: Optional[threading.Thread] = None
+        self._end_thread: Optional[threading.Thread] = None
+        self._mirror_thread: Optional[threading.Thread] = None
+
+    # ---- Core required methods ----
+
+    @property
+    def name(self) -> str:
+        return "noema"
+
+    def is_available(self) -> bool:
+        """Check if the plugin can activate — no network calls."""
+        # Load config eagerly if not yet loaded (is_available is called
+        # before initialize, so self._config may be empty).
+        config = self._config
+        if not config:
+            config = _load_config_from_hermes_home()
+        cortex = os.environ.get("NOEMA_CORTEX", "")
+        if not cortex:
+            cortex = config.get("cortex_name", "")
+        if not cortex:
+            return False
+        transport = config.get("transport", "stdio")
+        if transport == "stdio":
+            return find_binary(config.get("noema_binary")) is not None
+        elif transport == "http":
+            return bool(
+                config.get("http_url") or os.environ.get("NOEMA_HTTP_URL")
+            )
+        return False
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        hermes_home = kwargs.get("hermes_home", "")
+        self._config = _load_config(hermes_home) if hermes_home else {}
+        self._session_id = session_id
+        self._agent_identity = kwargs.get("agent_identity", "unknown")
+        self._session_title = kwargs.get("session_title", "")
+        self._platform = kwargs.get("platform", "cli")
+        self._author = f"hermes/{self._agent_identity}"
+
+        self._cortex_name = (
+            os.environ.get("NOEMA_CORTEX", "")
+            or self._config.get("cortex_name", "")
+        )
+
+        transport_mode = self._config.get("transport", "stdio")
+        if transport_mode == "http":
+            url = (
+                self._config.get("http_url")
+                or os.environ.get("NOEMA_HTTP_URL", "")
+            )
+            key = (
+                os.environ.get("NOEMA_MCP_KEY", "")
+                or self._config.get("bearer_key", "")
+            )
+            self._transport = HttpTransport(url, bearer_key=key or None)
+        else:
+            binary = find_binary(self._config.get("noema_binary"))
+            if not binary:
+                raise RuntimeError("noema binary not found")
+            self._transport = StdioTransport(binary, self._cortex_name)
+
+        self._transport.start()
+
+        # Learn cortex identity.
+        try:
+            identity_text = self._transport.call_tool("cortex_identity")
+            identity = json.loads(identity_text)
+            self._cortex_name = identity.get("name", self._cortex_name)
+            self._cortex_id = identity.get("id", "")
+        except Exception as e:
+            logger.warning("Failed to get cortex identity: %s", e)
+
+        # Cache instructions for system_prompt_block.
+        try:
+            self._instructions_cache = self._transport.call_tool("get_instructions")
+        except Exception as e:
+            logger.warning("Failed to get instructions: %s", e)
+
+        # Create the session log trace.
+        self._create_session_trace()
+
+    def get_tool_schemas(self) -> List[Dict[str, Any]]:
+        return list(ALL_TOOL_SCHEMAS)
+
+    def handle_tool_call(self, tool_name: str, args: Dict[str, Any], **kwargs) -> str:
+        noema_tool = _TOOL_MAP.get(tool_name)
+        if not noema_tool:
+            return _tool_error(f"Unknown tool: {tool_name}")
+
+        if not self._transport:
+            return _tool_error("Noema is not connected.")
+
+        # Build arguments for the Noema MCP tool.
+        mcp_args: Dict[str, Any] = {}
+
+        if tool_name == "noema_search":
+            mcp_args["query"] = args.get("query", "")
+
+        elif tool_name == "noema_remember":
+            mcp_args["title"] = args.get("title", "")
+            mcp_args["type"] = args.get("type", "note")
+            mcp_args["body"] = args.get("body", "")
+            mcp_args["author"] = self._author
+            if args.get("tags"):
+                mcp_args["tags"] = args["tags"]
+            if args.get("derived_from"):
+                mcp_args["derived_from"] = args["derived_from"]
+
+        elif tool_name == "noema_recall":
+            mcp_args["id"] = args.get("id", "")
+
+        elif tool_name == "noema_list":
+            for key in ("type", "author", "tag", "origin"):
+                if args.get(key):
+                    mcp_args[key] = args[key]
+
+        elif tool_name == "noema_update":
+            mcp_args["id"] = args.get("id", "")
+            for key in ("title", "type", "body", "tags"):
+                if args.get(key):
+                    mcp_args[key] = args[key]
+
+        elif tool_name == "noema_lineage":
+            mcp_args["id"] = args.get("id", "")
+
+        try:
+            result = self._transport.call_tool(noema_tool, mcp_args)
+            return json.dumps({"result": result})
+        except Exception as e:
+            # Attempt one restart for stdio transport.
+            if isinstance(self._transport, StdioTransport) and not self._transport.is_alive:
+                try:
+                    logger.info("Noema subprocess died, attempting restart")
+                    self._transport.start()
+                    result = self._transport.call_tool(noema_tool, mcp_args)
+                    return json.dumps({"result": result})
+                except Exception as e2:
+                    return _tool_error(f"Noema restart failed: {e2}")
+            return _tool_error(str(e))
+
+    # ---- Optional lifecycle hooks ----
+
+    def system_prompt_block(self) -> str:
+        return self._instructions_cache
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        if not self._transport or not query.strip():
+            return ""
+        try:
+            result = self._transport.call_tool("search_traces", {"query": query[:500]})
+            if not result or result == "No traces found.":
+                return ""
+            # Filter out session log traces from prefetch results.
+            lines = result.split("\n")
+            filtered = []
+            skip_until_next = False
+            for line in lines:
+                if "hermes-session" in line and "hermes-session-summary" not in line:
+                    skip_until_next = True
+                    continue
+                if skip_until_next and line.startswith("["):
+                    skip_until_next = False
+                if not skip_until_next:
+                    filtered.append(line)
+            context = "\n".join(filtered).strip()
+            if not context:
+                return ""
+            return (
+                "## Relevant Memories (from Noema)\n\n"
+                f"{context}\n\n"
+                "---\n"
+                "Use noema_search for more specific queries, "
+                "or noema_recall to read a full trace."
+            )
+        except Exception as e:
+            logger.debug("Noema prefetch failed: %s", e)
+            return ""
+
+    def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
+        # No-op in v1 — FTS5 on local SQLite is sub-millisecond.
+        pass
+
+    def on_turn_start(self, turn_number: int, message: str, **kwargs) -> None:
+        self._turn_count = turn_number
+
+    def sync_turn(self, user_content: str, assistant_content: str, *, session_id: str = "") -> None:
+        if not self._transport or not self._session_trace_id:
+            return
+
+        user_trunc = user_content[:_TURN_MAX_CHARS]
+        asst_trunc = assistant_content[:_TURN_MAX_CHARS]
+        turn_num = self._turn_count
+        timestamp = _now_iso()
+
+        def _sync():
+            try:
+                block = (
+                    f"\n---\n### Turn {turn_num} — {timestamp}\n\n"
+                    f"**User:** {user_trunc}\n\n"
+                    f"**Assistant:** {asst_trunc}"
+                )
+                self._transport.call_tool("append_trace", {
+                    "id": self._session_trace_id,
+                    "content": block,
+                })
+            except Exception as e:
+                logger.debug("Noema sync_turn failed: %s", e)
+
+        if self._sync_thread and self._sync_thread.is_alive():
+            self._sync_thread.join(timeout=5.0)
+        self._sync_thread = threading.Thread(target=_sync, daemon=True, name="noema-sync")
+        self._sync_thread.start()
+
+    def on_session_end(self, messages: List[Dict[str, Any]]) -> None:
+        if not self._transport or not self._session_trace_id:
+            return
+
+        session_trace_id = self._session_trace_id
+        turn_count = self._turn_count
+        title = self._session_title or self._session_id[:12]
+
+        # Extract last assistant message for the summary.
+        last_assistant = ""
+        for msg in reversed(messages or []):
+            if msg.get("role") == "assistant":
+                content = msg.get("content", "")
+                if isinstance(content, str) and content.strip():
+                    last_assistant = content[:3000]
+                    break
+
+        def _end():
+            try:
+                # Wait for any pending sync_turn to finish.
+                if self._sync_thread and self._sync_thread.is_alive():
+                    self._sync_thread.join(timeout=5.0)
+
+                body = f"Session with {turn_count} turns.\n\n{last_assistant}" if last_assistant else f"Session with {turn_count} turns."
+                self._transport.call_tool("create_trace", {
+                    "title": f"session-summary: {title}",
+                    "type": "observation",
+                    "author": self._author,
+                    "tags": f"hermes-session-summary, session-{self._session_id[:12]}",
+                    "derived_from": session_trace_id,
+                    "body": body,
+                })
+                self._transport.call_tool("archive_trace", {
+                    "id": session_trace_id,
+                })
+            except Exception as e:
+                logger.debug("Noema on_session_end failed: %s", e)
+
+        if self._end_thread and self._end_thread.is_alive():
+            self._end_thread.join(timeout=5.0)
+        self._end_thread = threading.Thread(target=_end, daemon=True, name="noema-end")
+        self._end_thread.start()
+
+    def on_pre_compress(self, messages: List[Dict[str, Any]]) -> str:
+        if not self._transport or not self._session_trace_id:
+            return ""
+
+        timestamp = _now_iso()
+        session_trace_id = self._session_trace_id
+        turn_count = len([m for m in (messages or []) if m.get("role") == "user"])
+
+        # Build a compressed block from the messages being dropped.
+        parts = []
+        for msg in messages or []:
+            role = msg.get("role", "")
+            content = str(msg.get("content", ""))[:500]
+            if role in ("user", "assistant") and content.strip():
+                parts.append(f"**{role.title()}:** {content}")
+        block = "\n\n".join(parts)
+
+        def _compress():
+            try:
+                self._transport.call_tool("append_trace", {
+                    "id": session_trace_id,
+                    "content": (
+                        f"\n---\n## Context compression at {timestamp}\n\n"
+                        f"{turn_count} turns compressed.\n\n{block}"
+                    ),
+                })
+            except Exception as e:
+                logger.debug("Noema on_pre_compress append failed: %s", e)
+
+        thread = threading.Thread(target=_compress, daemon=True, name="noema-compress")
+        thread.start()
+
+        return (
+            f"Context compressed. Prior conversation preserved in Noema trace "
+            f"{session_trace_id}. Use noema_recall to retrieve if needed."
+        )
+
+    def on_memory_write(self, action: str, target: str, content: str) -> None:
+        if not self._transport:
+            return
+
+        def _mirror():
+            try:
+                if action == "add":
+                    # Extract a title from the first line or truncate.
+                    lines = content.strip().split("\n")
+                    title = lines[0][:80] if lines else "mirrored memory"
+                    self._transport.call_tool("create_trace", {
+                        "title": title,
+                        "type": "note",
+                        "author": self._author,
+                        "tags": "hermes-mirror",
+                        "body": content,
+                    })
+                elif action == "update":
+                    # Try to find and update a matching mirrored trace.
+                    results = self._transport.call_tool("search_traces", {
+                        "query": target[:200],
+                    })
+                    # Best-effort: if we can't find it, create a new one.
+                    if results and results != "No traces found.":
+                        # Extract the first trace ID from the results.
+                        trace_id = self._extract_first_trace_id(results)
+                        if trace_id:
+                            self._transport.call_tool("update_trace", {
+                                "id": trace_id,
+                                "body": content,
+                            })
+                            return
+                    # Fallback: create a new trace.
+                    self._transport.call_tool("create_trace", {
+                        "title": target[:80] or "mirrored memory",
+                        "type": "note",
+                        "author": self._author,
+                        "tags": "hermes-mirror",
+                        "body": content,
+                    })
+                elif action == "delete":
+                    results = self._transport.call_tool("search_traces", {
+                        "query": target[:200],
+                    })
+                    if results and results != "No traces found.":
+                        trace_id = self._extract_first_trace_id(results)
+                        if trace_id:
+                            self._transport.call_tool("archive_trace", {"id": trace_id})
+            except Exception as e:
+                logger.debug("Noema on_memory_write failed: %s", e)
+
+        if self._mirror_thread and self._mirror_thread.is_alive():
+            self._mirror_thread.join(timeout=3.0)
+        self._mirror_thread = threading.Thread(target=_mirror, daemon=True, name="noema-mirror")
+        self._mirror_thread.start()
+
+    def shutdown(self) -> None:
+        # Join all daemon threads.
+        for thread in (self._sync_thread, self._end_thread, self._mirror_thread):
+            if thread and thread.is_alive():
+                thread.join(timeout=5.0)
+        # Close the transport.
+        if self._transport:
+            self._transport.close()
+            self._transport = None
+
+    # ---- Config ----
+
+    def get_config_schema(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "key": "cortex_name",
+                "description": "Name of the Noema cortex to use",
+                "required": True,
+                "env_var": "NOEMA_CORTEX",
+            },
+            {
+                "key": "noema_binary",
+                "description": "Path to the noema binary (auto-detected from PATH if omitted)",
+                "required": False,
+                "env_var": "NOEMA_BINARY",
+            },
+            {
+                "key": "transport",
+                "description": "How to connect: 'stdio' (spawn subprocess) or 'http' (connect to running server)",
+                "required": False,
+                "default": "stdio",
+                "choices": ["stdio", "http"],
+            },
+            {
+                "key": "http_url",
+                "description": "Noema HTTP endpoint (e.g. https://10.0.0.1:3000). Required when transport=http",
+                "required": False,
+                "env_var": "NOEMA_HTTP_URL",
+            },
+            {
+                "key": "bearer_key",
+                "description": "Bearer key for keyed-mode auth",
+                "required": False,
+                "secret": True,
+                "env_var": "NOEMA_MCP_KEY",
+            },
+        ]
+
+    def save_config(self, values: Dict[str, Any], hermes_home: str) -> None:
+        sanitized = {k: v for k, v in (values or {}).items() if v is not None}
+        config_path = Path(hermes_home) / "noema.json"
+        config_path.write_text(
+            json.dumps(sanitized, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+    # ---- Internal helpers ----
+
+    def _create_session_trace(self) -> None:
+        """Create the session log trace on initialize.
+
+        If the trace already exists (same session re-initialized on the same
+        day), look it up and reuse it instead of failing.
+        """
+        title_label = self._session_title or self._session_id[:12]
+        session_tag = f"session-{self._session_id[:12]}"
+        body = (
+            f"Session ID: {self._session_id}\n"
+            f"Agent: {self._agent_identity}\n"
+            f"Platform: {self._platform}\n"
+            f"Started: {_now_iso()}"
+        )
+        try:
+            result = self._transport.call_tool("create_trace", {
+                "title": f"hermes-session: {title_label}",
+                "type": "context",
+                "author": self._author,
+                "tags": f"hermes-session, {session_tag}",
+                "body": body,
+            })
+            # Extract trace ID from "Trace created: <id>" response.
+            if result and result.startswith("Trace created: "):
+                self._session_trace_id = result.split("Trace created: ", 1)[1].strip()
+            else:
+                logger.warning("Unexpected create_trace response: %s", result)
+        except RuntimeError as e:
+            if "UNIQUE constraint" in str(e):
+                # Session re-initialized — find and reuse the existing trace.
+                logger.info("Session trace already exists, reusing")
+                self._recover_session_trace(session_tag)
+            else:
+                logger.warning("Failed to create session trace: %s", e)
+        except Exception as e:
+            logger.warning("Failed to create session trace: %s", e)
+
+    def _recover_session_trace(self, session_tag: str) -> None:
+        """Find an existing session trace by tag and reuse it."""
+        try:
+            result = self._transport.call_tool(
+                "search_traces", {"query": session_tag}
+            )
+            trace_id = self._extract_first_trace_id(result)
+            if trace_id:
+                self._session_trace_id = trace_id
+                logger.info("Recovered session trace: %s", trace_id)
+            else:
+                logger.warning("Could not find existing session trace for %s", session_tag)
+        except Exception as e:
+            logger.warning("Failed to recover session trace: %s", e)
+
+    @staticmethod
+    def _extract_first_trace_id(list_output: str) -> Optional[str]:
+        """Extract the first trace ID from list_traces/search_traces output.
+
+        Output format: [type] trace-id (YYYY-MM-DD) — author [tags]
+        """
+        for line in list_output.split("\n"):
+            line = line.strip()
+            if line.startswith("["):
+                # [type] trace-id (date) — ...
+                parts = line.split("]", 1)
+                if len(parts) > 1:
+                    rest = parts[1].strip()
+                    trace_id = rest.split(" ", 1)[0].strip()
+                    if trace_id:
+                        return trace_id
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Plugin registration
+# ---------------------------------------------------------------------------
+
+def register(ctx) -> None:
+    """Called by Hermes plugin discovery."""
+    ctx.register_memory_provider(NoemaMemoryProvider())

--- a/plugins/hermes/plugin.yaml
+++ b/plugins/hermes/plugin.yaml
@@ -1,0 +1,8 @@
+name: noema
+version: 0.1.0
+description: "Structured memory backed by a Noema Cortex — markdown traces with types, tags, lineage, and full-text search."
+hooks:
+  - sync_turn
+  - on_session_end
+  - on_pre_compress
+  - on_memory_write

--- a/plugins/hermes/tests/test_integration.py
+++ b/plugins/hermes/tests/test_integration.py
@@ -1,0 +1,358 @@
+"""Integration tests for the Noema Hermes plugin — requires the noema binary.
+
+These tests spawn a real `noema serve --transport stdio` subprocess against
+a throwaway cortex and exercise the full plugin lifecycle.
+
+Skip with: pytest -m "not integration"
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import time
+
+import pytest
+
+from plugins.hermes.transport import find_binary, reset_binary_cache, StdioTransport
+from plugins.hermes import NoemaMemoryProvider
+
+# Mark every test in this module as integration.
+pytestmark = pytest.mark.integration
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+NOEMA_BINARY = None
+
+
+def _find_noema():
+    global NOEMA_BINARY
+    if NOEMA_BINARY is None:
+        reset_binary_cache()
+        NOEMA_BINARY = find_binary()
+    return NOEMA_BINARY
+
+
+@pytest.fixture(scope="module")
+def noema_binary():
+    binary = _find_noema()
+    if not binary:
+        pytest.skip("noema binary not found — skipping integration tests")
+    return binary
+
+
+@pytest.fixture()
+def cortex_dir(noema_binary):
+    """Create a throwaway cortex and return its path. Cleaned up after the test."""
+    tmpdir = tempfile.mkdtemp(prefix="noema-test-")
+    name = "hermes-test"
+    result = subprocess.run(
+        [noema_binary, "init", "--name", name, "--path", tmpdir],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, f"noema init failed: {result.stderr}"
+    yield name
+    shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Transport integration
+# ---------------------------------------------------------------------------
+
+class TestStdioTransportIntegration:
+    def test_start_and_handshake(self, noema_binary, cortex_dir):
+        t = StdioTransport(noema_binary, cortex_dir)
+        t.start()
+        assert t.is_alive
+        t.close()
+        assert not t.is_alive
+
+    def test_call_cortex_identity(self, noema_binary, cortex_dir):
+        t = StdioTransport(noema_binary, cortex_dir)
+        t.start()
+        try:
+            result = t.call_tool("cortex_identity")
+            identity = json.loads(result)
+            assert "name" in identity
+            assert "id" in identity
+            assert identity["name"] == cortex_dir
+        finally:
+            t.close()
+
+    def test_call_get_instructions(self, noema_binary, cortex_dir):
+        t = StdioTransport(noema_binary, cortex_dir)
+        t.start()
+        try:
+            result = t.call_tool("get_instructions")
+            assert "Trace" in result or "trace" in result
+            assert len(result) > 100  # Should be a substantial guide.
+        finally:
+            t.close()
+
+    def test_create_and_get_trace(self, noema_binary, cortex_dir):
+        t = StdioTransport(noema_binary, cortex_dir)
+        t.start()
+        try:
+            # Create a trace.
+            create_result = t.call_tool("create_trace", {
+                "title": "integration-test-trace",
+                "type": "note",
+                "body": "This is a test trace from the integration suite.",
+                "tags": "test, integration",
+            })
+            assert "Trace created:" in create_result
+            trace_id = create_result.split("Trace created: ")[1].strip()
+
+            # Get it back.
+            get_result = t.call_tool("get_trace", {"id": trace_id})
+            assert "integration-test-trace" in get_result
+            assert "This is a test trace" in get_result
+        finally:
+            t.close()
+
+    def test_search_traces(self, noema_binary, cortex_dir):
+        t = StdioTransport(noema_binary, cortex_dir)
+        t.start()
+        try:
+            # Create a trace with distinctive content.
+            t.call_tool("create_trace", {
+                "title": "zebra-unique-term",
+                "type": "fact",
+                "body": "Zebras have distinctive black and white stripes.",
+            })
+            # Search for it.
+            result = t.call_tool("search_traces", {"query": "zebra"})
+            assert "zebra" in result.lower()
+        finally:
+            t.close()
+
+    def test_append_trace(self, noema_binary, cortex_dir):
+        t = StdioTransport(noema_binary, cortex_dir)
+        t.start()
+        try:
+            # Create, then append.
+            create_result = t.call_tool("create_trace", {
+                "title": "append-target",
+                "type": "context",
+                "body": "Initial content.",
+            })
+            trace_id = create_result.split("Trace created: ")[1].strip()
+
+            t.call_tool("append_trace", {
+                "id": trace_id,
+                "content": "\n---\nAppended block.",
+            })
+
+            get_result = t.call_tool("get_trace", {"id": trace_id})
+            assert "Initial content." in get_result
+            assert "Appended block." in get_result
+        finally:
+            t.close()
+
+    def test_list_traces(self, noema_binary, cortex_dir):
+        t = StdioTransport(noema_binary, cortex_dir)
+        t.start()
+        try:
+            t.call_tool("create_trace", {
+                "title": "list-test",
+                "type": "decision",
+                "body": "Listing test.",
+            })
+            result = t.call_tool("list_traces")
+            assert "list-test" in result
+        finally:
+            t.close()
+
+    def test_archive_and_list(self, noema_binary, cortex_dir):
+        t = StdioTransport(noema_binary, cortex_dir)
+        t.start()
+        try:
+            create_result = t.call_tool("create_trace", {
+                "title": "archive-me",
+                "type": "note",
+                "body": "Will be archived.",
+            })
+            trace_id = create_result.split("Trace created: ")[1].strip()
+
+            t.call_tool("archive_trace", {"id": trace_id})
+
+            # Should not appear in default list.
+            result = t.call_tool("list_traces")
+            assert trace_id not in result
+        finally:
+            t.close()
+
+    def test_close_is_idempotent(self, noema_binary, cortex_dir):
+        t = StdioTransport(noema_binary, cortex_dir)
+        t.start()
+        t.close()
+        t.close()  # Should not raise.
+
+
+# ---------------------------------------------------------------------------
+# Full provider lifecycle
+# ---------------------------------------------------------------------------
+
+class TestProviderLifecycle:
+    def test_full_session(self, noema_binary, cortex_dir):
+        """Exercise the full Hermes lifecycle: init -> turns -> end -> shutdown."""
+        provider = NoemaMemoryProvider()
+        provider._config = {"cortex_name": cortex_dir, "transport": "stdio"}
+
+        # Initialize.
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("NOEMA_CORTEX", cortex_dir)
+            provider.initialize(
+                session_id="test-session-001",
+                agent_identity="researcher",
+                session_title="Integration test session",
+                platform="pytest",
+            )
+
+        assert provider._transport is not None
+        assert provider._transport.is_alive
+        assert provider._cortex_name == cortex_dir
+        assert provider._session_trace_id  # Should have created a session trace.
+        assert provider._instructions_cache  # Should have cached instructions.
+        assert provider._author == "hermes/researcher"
+
+        # System prompt block should return cached instructions.
+        prompt = provider.system_prompt_block()
+        assert len(prompt) > 100
+
+        # Tool schemas.
+        schemas = provider.get_tool_schemas()
+        assert len(schemas) == 6
+
+        # Simulate turns.
+        provider.on_turn_start(1, "What do you know about Go?")
+        provider.sync_turn(
+            "What do you know about Go?",
+            "Go is a statically typed language designed at Google.",
+        )
+        # Wait for the sync thread to complete.
+        if provider._sync_thread:
+            provider._sync_thread.join(timeout=5)
+
+        provider.on_turn_start(2, "Why did we choose it?")
+        provider.sync_turn(
+            "Why did we choose it?",
+            "We chose Go for pure-Go SQLite and fast iteration.",
+        )
+        if provider._sync_thread:
+            provider._sync_thread.join(timeout=5)
+
+        # Verify the session trace got appended.
+        session_content = provider._transport.call_tool(
+            "get_trace", {"id": provider._session_trace_id}
+        )
+        assert "Turn 1" in session_content
+        assert "Turn 2" in session_content
+        assert "Go" in session_content
+
+        # Tool calls.
+        result = json.loads(provider.handle_tool_call("noema_remember", {
+            "title": "Go is great",
+            "type": "decision",
+            "body": "We chose Go for its simplicity and tooling.",
+            "tags": "go, lang",
+        }))
+        assert "result" in result
+        assert "Trace created:" in result["result"]
+
+        # Search.
+        result = json.loads(provider.handle_tool_call("noema_search", {
+            "query": "Go simplicity",
+        }))
+        assert "result" in result
+
+        # Prefetch.
+        prefetch_result = provider.prefetch("Go language choice")
+        # May or may not find results depending on FTS indexing timing.
+        # Just verify it doesn't crash and returns a string.
+        assert isinstance(prefetch_result, str)
+
+        # Session end.
+        messages = [
+            {"role": "user", "content": "What do you know about Go?"},
+            {"role": "assistant", "content": "Go is a statically typed language."},
+            {"role": "user", "content": "Why did we choose it?"},
+            {"role": "assistant", "content": "We chose Go for pure-Go SQLite."},
+        ]
+        provider.on_session_end(messages)
+        if provider._end_thread:
+            provider._end_thread.join(timeout=10)
+
+        # Verify summary was created. List by type.
+        summary_result = provider._transport.call_tool(
+            "list_traces", {"type": "observation"}
+        )
+        assert "session-summary" in summary_result
+
+        # Verify session log was archived (shouldn't show in default list).
+        list_result = provider._transport.call_tool("list_traces")
+        assert provider._session_trace_id not in list_result
+
+        # Shutdown.
+        provider.shutdown()
+        assert provider._transport is None
+
+    def test_memory_write_add(self, noema_binary, cortex_dir):
+        """Test on_memory_write with add action."""
+        provider = NoemaMemoryProvider()
+        provider._config = {"cortex_name": cortex_dir, "transport": "stdio"}
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("NOEMA_CORTEX", cortex_dir)
+            provider.initialize(
+                session_id="test-mirror-001",
+                agent_identity="tester",
+            )
+
+        provider.on_memory_write("add", "test-memory", "This is a mirrored memory.")
+        if provider._mirror_thread:
+            provider._mirror_thread.join(timeout=5)
+
+        # Verify it was created.
+        result = provider._transport.call_tool(
+            "search_traces", {"query": "mirrored memory"}
+        )
+        assert "hermes-mirror" in result or "mirrored" in result.lower()
+
+        provider.shutdown()
+
+    def test_pre_compress(self, noema_binary, cortex_dir):
+        """Test on_pre_compress returns a breadcrumb and appends to session log."""
+        provider = NoemaMemoryProvider()
+        provider._config = {"cortex_name": cortex_dir, "transport": "stdio"}
+
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setenv("NOEMA_CORTEX", cortex_dir)
+            provider.initialize(
+                session_id="test-compress-001",
+                agent_identity="tester",
+            )
+
+        messages = [
+            {"role": "user", "content": "First message"},
+            {"role": "assistant", "content": "First reply"},
+        ]
+
+        breadcrumb = provider.on_pre_compress(messages)
+        assert "Context compressed" in breadcrumb
+        assert provider._session_trace_id in breadcrumb
+        assert "noema_recall" in breadcrumb
+
+        # Wait for the background thread.
+        time.sleep(1)
+
+        # Verify the compression block was appended.
+        session_content = provider._transport.call_tool(
+            "get_trace", {"id": provider._session_trace_id}
+        )
+        assert "Context compression" in session_content
+
+        provider.shutdown()

--- a/plugins/hermes/tests/test_unit.py
+++ b/plugins/hermes/tests/test_unit.py
@@ -1,0 +1,598 @@
+"""Unit tests for the Noema Hermes plugin — no binary or network needed."""
+
+import json
+import os
+import stat
+import tempfile
+import threading
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Import transport helpers directly.
+from plugins.hermes.transport import (
+    _jsonrpc_request,
+    _parse_jsonrpc_response,
+    _extract_text,
+    find_binary,
+    reset_binary_cache,
+    StdioTransport,
+    HttpTransport,
+)
+from plugins.hermes import (
+    __version__,
+    NoemaMemoryProvider,
+    ALL_TOOL_SCHEMAS,
+    _TOOL_MAP,
+    _tool_error,
+    _now_iso,
+    _load_config,
+)
+
+
+# ---------------------------------------------------------------------------
+# transport.py — JSON-RPC helpers
+# ---------------------------------------------------------------------------
+
+class TestJsonRpcRequest:
+    def test_basic_request(self):
+        raw = _jsonrpc_request("tools/call", {"name": "list_traces"}, 1)
+        payload = json.loads(raw.decode("utf-8"))
+        assert payload["jsonrpc"] == "2.0"
+        assert payload["id"] == 1
+        assert payload["method"] == "tools/call"
+        assert payload["params"] == {"name": "list_traces"}
+
+    def test_newline_terminated(self):
+        raw = _jsonrpc_request("initialize", {}, 42)
+        assert raw.endswith(b"\n")
+
+    def test_incrementing_ids(self):
+        r1 = json.loads(_jsonrpc_request("a", {}, 1))
+        r2 = json.loads(_jsonrpc_request("b", {}, 2))
+        assert r1["id"] == 1
+        assert r2["id"] == 2
+
+
+class TestParseJsonRpcResponse:
+    def test_success_response(self):
+        line = json.dumps({"jsonrpc": "2.0", "id": 1, "result": {"content": []}})
+        result = _parse_jsonrpc_response(line)
+        assert result == {"content": []}
+
+    def test_error_response_dict(self):
+        line = json.dumps({"jsonrpc": "2.0", "id": 1, "error": {"message": "not found"}})
+        with pytest.raises(RuntimeError, match="not found"):
+            _parse_jsonrpc_response(line)
+
+    def test_error_response_string(self):
+        line = json.dumps({"jsonrpc": "2.0", "id": 1, "error": "something broke"})
+        with pytest.raises(RuntimeError, match="something broke"):
+            _parse_jsonrpc_response(line)
+
+    def test_null_error_is_success(self):
+        line = json.dumps({"jsonrpc": "2.0", "id": 1, "result": {"ok": True}, "error": None})
+        result = _parse_jsonrpc_response(line)
+        assert result == {"ok": True}
+
+    def test_missing_result_returns_empty(self):
+        line = json.dumps({"jsonrpc": "2.0", "id": 1})
+        result = _parse_jsonrpc_response(line)
+        assert result == {}
+
+
+class TestExtractText:
+    def test_extracts_text_content(self):
+        result = {"content": [{"type": "text", "text": "hello world"}]}
+        assert _extract_text(result) == "hello world"
+
+    def test_skips_non_text_content(self):
+        result = {"content": [{"type": "image", "data": "..."}, {"type": "text", "text": "found"}]}
+        assert _extract_text(result) == "found"
+
+    def test_empty_content(self):
+        assert _extract_text({"content": []}) == ""
+        assert _extract_text({}) == ""
+
+    def test_missing_text_field(self):
+        result = {"content": [{"type": "text"}]}
+        assert _extract_text(result) == ""
+
+
+# ---------------------------------------------------------------------------
+# transport.py — binary discovery
+# ---------------------------------------------------------------------------
+
+class TestFindBinary:
+    def setup_method(self):
+        reset_binary_cache()
+
+    def teardown_method(self):
+        reset_binary_cache()
+
+    def test_explicit_override(self, tmp_path):
+        binary = tmp_path / "noema"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+        result = find_binary(str(binary))
+        assert result == str(binary)
+
+    def test_explicit_override_not_found(self, tmp_path):
+        result = find_binary(str(tmp_path / "nonexistent"))
+        assert result is None
+
+    def test_env_var_override(self, tmp_path):
+        binary = tmp_path / "noema"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+        reset_binary_cache()
+        with patch.dict(os.environ, {"NOEMA_BINARY": str(binary)}):
+            result = find_binary()
+            assert result == str(binary)
+
+    def test_path_lookup(self, tmp_path):
+        reset_binary_cache()
+        binary = tmp_path / "noema"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+        with patch.dict(os.environ, {}, clear=True):
+            with patch("plugins.hermes.transport.shutil.which", return_value=str(binary)):
+                result = find_binary()
+                assert result == str(binary)
+
+    def test_cache_persists(self, tmp_path):
+        binary = tmp_path / "noema"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+        reset_binary_cache()
+        result1 = find_binary(str(binary))
+        # Second call should use cache even without the override.
+        result2 = find_binary()
+        assert result1 == result2 == str(binary)
+
+    def test_cache_cleared(self, tmp_path):
+        binary = tmp_path / "noema"
+        binary.write_text("#!/bin/sh\n")
+        binary.chmod(0o755)
+        find_binary(str(binary))
+        reset_binary_cache()
+        # After reset, with no PATH or override, should return None
+        # (assuming shutil.which won't find it in tmp_path).
+        with patch("plugins.hermes.transport.shutil.which", return_value=None):
+            result = find_binary()
+            # May find it in well-known locations; just verify cache was reset.
+            # The important thing is no exception.
+
+
+# ---------------------------------------------------------------------------
+# transport.py — StdioTransport
+# ---------------------------------------------------------------------------
+
+class TestStdioTransport:
+    def test_is_alive_before_start(self):
+        t = StdioTransport("/usr/bin/false", "test-cortex")
+        assert t.is_alive is False
+
+    def test_close_before_start(self):
+        t = StdioTransport("/usr/bin/false", "test-cortex")
+        t.close()  # Should not raise.
+
+    def test_send_raises_when_not_running(self):
+        t = StdioTransport("/usr/bin/false", "test-cortex")
+        with pytest.raises(RuntimeError, match="not running"):
+            t.call_tool("list_traces")
+
+
+# ---------------------------------------------------------------------------
+# transport.py — HttpTransport
+# ---------------------------------------------------------------------------
+
+class TestHttpTransport:
+    def test_url_normalization(self):
+        t = HttpTransport("http://localhost:3000")
+        assert t._url == "http://localhost:3000/mcp"
+
+    def test_url_already_has_mcp(self):
+        t = HttpTransport("http://localhost:3000/mcp")
+        assert t._url == "http://localhost:3000/mcp"
+
+    def test_url_trailing_slash(self):
+        t = HttpTransport("http://localhost:3000/")
+        assert t._url == "http://localhost:3000/mcp"
+
+    def test_is_alive_always_true(self):
+        t = HttpTransport("http://localhost:3000")
+        assert t.is_alive is True
+
+    def test_close_is_noop(self):
+        t = HttpTransport("http://localhost:3000")
+        t.close()  # Should not raise.
+
+    def test_bearer_key_stored(self):
+        t = HttpTransport("http://localhost:3000", bearer_key="secret123")
+        assert t._bearer_key == "secret123"
+
+
+# ---------------------------------------------------------------------------
+# __init__.py — version
+# ---------------------------------------------------------------------------
+
+class TestVersion:
+    def test_version_exists(self):
+        assert __version__
+        parts = __version__.split(".")
+        assert len(parts) == 3
+
+
+# ---------------------------------------------------------------------------
+# __init__.py — tool schemas
+# ---------------------------------------------------------------------------
+
+class TestToolSchemas:
+    def test_six_tools(self):
+        assert len(ALL_TOOL_SCHEMAS) == 6
+
+    def test_all_have_required_fields(self):
+        for schema in ALL_TOOL_SCHEMAS:
+            assert "name" in schema
+            assert "description" in schema
+            assert "parameters" in schema
+            assert schema["parameters"]["type"] == "object"
+
+    def test_tool_names(self):
+        names = {s["name"] for s in ALL_TOOL_SCHEMAS}
+        assert names == {
+            "noema_search", "noema_remember", "noema_recall",
+            "noema_list", "noema_update", "noema_lineage",
+        }
+
+    def test_remember_required_fields(self):
+        schema = next(s for s in ALL_TOOL_SCHEMAS if s["name"] == "noema_remember")
+        assert set(schema["parameters"]["required"]) == {"title", "type", "body"}
+
+    def test_search_required_fields(self):
+        schema = next(s for s in ALL_TOOL_SCHEMAS if s["name"] == "noema_search")
+        assert schema["parameters"]["required"] == ["query"]
+
+    def test_remember_type_enum(self):
+        schema = next(s for s in ALL_TOOL_SCHEMAS if s["name"] == "noema_remember")
+        enum = schema["parameters"]["properties"]["type"]["enum"]
+        assert "fact" in enum
+        assert "decision" in enum
+        assert "divergence" not in enum  # Agent can't create divergence traces.
+
+
+# ---------------------------------------------------------------------------
+# __init__.py — tool mapping
+# ---------------------------------------------------------------------------
+
+class TestToolMap:
+    def test_all_schemas_mapped(self):
+        schema_names = {s["name"] for s in ALL_TOOL_SCHEMAS}
+        mapped_names = set(_TOOL_MAP.keys())
+        assert schema_names == mapped_names
+
+    def test_mapping_values(self):
+        assert _TOOL_MAP["noema_search"] == "search_traces"
+        assert _TOOL_MAP["noema_remember"] == "create_trace"
+        assert _TOOL_MAP["noema_recall"] == "get_trace"
+        assert _TOOL_MAP["noema_list"] == "list_traces"
+        assert _TOOL_MAP["noema_update"] == "update_trace"
+        assert _TOOL_MAP["noema_lineage"] == "trace_lineage"
+
+
+# ---------------------------------------------------------------------------
+# __init__.py — helpers
+# ---------------------------------------------------------------------------
+
+class TestHelpers:
+    def test_tool_error_json(self):
+        result = json.loads(_tool_error("something broke"))
+        assert result == {"error": "something broke"}
+
+    def test_now_iso_format(self):
+        ts = _now_iso()
+        assert ts.endswith("Z")
+        assert "T" in ts
+
+    def test_extract_first_trace_id(self):
+        output = "[fact] 20260412-my-trace (2026-04-12) — agent [tag1]"
+        result = NoemaMemoryProvider._extract_first_trace_id(output)
+        assert result == "20260412-my-trace"
+
+    def test_extract_first_trace_id_multiline(self):
+        output = (
+            "Found 2 traces:\n"
+            "[decision] 20260412-chose-go (2026-04-12) — mark [go]\n"
+            "[fact] 20260412-sqlite-perf (2026-04-12) — mark [perf]"
+        )
+        result = NoemaMemoryProvider._extract_first_trace_id(output)
+        assert result == "20260412-chose-go"
+
+    def test_extract_first_trace_id_none(self):
+        assert NoemaMemoryProvider._extract_first_trace_id("No traces found.") is None
+        assert NoemaMemoryProvider._extract_first_trace_id("") is None
+
+
+# ---------------------------------------------------------------------------
+# __init__.py — config loading
+# ---------------------------------------------------------------------------
+
+class TestConfig:
+    def test_load_config(self, tmp_path):
+        config = {"cortex_name": "test", "transport": "stdio"}
+        (tmp_path / "noema.json").write_text(json.dumps(config))
+        result = _load_config(str(tmp_path))
+        assert result == config
+
+    def test_load_config_missing(self, tmp_path):
+        result = _load_config(str(tmp_path))
+        assert result == {}
+
+    def test_load_config_invalid_json(self, tmp_path):
+        (tmp_path / "noema.json").write_text("not json{{{")
+        result = _load_config(str(tmp_path))
+        assert result == {}
+
+    def test_save_config(self, tmp_path):
+        provider = NoemaMemoryProvider()
+        provider.save_config({"cortex_name": "my-cortex", "transport": "stdio"}, str(tmp_path))
+        saved = json.loads((tmp_path / "noema.json").read_text())
+        assert saved["cortex_name"] == "my-cortex"
+        assert saved["transport"] == "stdio"
+
+    def test_save_config_strips_none(self, tmp_path):
+        provider = NoemaMemoryProvider()
+        provider.save_config({"cortex_name": "x", "bearer_key": None}, str(tmp_path))
+        saved = json.loads((tmp_path / "noema.json").read_text())
+        assert "bearer_key" not in saved
+
+    def test_config_schema(self):
+        provider = NoemaMemoryProvider()
+        schema = provider.get_config_schema()
+        keys = [item["key"] for item in schema]
+        assert keys == ["cortex_name", "noema_binary", "transport", "http_url", "bearer_key"]
+        required = [item["key"] for item in schema if item.get("required")]
+        assert required == ["cortex_name"]
+        secret = [item["key"] for item in schema if item.get("secret")]
+        assert secret == ["bearer_key"]
+
+
+# ---------------------------------------------------------------------------
+# __init__.py — provider basics
+# ---------------------------------------------------------------------------
+
+class TestProviderBasics:
+    def test_name(self):
+        p = NoemaMemoryProvider()
+        assert p.name == "noema"
+
+    def test_is_available_no_cortex(self):
+        p = NoemaMemoryProvider()
+        with patch.dict(os.environ, {}, clear=True):
+            assert p.is_available() is False
+
+    def test_is_available_stdio_no_binary(self):
+        p = NoemaMemoryProvider()
+        p._config = {"cortex_name": "test", "transport": "stdio"}
+        reset_binary_cache()
+        with patch.dict(os.environ, {"NOEMA_CORTEX": "test"}, clear=True):
+            with patch("plugins.hermes.transport.shutil.which", return_value=None):
+                with patch("plugins.hermes.transport.Path.is_file", return_value=False):
+                    assert p.is_available() is False
+        reset_binary_cache()
+
+    def test_is_available_http_no_url(self):
+        p = NoemaMemoryProvider()
+        p._config = {"cortex_name": "test", "transport": "http"}
+        with patch.dict(os.environ, {"NOEMA_CORTEX": "test"}, clear=True):
+            assert p.is_available() is False
+
+    def test_is_available_http_with_url(self):
+        p = NoemaMemoryProvider()
+        p._config = {"cortex_name": "test", "transport": "http", "http_url": "http://localhost:3000"}
+        with patch.dict(os.environ, {"NOEMA_CORTEX": "test"}, clear=True):
+            assert p.is_available() is True
+
+    def test_get_tool_schemas_returns_copy(self):
+        p = NoemaMemoryProvider()
+        schemas = p.get_tool_schemas()
+        assert schemas == ALL_TOOL_SCHEMAS
+        assert schemas is not ALL_TOOL_SCHEMAS  # Should be a copy.
+
+    def test_handle_tool_call_unknown_tool(self):
+        p = NoemaMemoryProvider()
+        result = json.loads(p.handle_tool_call("noema_explode", {}))
+        assert "error" in result
+
+    def test_handle_tool_call_no_transport(self):
+        p = NoemaMemoryProvider()
+        result = json.loads(p.handle_tool_call("noema_search", {"query": "test"}))
+        assert "error" in result
+
+    def test_queue_prefetch_is_noop(self):
+        p = NoemaMemoryProvider()
+        p.queue_prefetch("test")  # Should not raise.
+
+    def test_on_turn_start_increments_counter(self):
+        p = NoemaMemoryProvider()
+        p.on_turn_start(5, "hello")
+        assert p._turn_count == 5
+
+    def test_shutdown_without_transport(self):
+        p = NoemaMemoryProvider()
+        p.shutdown()  # Should not raise.
+
+
+# ---------------------------------------------------------------------------
+# __init__.py — handle_tool_call routing (mocked transport)
+# ---------------------------------------------------------------------------
+
+class TestHandleToolCallRouting:
+    def setup_method(self):
+        self.provider = NoemaMemoryProvider()
+        self.provider._transport = MagicMock()
+        self.provider._author = "hermes/tester"
+        self.provider._transport.call_tool.return_value = "ok"
+
+    def test_search_routes_correctly(self):
+        self.provider.handle_tool_call("noema_search", {"query": "sqlite"})
+        self.provider._transport.call_tool.assert_called_once_with(
+            "search_traces", {"query": "sqlite"}
+        )
+
+    def test_remember_includes_author(self):
+        self.provider.handle_tool_call("noema_remember", {
+            "title": "test", "type": "fact", "body": "content",
+        })
+        call_args = self.provider._transport.call_tool.call_args
+        assert call_args[0][0] == "create_trace"
+        assert call_args[0][1]["author"] == "hermes/tester"
+
+    def test_remember_passes_tags(self):
+        self.provider.handle_tool_call("noema_remember", {
+            "title": "test", "type": "fact", "body": "content", "tags": "a, b",
+        })
+        call_args = self.provider._transport.call_tool.call_args
+        assert call_args[0][1]["tags"] == "a, b"
+
+    def test_recall_routes_correctly(self):
+        self.provider.handle_tool_call("noema_recall", {"id": "20260412-test"})
+        self.provider._transport.call_tool.assert_called_once_with(
+            "get_trace", {"id": "20260412-test"}
+        )
+
+    def test_list_passes_filters(self):
+        self.provider.handle_tool_call("noema_list", {"type": "decision", "tag": "go"})
+        call_args = self.provider._transport.call_tool.call_args
+        assert call_args[0][1] == {"type": "decision", "tag": "go"}
+
+    def test_update_routes_correctly(self):
+        self.provider.handle_tool_call("noema_update", {"id": "20260412-test", "body": "new"})
+        call_args = self.provider._transport.call_tool.call_args
+        assert call_args[0][0] == "update_trace"
+        assert call_args[0][1]["id"] == "20260412-test"
+        assert call_args[0][1]["body"] == "new"
+
+    def test_lineage_routes_correctly(self):
+        self.provider.handle_tool_call("noema_lineage", {"id": "20260412-test"})
+        self.provider._transport.call_tool.assert_called_once_with(
+            "trace_lineage", {"id": "20260412-test"}
+        )
+
+    def test_result_wrapped_in_json(self):
+        self.provider._transport.call_tool.return_value = "trace body here"
+        raw = self.provider.handle_tool_call("noema_recall", {"id": "x"})
+        result = json.loads(raw)
+        assert result == {"result": "trace body here"}
+
+    def test_transport_error_returns_error_json(self):
+        self.provider._transport.call_tool.side_effect = RuntimeError("connection lost")
+        self.provider._transport.is_alive = True
+        raw = self.provider.handle_tool_call("noema_search", {"query": "x"})
+        result = json.loads(raw)
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# __init__.py — prefetch (mocked transport)
+# ---------------------------------------------------------------------------
+
+class TestPrefetch:
+    def test_empty_query(self):
+        p = NoemaMemoryProvider()
+        p._transport = MagicMock()
+        assert p.prefetch("") == ""
+        assert p.prefetch("   ") == ""
+
+    def test_no_results(self):
+        p = NoemaMemoryProvider()
+        p._transport = MagicMock()
+        p._transport.call_tool.return_value = "No traces found."
+        assert p.prefetch("test query") == ""
+
+    def test_formats_results(self):
+        p = NoemaMemoryProvider()
+        p._transport = MagicMock()
+        p._transport.call_tool.return_value = "[fact] 20260412-test (2026-04-12) — agent [tag]"
+        result = p.prefetch("test query")
+        assert "## Relevant Memories (from Noema)" in result
+        assert "20260412-test" in result
+        assert "noema_search" in result
+
+    def test_filters_session_logs(self):
+        p = NoemaMemoryProvider()
+        p._transport = MagicMock()
+        p._transport.call_tool.return_value = (
+            "[context] 20260412-hermes-session (2026-04-12) — hermes/agent [hermes-session]\n"
+            "[fact] 20260412-real-trace (2026-04-12) — agent [useful]"
+        )
+        result = p.prefetch("test")
+        assert "hermes-session" not in result or "hermes-session-summary" in result
+        assert "20260412-real-trace" in result
+
+    def test_keeps_session_summaries(self):
+        p = NoemaMemoryProvider()
+        p._transport = MagicMock()
+        p._transport.call_tool.return_value = (
+            "[observation] 20260412-session-summary (2026-04-12) — hermes/agent [hermes-session-summary]"
+        )
+        result = p.prefetch("test")
+        assert "hermes-session-summary" in result
+
+    def test_truncates_long_query(self):
+        p = NoemaMemoryProvider()
+        p._transport = MagicMock()
+        p._transport.call_tool.return_value = "No traces found."
+        p.prefetch("x" * 1000)
+        call_args = p._transport.call_tool.call_args
+        assert len(call_args[0][1]["query"]) == 500
+
+    def test_transport_error_returns_empty(self):
+        p = NoemaMemoryProvider()
+        p._transport = MagicMock()
+        p._transport.call_tool.side_effect = RuntimeError("boom")
+        assert p.prefetch("test") == ""
+
+
+# ---------------------------------------------------------------------------
+# __init__.py — session trace creation (mocked transport)
+# ---------------------------------------------------------------------------
+
+class TestSessionTrace:
+    def test_session_trace_created(self):
+        p = NoemaMemoryProvider()
+        p._transport = MagicMock()
+        p._transport.call_tool.return_value = "Trace created: 20260412-hermes-session-abc"
+        p._session_id = "session-abc123"
+        p._agent_identity = "researcher"
+        p._author = "hermes/researcher"
+        p._session_title = "Research session"
+        p._platform = "cli"
+
+        p._create_session_trace()
+
+        call_args = p._transport.call_tool.call_args
+        assert call_args[0][0] == "create_trace"
+        args = call_args[0][1]
+        assert args["title"] == "hermes-session: Research session"
+        assert args["type"] == "context"
+        assert args["author"] == "hermes/researcher"
+        assert "hermes-session" in args["tags"]
+        assert p._session_trace_id == "20260412-hermes-session-abc"
+
+    def test_session_trace_uses_id_fallback(self):
+        p = NoemaMemoryProvider()
+        p._transport = MagicMock()
+        p._transport.call_tool.return_value = "Trace created: 20260412-hermes-session-x"
+        p._session_id = "abcdefghijklmnop"
+        p._session_title = ""
+        p._author = "hermes/unknown"
+        p._platform = "cli"
+        p._agent_identity = "unknown"
+
+        p._create_session_trace()
+
+        call_args = p._transport.call_tool.call_args
+        assert "abcdefghijkl" in call_args[0][1]["title"]

--- a/plugins/hermes/transport.py
+++ b/plugins/hermes/transport.py
@@ -1,0 +1,307 @@
+"""Noema MCP transport layer for the Hermes memory provider plugin.
+
+Two transports are supported:
+
+- StdioTransport: spawns `noema serve --transport stdio` as a subprocess
+  and communicates via JSON-RPC 2.0 over stdin/stdout pipes.
+- HttpTransport: connects to an already-running `noema serve --transport http`
+  endpoint via POST /mcp with JSON-RPC 2.0 payloads.
+
+Both expose the same call_tool(name, args) -> dict interface. A threading.Lock
+guards all I/O so concurrent calls from daemon threads are safe.
+"""
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+import threading
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from urllib.request import Request, urlopen
+from urllib.error import URLError
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Binary discovery
+# ---------------------------------------------------------------------------
+
+_binary_cache: Optional[str] = None
+_binary_lock = threading.Lock()
+
+
+def find_binary(override: Optional[str] = None) -> Optional[str]:
+    """Locate the noema binary. Resolution order:
+    1. Explicit override (config or NOEMA_BINARY env)
+    2. shutil.which("noema") — standard PATH lookup
+    3. Well-known install locations
+    """
+    global _binary_cache
+    with _binary_lock:
+        if _binary_cache is not None:
+            return _binary_cache if _binary_cache != "" else None
+
+    # Explicit override.
+    path = override or os.environ.get("NOEMA_BINARY", "")
+    if path:
+        if os.path.isfile(path) and os.access(path, os.X_OK):
+            with _binary_lock:
+                _binary_cache = path
+            return path
+        logger.warning("Configured noema binary %s not found or not executable", path)
+        with _binary_lock:
+            _binary_cache = ""
+        return None
+
+    # PATH lookup.
+    found = shutil.which("noema")
+    if found:
+        with _binary_lock:
+            _binary_cache = found
+        return found
+
+    # Well-known locations.
+    home = Path.home()
+    candidates = [
+        home / "go" / "bin" / "noema",
+        Path("/usr/local/bin/noema"),
+        home / ".local" / "bin" / "noema",
+    ]
+    for c in candidates:
+        if c.is_file() and os.access(str(c), os.X_OK):
+            with _binary_lock:
+                _binary_cache = str(c)
+            return str(c)
+
+    with _binary_lock:
+        _binary_cache = ""
+    return None
+
+
+def reset_binary_cache() -> None:
+    """Clear the cached binary path (useful after config changes)."""
+    global _binary_cache
+    with _binary_lock:
+        _binary_cache = None
+
+
+# ---------------------------------------------------------------------------
+# JSON-RPC helpers
+# ---------------------------------------------------------------------------
+
+def _jsonrpc_request(method: str, params: dict, req_id: int) -> bytes:
+    """Build a JSON-RPC 2.0 request as a newline-terminated byte string."""
+    payload = {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "method": method,
+        "params": params,
+    }
+    return json.dumps(payload).encode("utf-8") + b"\n"
+
+
+def _parse_jsonrpc_response(line: str) -> dict:
+    """Parse a JSON-RPC 2.0 response, returning the result or raising on error."""
+    resp = json.loads(line)
+    if "error" in resp and resp["error"] is not None:
+        err = resp["error"]
+        msg = err.get("message", str(err)) if isinstance(err, dict) else str(err)
+        raise RuntimeError(f"JSON-RPC error: {msg}")
+    return resp.get("result", {})
+
+
+def _extract_text(result: dict) -> str:
+    """Extract text content from an MCP CallToolResult."""
+    content = result.get("content", [])
+    for item in content:
+        if isinstance(item, dict) and item.get("type") == "text":
+            return item.get("text", "")
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# MCP initialize handshake
+# ---------------------------------------------------------------------------
+
+_INIT_PARAMS = {
+    "protocolVersion": "2025-03-26",
+    "capabilities": {},
+    "clientInfo": {
+        "name": "noema-hermes-plugin",
+        "version": "0.1.0",
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# StdioTransport
+# ---------------------------------------------------------------------------
+
+class StdioTransport:
+    """Spawn `noema serve --transport stdio` and communicate via pipes."""
+
+    def __init__(self, binary: str, cortex_name: str):
+        self._binary = binary
+        self._cortex_name = cortex_name
+        self._process: Optional[subprocess.Popen] = None
+        self._lock = threading.Lock()
+        self._req_id = 0
+
+    def start(self) -> None:
+        """Spawn the subprocess and perform the MCP initialize handshake."""
+        cmd = [self._binary, "serve", "--transport", "stdio", "--cortex", self._cortex_name]
+        self._process = subprocess.Popen(
+            cmd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=False,
+        )
+        self._handshake()
+
+    def _handshake(self) -> None:
+        """Send MCP initialize + initialized notification."""
+        # initialize request
+        resp = self._send("initialize", _INIT_PARAMS)
+        logger.debug("MCP initialize response: %s", resp)
+        # initialized notification (no id, no response expected)
+        notif = json.dumps({
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized",
+        }).encode("utf-8") + b"\n"
+        with self._lock:
+            self._process.stdin.write(notif)
+            self._process.stdin.flush()
+
+    def _send(self, method: str, params: dict) -> dict:
+        """Send a JSON-RPC request and read the response. Thread-safe.
+
+        Skips non-JSON lines (e.g. server log output on startup) by
+        reading until a line starting with '{' is found.
+        """
+        with self._lock:
+            if self._process is None or self._process.poll() is not None:
+                raise RuntimeError("Noema subprocess is not running")
+            self._req_id += 1
+            req = _jsonrpc_request(method, params, self._req_id)
+            self._process.stdin.write(req)
+            self._process.stdin.flush()
+            while True:
+                line = self._process.stdout.readline()
+                if not line:
+                    raise RuntimeError("Noema subprocess returned no output (EOF)")
+                text = line.decode("utf-8").strip()
+                if text.startswith("{"):
+                    return _parse_jsonrpc_response(text)
+                logger.debug("Skipping non-JSON output: %s", text)
+
+    def call_tool(self, name: str, arguments: Optional[Dict[str, Any]] = None) -> str:
+        """Call a Noema MCP tool. Returns the text content of the result."""
+        params = {"name": name}
+        if arguments:
+            params["arguments"] = arguments
+        result = self._send("tools/call", params)
+        return _extract_text(result)
+
+    @property
+    def is_alive(self) -> bool:
+        return self._process is not None and self._process.poll() is None
+
+    def close(self) -> None:
+        """Terminate the subprocess."""
+        if self._process is None:
+            return
+        try:
+            self._process.terminate()
+            self._process.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            self._process.kill()
+            self._process.wait(timeout=2)
+        except Exception:
+            pass
+        self._process = None
+
+
+# ---------------------------------------------------------------------------
+# HttpTransport
+# ---------------------------------------------------------------------------
+
+class HttpTransport:
+    """Connect to an already-running Noema HTTP MCP endpoint."""
+
+    def __init__(self, url: str, bearer_key: Optional[str] = None):
+        self._url = url.rstrip("/")
+        if not self._url.endswith("/mcp"):
+            self._url += "/mcp"
+        self._bearer_key = bearer_key
+        self._session_id: Optional[str] = None
+        self._lock = threading.Lock()
+        self._req_id = 0
+
+    def start(self) -> None:
+        """Perform the MCP initialize handshake over HTTP."""
+        resp = self._send("initialize", _INIT_PARAMS)
+        logger.debug("MCP initialize response: %s", resp)
+        # Send initialized notification.
+        self._send_notification("notifications/initialized")
+
+    def _build_request(self, body: bytes) -> Request:
+        """Build an HTTP request with standard headers."""
+        req = Request(self._url, data=body, method="POST")
+        req.add_header("Content-Type", "application/json")
+        if self._bearer_key:
+            req.add_header("Authorization", f"Bearer {self._bearer_key}")
+        if self._session_id:
+            req.add_header("Mcp-Session-Id", self._session_id)
+        return req
+
+    def _send(self, method: str, params: dict) -> dict:
+        """Send a JSON-RPC request over HTTP. Thread-safe."""
+        with self._lock:
+            self._req_id += 1
+            body = json.dumps({
+                "jsonrpc": "2.0",
+                "id": self._req_id,
+                "method": method,
+                "params": params,
+            }).encode("utf-8")
+            req = self._build_request(body)
+            with urlopen(req, timeout=30) as resp:
+                # Capture session ID from first response.
+                sid = resp.headers.get("Mcp-Session-Id")
+                if sid:
+                    self._session_id = sid
+                data = resp.read().decode("utf-8")
+                return _parse_jsonrpc_response(data)
+
+    def _send_notification(self, method: str) -> None:
+        """Send a JSON-RPC notification (no id, no response expected)."""
+        with self._lock:
+            body = json.dumps({
+                "jsonrpc": "2.0",
+                "method": method,
+            }).encode("utf-8")
+            req = self._build_request(body)
+            try:
+                with urlopen(req, timeout=10) as resp:
+                    resp.read()
+            except Exception:
+                pass  # Notifications are best-effort.
+
+    def call_tool(self, name: str, arguments: Optional[Dict[str, Any]] = None) -> str:
+        """Call a Noema MCP tool. Returns the text content of the result."""
+        params = {"name": name}
+        if arguments:
+            params["arguments"] = arguments
+        result = self._send("tools/call", params)
+        return _extract_text(result)
+
+    @property
+    def is_alive(self) -> bool:
+        return True  # HTTP is connectionless; we can't check without a call.
+
+    def close(self) -> None:
+        """No-op for HTTP (the server is independently managed)."""
+        pass

--- a/tests/security-mcp-pentest-playbook.md
+++ b/tests/security-mcp-pentest-playbook.md
@@ -1,0 +1,317 @@
+# Security MCP Pentest Playbook
+
+**Target**: Noema MCP HTTP server
+**Transport**: Streamable HTTP with TLS
+**Scope**: Auth, CORS, input validation, federation, MCP protocol
+
+## Setup
+
+Before running scenarios, start a clean test server:
+
+```bash
+cd /workspace/testing
+rm -rf cortex/testcortex
+./files/noema init --name testcortex --path cortex/
+
+# Write access key
+printf 'test-bearer-token-12345\n' > cortex/testcortex/.access.secret
+chmod 600 cortex/testcortex/.access.secret
+
+# Add access block to cortex.md
+cat >> cortex/testcortex/cortex.md << 'MANIFEST'
+
+access:
+  shared_key_file: .access.secret
+MANIFEST
+
+# Start server in background
+NOEMA_MCP_KEY=test-bearer-token-12345 ./files/noema serve \
+  --cortex testcortex --transport http \
+  --host 127.0.0.1 --port 3000 \
+  --tls-cert /home/mark/.certs/fullchain.cer \
+  --tls-key /home/mark/.certs/home-dns.com.key &
+SERVER_PID=$!
+sleep 2
+```
+
+Set shared variables:
+
+```bash
+URL="https://127.0.0.1:3000/mcp"
+K="-k"  # trust self-signed cert
+AUTH="Authorization: Bearer test-bearer-token-12345"
+CT="Content-Type: application/json"
+```
+
+Helper for MCP tool calls:
+
+```bash
+mcp_call() {
+  local method="$1" params="$2"
+  curl $K -s -o /dev/null -w "%{http_code}" -X POST "$URL" \
+    -H "$CT" -H "$AUTH" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":\"1\",\"method\":\"$method\",\"params\":$params}"
+}
+mcp_body() {
+  local method="$1" params="$2"
+  curl $K -s -X POST "$URL" \
+    -H "$CT" -H "$AUTH" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":\"1\",\"method\":\"$method\",\"params\":$params}"
+}
+```
+
+---
+
+## Category A: Authentication
+
+**S01 — Missing Authorization header**
+```bash
+CODE=$(curl $K -s -o /dev/null -w "%{http_code}" -X POST "$URL" \
+  -H "$CT" \
+  -d '{"jsonrpc":"2.0","id":"1","method":"tools/list","params":{}}')
+[ "$CODE" = "401" ] && echo "[PASS] S01" || echo "[FAIL] S01 got $CODE"
+```
+Expected: 401
+
+**S02 — Empty bearer token**
+```bash
+CODE=$(curl $K -s -o /dev/null -w "%{http_code}" -X POST "$URL" \
+  -H "$CT" -H "Authorization: Bearer " \
+  -d '{"jsonrpc":"2.0","id":"1","method":"tools/list","params":{}}')
+[ "$CODE" = "401" ] && echo "[PASS] S02" || echo "[FAIL] S02 got $CODE"
+```
+Expected: 401
+
+**S03 — Wrong bearer token**
+```bash
+CODE=$(curl $K -s -o /dev/null -w "%{http_code}" -X POST "$URL" \
+  -H "$CT" -H "Authorization: Bearer wrong-token" \
+  -d '{"jsonrpc":"2.0","id":"1","method":"tools/list","params":{}}')
+[ "$CODE" = "401" ] && echo "[PASS] S03" || echo "[FAIL] S03 got $CODE"
+```
+Expected: 401
+
+**S04 — Token in query string (not supported)**
+```bash
+CODE=$(curl $K -s -o /dev/null -w "%{http_code}" -X POST "$URL?token=test-bearer-token-12345" \
+  -H "$CT" \
+  -d '{"jsonrpc":"2.0","id":"1","method":"tools/list","params":{}}')
+[ "$CODE" = "401" ] && echo "[PASS] S04" || echo "[FAIL] S04 got $CODE"
+```
+Expected: 401
+
+**S05 — Valid bearer token succeeds**
+```bash
+CODE=$(curl $K -s -o /dev/null -w "%{http_code}" -X POST "$URL" \
+  -H "$CT" -H "$AUTH" \
+  -d '{"jsonrpc":"2.0","id":"1","method":"tools/list","params":{}}')
+[ "$CODE" = "200" ] && echo "[PASS] S05" || echo "[FAIL] S05 got $CODE"
+```
+Expected: 200
+
+**S06 — Lowercase "bearer" scheme rejected**
+```bash
+CODE=$(curl $K -s -o /dev/null -w "%{http_code}" -X POST "$URL" \
+  -H "$CT" -H "Authorization: bearer test-bearer-token-12345" \
+  -d '{"jsonrpc":"2.0","id":"1","method":"tools/list","params":{}}')
+[ "$CODE" = "401" ] && echo "[PASS] S06" || echo "[FAIL] S06 got $CODE"
+```
+Expected: 401
+
+**S07 — Token not leaked in 401 response body**
+```bash
+BODY=$(curl $K -s -X POST "$URL" \
+  -H "$CT" -H "Authorization: Bearer my-secret-token-probe" \
+  -d '{"jsonrpc":"2.0","id":"1","method":"tools/list","params":{}}')
+echo "$BODY" | grep -q "my-secret-token-probe" && echo "[FAIL] S07 token leaked" || echo "[PASS] S07"
+```
+Expected: token not present in response
+
+---
+
+## Category B: CORS
+
+**S08 — OPTIONS preflight succeeds without auth**
+```bash
+CODE=$(curl $K -s -o /dev/null -w "%{http_code}" -X OPTIONS "$URL" \
+  -H "Origin: https://evil.example.com" \
+  -H "Access-Control-Request-Method: POST" \
+  -H "Access-Control-Request-Headers: authorization,content-type")
+[ "$CODE" = "204" ] && echo "[PASS] S08" || echo "[FAIL] S08 got $CODE"
+```
+Expected: 204
+
+**S09 — CORS headers on preflight response**
+```bash
+HEADERS=$(curl $K -s -D - -o /dev/null -X OPTIONS "$URL" \
+  -H "Origin: https://evil.example.com" \
+  -H "Access-Control-Request-Method: POST" \
+  -H "Access-Control-Request-Headers: authorization,content-type")
+echo "$HEADERS" | grep -qi "access-control-allow-origin" && echo "[PASS] S09" || echo "[FAIL] S09"
+```
+Expected: Access-Control-Allow-Origin header present
+
+**S10 — CORS headers present on 401**
+```bash
+HEADERS=$(curl $K -s -D - -o /dev/null -X POST "$URL" \
+  -H "Origin: https://evil.example.com" -H "$CT" \
+  -d '{"jsonrpc":"2.0","id":"1","method":"tools/list","params":{}}')
+echo "$HEADERS" | grep -qi "access-control-allow-origin" && echo "[PASS] S10" || echo "[FAIL] S10"
+```
+Expected: CORS headers present even on auth failure
+
+---
+
+## Category C: Input Validation
+
+**S11 — Path traversal in trace ID**
+```bash
+BODY=$(mcp_body "call_tool" '{"name":"get_trace","arguments":{"id":"../../../etc/passwd"}}')
+echo "$BODY" | grep -qi "error\|not found\|invalid" && echo "[PASS] S11" || echo "[FAIL] S11"
+```
+Expected: error or not found, never file contents
+
+**S12 — Path traversal in trace title**
+```bash
+BODY=$(mcp_body "call_tool" '{"name":"create_trace","arguments":{"title":"../../etc/cron","type":"note","body":"test"}}')
+# Verify no file written outside cortex
+ls /workspace/testing/cortex/testcortex/traces/ | head -5
+[ ! -f "/workspace/testing/etc/cron.md" ] && echo "[PASS] S12" || echo "[FAIL] S12 file escaped cortex"
+```
+Expected: file stays within traces/ directory
+
+**S13 — SQL injection in search query**
+```bash
+BODY=$(mcp_body "call_tool" '{"name":"search_traces","arguments":{"query":"foo\"; DROP TABLE traces; --"}}')
+# Verify database is intact by listing traces
+BODY2=$(mcp_body "call_tool" '{"name":"list_traces","arguments":{}}')
+echo "$BODY2" | grep -qi "error" && echo "[FAIL] S13 DB may be damaged" || echo "[PASS] S13"
+```
+Expected: search completes normally, database intact
+
+**S14 — Null bytes in trace title**
+```bash
+BODY=$(mcp_body "call_tool" "{\"name\":\"create_trace\",\"arguments\":{\"title\":\"test\\u0000evil\",\"type\":\"note\",\"body\":\"test\"}}")
+echo "$BODY" | grep -qi "error\|invalid" && echo "[PASS] S14 rejected null" || echo "[INFO] S14 accepted (check trace ID format)"
+```
+Expected: rejected or sanitized
+
+**S15 — Invalid trace type**
+```bash
+BODY=$(mcp_body "call_tool" '{"name":"create_trace","arguments":{"title":"test","type":"MALICIOUS_TYPE","body":"test"}}')
+echo "$BODY" | grep -qi "error\|invalid\|unknown" && echo "[PASS] S15" || echo "[FAIL] S15 accepted bad type"
+```
+Expected: rejected with validation error
+
+**S16 — Oversized trace body (5 MB)**
+```bash
+BIGBODY=$(python3 -c "print('A' * 5242880)")
+CODE=$(curl $K -s -o /dev/null -w "%{http_code}" -X POST "$URL" \
+  -H "$CT" -H "$AUTH" \
+  -d "{\"jsonrpc\":\"2.0\",\"id\":\"1\",\"method\":\"call_tool\",\"params\":{\"name\":\"create_trace\",\"arguments\":{\"title\":\"big\",\"type\":\"note\",\"body\":\"$BIGBODY\"}}}")
+echo "S16: HTTP $CODE (should not crash server)"
+# Verify server still responds
+CODE2=$(mcp_call "tools/list" '{}')
+[ "$CODE2" = "200" ] && echo "[PASS] S16 server survived" || echo "[FAIL] S16 server down"
+```
+Expected: server handles gracefully and stays alive
+
+---
+
+## Category D: Federation
+
+**S17 — Self-name collision in announce_peer**
+```bash
+# Get local cortex name
+IDENTITY=$(mcp_body "call_tool" '{"name":"cortex_identity","arguments":{}}')
+echo "Local identity: $IDENTITY"
+
+BODY=$(mcp_body "call_tool" '{"name":"announce_peer","arguments":{"name":"testcortex","endpoint":"https://evil.example.com"}}')
+echo "$BODY" | grep -qi "error\|collision\|matches\|own name" && echo "[PASS] S17" || echo "[FAIL] S17 self-collision not detected"
+```
+Expected: rejected with name collision error
+
+**S18 — Valid peer announcement**
+```bash
+BODY=$(mcp_body "call_tool" '{"name":"announce_peer","arguments":{"name":"legit-peer","endpoint":"https://legit-peer.example.com"}}')
+echo "$BODY" | grep -qi "acknowledged\|Acknowledged" && echo "[PASS] S18" || echo "[FAIL] S18"
+```
+Expected: acknowledged
+
+---
+
+## Category E: MCP Protocol
+
+**S19 — Malformed JSON**
+```bash
+CODE=$(curl $K -s -o /dev/null -w "%{http_code}" -X POST "$URL" \
+  -H "$CT" -H "$AUTH" \
+  -d '{this is not json}')
+echo "S19: HTTP $CODE"
+[ "$CODE" = "400" ] || [ "$CODE" = "200" ] && echo "[PASS] S19" || echo "[FAIL] S19"
+```
+Expected: 400 or JSON-RPC error response
+
+**S20 — Missing method field**
+```bash
+BODY=$(curl $K -s -X POST "$URL" \
+  -H "$CT" -H "$AUTH" \
+  -d '{"jsonrpc":"2.0","id":"1","params":{}}')
+echo "$BODY" | grep -qi "error" && echo "[PASS] S20" || echo "[FAIL] S20"
+```
+Expected: JSON-RPC error
+
+**S21 — Unknown method name**
+```bash
+BODY=$(curl $K -s -X POST "$URL" \
+  -H "$CT" -H "$AUTH" \
+  -d '{"jsonrpc":"2.0","id":"1","method":"call_tool","params":{"name":"drop_database","arguments":{}}}')
+echo "$BODY" | grep -qi "error\|not found\|unknown" && echo "[PASS] S21" || echo "[FAIL] S21"
+```
+Expected: error
+
+**S22 — Missing required tool params**
+```bash
+BODY=$(mcp_body "call_tool" '{"name":"get_trace","arguments":{}}')
+echo "$BODY" | grep -qi "error\|required\|missing" && echo "[PASS] S22" || echo "[FAIL] S22"
+```
+Expected: error about missing id parameter
+
+**S23 — Non-/mcp path returns 404**
+```bash
+CODE=$(curl $K -s -o /dev/null -w "%{http_code}" -X POST "https://127.0.0.1:3000/admin" \
+  -H "$CT" -H "$AUTH")
+[ "$CODE" = "404" ] && echo "[PASS] S23" || echo "[FAIL] S23 got $CODE"
+```
+Expected: 404
+
+**S24 — GET on /mcp without session**
+```bash
+CODE=$(curl $K -s -o /dev/null -w "%{http_code}" -X GET "$URL" \
+  -H "$AUTH")
+echo "S24: HTTP $CODE (GET without session)"
+# mcp-go may return 400 or 405 for GET without Mcp-Session-Id
+[ "$CODE" != "200" ] && echo "[PASS] S24" || echo "[INFO] S24 returned 200 (check if streaming)"
+```
+Expected: non-200 or SSE stream
+
+---
+
+## Teardown
+
+```bash
+kill $SERVER_PID 2>/dev/null
+rm -rf /workspace/testing/cortex/testcortex
+echo "Teardown complete"
+```
+
+---
+
+## Verdict Summary
+
+Record results as:
+- **[PASS]** — scenario behaved as expected
+- **[FAIL]** — unexpected behavior, potential vulnerability
+- **[SKIP]** — could not execute (missing prereq, server config)
+
+Save results to `/workspace/testing/results/security-mcp-pentest-YYYYMMDD-HHMMSS.md`


### PR DESCRIPTION
## Summary

Catches `next` up with `main`, which is 9 commits ahead. Fast-forward equivalent (next had no unique content), cherry-picked as linear commits to comply with the repo's no-merge-commits rule on `next`.

## Commits brought in

- #18 fix(security): harden federation replay against path traversal, hash forgery, DoS
- #19 fix(test): sandbox config home in migrate tests to prevent real config overwrite
- feat: append_trace MCP tool for fire-and-forget appends
- docs: README badges + SECURITY.md
- chore: rename Homebrew tap to homebrew-tap
- chore: update .gitignore and branch strategy in CLAUDE.md
- #22 Hermes memory provider plugin + FTS5 search fix
- #23 feat: repeatable --host flag and stdio-mode flag guard
- #24 security: harden MCP server, federation, and query sanitizer

PR #17 (content hashing, source-locking) is already on `next` as commit `8bae74e` — skipped as an empty cherry-pick.

## Why this matters

- `next` was missing the Hermes plugin that shipped to `main`.
- `next` was missing the test-isolation fix from #19 (the one that prevents `TestMigrateCortexID_ResetClearsCursors` from writing into the real user config — the bug that ate the `agentbrain` registry entry during smoke testing earlier today).
- Subsequent feature branches branching off `next` were building on stale infra.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` all packages pass

**Use rebase-and-merge** to preserve the linear commit history on `next`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)