### PR TITLE
fix(cortex): Open() refreshes AGENTS.md on drift + always drops legacy AGENT.md

### DIFF
--- a/internal/cortex/cortex.go
+++ b/internal/cortex/cortex.go
@@ -573,15 +573,26 @@ func Open(name, dir string) (*Cortex, error) {
 	}
 	_ = cx.Purge(days)
 
-	// Write AGENTS.md if it doesn't exist. Covers both fresh cortexes created
-	// before this file existed and cortexes being upgraded from the older
-	// AGENT.md naming — we silently remove any legacy AGENT.md in that case so
-	// the directory matches the current agents.md convention.
-	agentsMDPath := filepath.Join(dir, "AGENTS.md")
-	if _, err := os.Stat(agentsMDPath); os.IsNotExist(err) {
-		if mErr == nil {
-			_ = os.WriteFile(agentsMDPath, []byte(agentsMDContent(m)), 0o640)
-			_ = os.Remove(filepath.Join(dir, "AGENT.md"))
+	// Refresh the per-cortex agent-instructions file on every Open so
+	// existing cortexes pick up template changes (new sections, renamed
+	// commands, etc.) without the operator having to delete the file
+	// first. The file's header documents it as auto-generated.
+	//
+	// The write is drift-aware: we only overwrite when the on-disk
+	// content diverges from the current template. That keeps the mtime
+	// stable under iCloud/Dropbox/Syncthing so a noop open doesn't cause
+	// a sync ripple.
+	//
+	// Any legacy AGENT.md (singular, pre-#27 naming) is removed
+	// unconditionally — regardless of whether AGENTS.md also exists —
+	// so mixed states from partial upgrades clean themselves up.
+	_ = os.Remove(filepath.Join(dir, "AGENT.md"))
+	if mErr == nil {
+		agentsMDPath := filepath.Join(dir, "AGENTS.md")
+		want := agentsMDContent(m)
+		existing, _ := os.ReadFile(agentsMDPath)
+		if string(existing) != want {
+			_ = os.WriteFile(agentsMDPath, []byte(want), 0o640)
 		}
 	}
 

--- a/internal/cortex/cortex_test.go
+++ b/internal/cortex/cortex_test.go
@@ -138,6 +138,113 @@ func TestOpen_RemovesLegacyAgentMD(t *testing.T) {
 	}
 }
 
+// TestOpen_RemovesLegacyAgentMD_WhenBothExist covers the mixed state that
+// occurs when an older Noema wrote AGENT.md, then a newer Noema wrote
+// AGENTS.md alongside it without cleaning up the legacy name. Both files
+// end up on disk; Open must drop the legacy one so there's a single
+// source of truth for agent tooling.
+func TestOpen_RemovesLegacyAgentMD_WhenBothExist(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := cortex.Create("mixed", dir); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	root := filepath.Join(dir, "mixed")
+	// Put a stale AGENT.md on disk alongside the generated AGENTS.md.
+	if err := os.WriteFile(filepath.Join(root, "AGENT.md"), []byte("stale legacy content\n"), 0o640); err != nil {
+		t.Fatalf("write legacy: %v", err)
+	}
+
+	cx, err := cortex.Open("mixed", root)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	cx.Close()
+
+	if _, err := os.Stat(filepath.Join(root, "AGENTS.md")); err != nil {
+		t.Error("AGENTS.md must still exist after Open")
+	}
+	if _, err := os.Stat(filepath.Join(root, "AGENT.md")); !os.IsNotExist(err) {
+		t.Error("legacy AGENT.md must be removed even when AGENTS.md is present")
+	}
+}
+
+// TestOpen_RefreshesStaleAgentsMD verifies that an AGENTS.md whose content
+// has drifted from the current template (e.g. a cortex created under an
+// older binary whose template predated a feature) is rewritten on Open so
+// the operator doesn't have to manually delete the file to pick up the
+// new template.
+func TestOpen_RefreshesStaleAgentsMD(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := cortex.Create("stale", dir); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	root := filepath.Join(dir, "stale")
+	staleContent := "# this was written by an older noema and no longer matches the template\n"
+	agentsPath := filepath.Join(root, "AGENTS.md")
+	if err := os.WriteFile(agentsPath, []byte(staleContent), 0o640); err != nil {
+		t.Fatalf("write stale: %v", err)
+	}
+
+	cx, err := cortex.Open("stale", root)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	cx.Close()
+
+	got, err := os.ReadFile(agentsPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) == staleContent {
+		t.Error("AGENTS.md must be refreshed when content has drifted from the current template")
+	}
+	// Sanity: refreshed content should contain current-template markers.
+	for _, marker := range []string{"Noema Cortex — Agent Guide", "Trace Types", "Titles"} {
+		if !strings.Contains(string(got), marker) {
+			t.Errorf("refreshed AGENTS.md missing expected marker %q", marker)
+		}
+	}
+}
+
+// TestOpen_PreservesAgentsMDWhenMatching verifies that a cortex whose
+// AGENTS.md already matches the current template is left untouched — the
+// mtime must not advance on an idempotent open, because cortex
+// directories live on iCloud/Dropbox/Syncthing and a phantom mtime bump
+// would trigger unnecessary sync traffic.
+func TestOpen_PreservesAgentsMDWhenMatching(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := cortex.Create("fresh", dir); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	root := filepath.Join(dir, "fresh")
+	agentsPath := filepath.Join(root, "AGENTS.md")
+
+	before, err := os.Stat(agentsPath)
+	if err != nil {
+		t.Fatalf("stat before: %v", err)
+	}
+
+	// Some filesystems quantize mtime to 1s; wait past that so a real
+	// write would produce a distinct timestamp.
+	time.Sleep(1100 * time.Millisecond)
+
+	cx, err := cortex.Open("fresh", root)
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	cx.Close()
+
+	after, err := os.Stat(agentsPath)
+	if err != nil {
+		t.Fatalf("stat after: %v", err)
+	}
+
+	if !after.ModTime().Equal(before.ModTime()) {
+		t.Errorf("AGENTS.md mtime changed (%s -> %s) despite matching template — drift-aware write is broken",
+			before.ModTime(), after.ModTime())
+	}
+}
+
 func TestReadManifest(t *testing.T) {
 	dir := t.TempDir()
 	if _, err := cortex.Create("manifested", dir); err != nil {


### PR DESCRIPTION
## Summary

Follow-up to #29: the watcher-under-stdio change updated the AGENTS.md template, but existing cortexes kept the stale on-disk copy (verified on an agentbrain cortex that still had \`under \\\`noema serve --transport http\\\`\` in AGENTS.md even after re-launch). The old \`Open()\` logic only regenerated the file when it was missing, and only cleaned up legacy \`AGENT.md\` as a side effect of that regen.

## Behavior change

- **Always remove \`AGENT.md\`** on Open, regardless of whether AGENTS.md also exists. The singular name was retired in favor of the [agents.md](https://agents.md/) convention — there's no valid state where both should coexist. Partial-upgrade or backup-restore scenarios that left both files on disk now clean themselves up.
- **Refresh \`AGENTS.md\` whenever the on-disk content drifts from the current template.** The write is drift-aware: if the existing file already matches, the file is left alone (no mtime change), so an idempotent open doesn't cause a sync ripple on iCloud/Dropbox/Syncthing.

The file header already says \"This file was generated by \`noema init\`\", so overwriting drifted content matches the documented contract.

## Tests

- \`TestOpen_RemovesLegacyAgentMD_WhenBothExist\` — mixed state cleanup
- \`TestOpen_RefreshesStaleAgentsMD\` — drift triggers a rewrite with current template markers
- \`TestOpen_PreservesAgentsMDWhenMatching\` — idempotent open does not bump mtime (waits 1.1s past a quantized filesystem tick to catch a real write)

All tests pass. \`go build ./...\`, \`go vet ./...\`, \`go test ./...\` clean.

## Operator impact

After this merges, any existing cortex will pick up the current AGENTS.md template on next \`noema serve\` or CLI invocation — no manual \`rm AGENTS.md\` needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)