### PR TITLE
chore(hermes): fix ruff lint + basedpyright type errors in plugin

### DIFF
--- a/plugins/hermes/__init__.py
+++ b/plugins/hermes/__init__.py
@@ -18,7 +18,6 @@ import json
 import logging
 import os
 import threading
-import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -30,7 +29,12 @@ except ImportError:
     class MemoryProvider:  # type: ignore[no-redef]
         pass
 
-from .transport import StdioTransport, HttpTransport, find_binary, reset_binary_cache
+from .transport import (
+    HttpTransport,
+    StdioTransport,
+    find_binary,
+    reset_binary_cache as reset_binary_cache,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/plugins/hermes/tests/test_integration.py
+++ b/plugins/hermes/tests/test_integration.py
@@ -7,7 +7,6 @@ Skip with: pytest -m "not integration"
 """
 
 import json
-import os
 import shutil
 import subprocess
 import tempfile

--- a/plugins/hermes/tests/test_unit.py
+++ b/plugins/hermes/tests/test_unit.py
@@ -2,10 +2,6 @@
 
 import json
 import os
-import stat
-import tempfile
-import threading
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -160,9 +156,9 @@ class TestFindBinary:
         # After reset, with no PATH or override, should return None
         # (assuming shutil.which won't find it in tmp_path).
         with patch("plugins.hermes.transport.shutil.which", return_value=None):
-            result = find_binary()
-            # May find it in well-known locations; just verify cache was reset.
-            # The important thing is no exception.
+            # May find it in well-known locations; just verify cache was reset
+            # and the call completes without exception.
+            find_binary()
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/hermes/transport.py
+++ b/plugins/hermes/transport.py
@@ -18,9 +18,8 @@ import shutil
 import subprocess
 import threading
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 from urllib.request import Request, urlopen
-from urllib.error import URLError
 
 logger = logging.getLogger(__name__)
 
@@ -172,24 +171,40 @@ class StdioTransport:
             "method": "notifications/initialized",
         }).encode("utf-8") + b"\n"
         with self._lock:
-            self._process.stdin.write(notif)
-            self._process.stdin.flush()
+            stdin = self._require_pipes()[0]
+            stdin.write(notif)
+            stdin.flush()
 
-    def _send(self, method: str, params: dict) -> dict:
+    def _require_pipes(self):
+        """Return (stdin, stdout) as non-Optional handles or raise.
+
+        Popen(stdin=PIPE, stdout=PIPE) guarantees both are non-None, but the
+        stdlib types expose them as Optional[IO[bytes]]. Rather than repeat
+        `assert self._process.stdin is not None` at every I/O site, funnel
+        through this helper so the narrowing is in one place and the
+        is-not-running check stays consistent with start()/close().
+        """
+        p = self._process
+        if p is None or p.poll() is not None:
+            raise RuntimeError("Noema subprocess is not running")
+        if p.stdin is None or p.stdout is None:
+            raise RuntimeError("Noema subprocess has no stdin/stdout pipes")
+        return p.stdin, p.stdout
+
+    def _send(self, method: str, params: Dict[str, Any]) -> dict:
         """Send a JSON-RPC request and read the response. Thread-safe.
 
         Skips non-JSON lines (e.g. server log output on startup) by
         reading until a line starting with '{' is found.
         """
         with self._lock:
-            if self._process is None or self._process.poll() is not None:
-                raise RuntimeError("Noema subprocess is not running")
+            stdin, stdout = self._require_pipes()
             self._req_id += 1
             req = _jsonrpc_request(method, params, self._req_id)
-            self._process.stdin.write(req)
-            self._process.stdin.flush()
+            stdin.write(req)
+            stdin.flush()
             while True:
-                line = self._process.stdout.readline()
+                line = stdout.readline()
                 if not line:
                     raise RuntimeError("Noema subprocess returned no output (EOF)")
                 text = line.decode("utf-8").strip()
@@ -199,7 +214,7 @@ class StdioTransport:
 
     def call_tool(self, name: str, arguments: Optional[Dict[str, Any]] = None) -> str:
         """Call a Noema MCP tool. Returns the text content of the result."""
-        params = {"name": name}
+        params: Dict[str, Any] = {"name": name}
         if arguments:
             params["arguments"] = arguments
         result = self._send("tools/call", params)
@@ -257,7 +272,7 @@ class HttpTransport:
             req.add_header("Mcp-Session-Id", self._session_id)
         return req
 
-    def _send(self, method: str, params: dict) -> dict:
+    def _send(self, method: str, params: Dict[str, Any]) -> dict:
         """Send a JSON-RPC request over HTTP. Thread-safe."""
         with self._lock:
             self._req_id += 1
@@ -292,7 +307,7 @@ class HttpTransport:
 
     def call_tool(self, name: str, arguments: Optional[Dict[str, Any]] = None) -> str:
         """Call a Noema MCP tool. Returns the text content of the result."""
-        params = {"name": name}
+        params: Dict[str, Any] = {"name": name}
         if arguments:
             params["arguments"] = arguments
         result = self._send("tools/call", params)


### PR DESCRIPTION
## Summary

Cleanup of static-analysis issues in the Hermes memory-provider plugin that landed in #22. No runtime behavior change — all 88 plugin pytest tests still pass. This quiets the red squiggles in IDEs running ruff and basedpyright.

## What was flagged

### Ruff (10 F401/F841 errors)
- `transport.py`: unused `typing.List`, `urllib.error.URLError`
- `__init__.py`: unused `time`; `reset_binary_cache` reported as unused (it's actually a public re-export)
- `tests/test_unit.py`: unused `stat`, `tempfile`, `threading`, `pathlib.Path`; unused `result` variable
- `tests/test_integration.py`: unused `os`

### basedpyright (`reportOptionalMemberAccess`, `reportArgumentType`)
- `self._process.stdin.write/flush/readline` — subprocess.Popen's stdin/stdout are typed as `Optional[IO[bytes]]` even when opened with `PIPE`. The code worked at runtime but lit up every I/O line in red.
- `params["arguments"] = arguments` — `params` was inferred as `Dict[str, str]` from the first assignment; assigning a `Dict[str, Any]` value failed the narrowed type.

## Fixes

- **Drop unused imports.**
- **Re-export `reset_binary_cache`** explicitly (`... as reset_binary_cache`) so ruff sees it as public API.
- **New `_require_pipes()` helper** on `StdioTransport` that returns non-Optional `(stdin, stdout)` in one place, raising if the subprocess is not running or the pipes are missing. Replaces repeated `self._process.stdin.write(...)` sites that each would have needed their own assertion.
- **Explicit `Dict[str, Any]` type** on `params` dicts in both `StdioTransport.call_tool` and `HttpTransport.call_tool`, and on `_send(self, method, params: Dict[str, Any])` signatures.
- **Drop unused `result`** in `test_unit.py`; the assertion was "cache was reset + no exception," which doesn't need the return value.

## Test plan

- [x] `ruff check plugins/hermes` — clean
- [x] `python3 -m pytest plugins/hermes/tests/ -q` — 88 passed
- [x] `go build ./... && go vet ./...` — clean (no Go changes, but sanity check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)