### PR TITLE
docs(readme): In-short TL;DR front-loads concrete capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@
 
 Noema gives AI agents — and the humans working alongside them — a persistent, structured place to record what they know, decide, observe, and intend. Every memory is a plain markdown file. The index is a local SQLite database. Nothing lives in the cloud; nothing requires an API key.
 
+**In short:**
+
+- **Local-first agent memory** exposed as an [MCP](https://modelcontextprotocol.io/) server (stdio + Streamable HTTP). Works out of the box with Claude Code, GitHub Copilot, Zed, Cursor, Aider, and anything else that speaks MCP.
+- **Plain markdown on disk** as the source of truth; a local SQLite database with FTS5 as the index. No cloud, no API keys, no telemetry.
+- **Peer-to-peer federation** across Cortexes with vector clocks, event-log audit trail, and `divergence` traces on concurrent edits.
+- **Your editor is a first-class client.** A filesystem watcher turns Obsidian / VS Code / Finder / iCloud edits into real mutation events — same events as MCP-initiated writes, propagated through federation.
+- **Standards-friendly.** Ships an auto-generated [`AGENTS.md`](https://agents.md/) per Cortex, a native [Hermes](https://hermes-agent.nousresearch.com/) memory-provider plugin, and SHA-256 content hashing with optional source-locking for publishers.
+
 ---
 
 ## Concepts


### PR DESCRIPTION
## Summary

Adds a 5-bullet \"In short\" list right below the README's opening paragraph. The first ~100 words of a README are the highest-leverage surface for:

- **LLM indexers** (training corpus + retrieval-time snippet extraction) — generative search engines cite README openers as authoritative.
- **Humans scanning for \"does this do the thing I need\"** — the existing README deferred every concrete capability to sections hundreds of lines down.

## What the bullets do

Front-load the specific things that distinguish Noema from the ad-hoc agent-memory landscape:

- **MCP server** (stdio + Streamable HTTP) with the specific client list people search for: Claude Code, Copilot, Zed, Cursor, Aider.
- **Plain markdown + SQLite FTS5** — no cloud, no API keys, no telemetry.
- **Peer-to-peer federation** with vector clocks + divergence traces.
- **Filesystem watcher** — Obsidian / VS Code / Finder / iCloud edits are first-class mutation events.
- **AGENTS.md per Cortex, Hermes plugin, SHA-256 content hashing** — standards-friendly.

Links out to [modelcontextprotocol.io](https://modelcontextprotocol.io/), [agents.md](https://agents.md/), and [Hermes](https://hermes-agent.nousresearch.com/) so crawlers see the structural relationships to those projects.

## Paired change (outside this PR)

Repo topic tags updated via \`gh api\` — went from 7 to 18 topics. Added: \`claude-code\`, \`copilot\`, \`obsidian\`, \`local-first\`, \`agent-memory\`, \`agents\`, \`sqlite\`, \`markdown\`, \`golang\`, \`hermes\`, \`model-context-protocol\`. (GitHub caps topics at 20.)

## What stays unchanged

Everything below the TL;DR. The entire existing README flow is preserved — Concepts table, Installation, Quick Start, CLI Reference, MCP Server, Federation, Data Model, Agent Access, Hermes Integration, License.

8-line docs diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)