### PR TITLE
fix(watch): auto-onboard non-conforming files dropped by external tools

### DIFF
--- a/internal/cortex/cortex.go
+++ b/internal/cortex/cortex.go
@@ -105,6 +105,15 @@ type WatchConfig struct {
 	// DebounceMs is the per-path debounce window in milliseconds.
 	// Zero means use the default (300ms).
 	DebounceMs int `yaml:"debounce_ms,omitempty"`
+	// AutoOnboard controls what happens when a new file is dropped into
+	// traces/ without conforming frontmatter (no id, empty id, invalid
+	// id format, or filename mismatch). Nil / unset defaults to true:
+	// the watcher rescues the file by synthesizing valid frontmatter,
+	// generating an ID from the title or filename, and renaming the
+	// file to match. Makes Obsidian Web Clipper, Drafts, and shortcut
+	// macros work without teaching users Noema's filename-ID rules.
+	// Set to false to restore the prior skip-and-log behaviour.
+	AutoOnboard *bool `yaml:"auto_onboard,omitempty"`
 }
 
 // WatchEnabled reports whether the watcher should run given the parsed
@@ -114,6 +123,17 @@ func (wc *WatchConfig) WatchEnabled() bool {
 		return true
 	}
 	return *wc.Enabled
+}
+
+// AutoOnboardEnabled reports whether the watcher should rescue non-
+// conforming files dropped into traces/. Nil manifest or nil
+// AutoOnboard pointer both mean "on" so users get the graceful
+// behaviour by default.
+func (wc *WatchConfig) AutoOnboardEnabled() bool {
+	if wc == nil || wc.AutoOnboard == nil {
+		return true
+	}
+	return *wc.AutoOnboard
 }
 
 // EffectiveDebounce returns the configured debounce duration, defaulting

--- a/internal/watch/onboard.go
+++ b/internal/watch/onboard.go
@@ -1,0 +1,156 @@
+package watch
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/Fail-Safe/Noema/internal/trace"
+)
+
+// autoOnboard rescues a non-conforming file dropped into traces/ by an
+// external tool (Obsidian Web Clipper, Drafts, shortcut macros, a raw
+// `cp` from another note) that didn't follow Noema's filename-ID
+// convention. It synthesises valid frontmatter, generates a proper
+// ID from the best available title signal, and writes a new file at
+// the canonical path. The original file is removed afterwards so
+// Obsidian / iCloud / the editor all converge on the renamed copy.
+//
+// Returns the new path and the onboarded trace on success. The
+// caller — the watcher's reconcile path — then hands the trace to
+// Cortex.Add as if a well-formed external create had happened.
+// Returns an error for files that can't be rescued (empty, binary-
+// looking, unreadable); callers should log the error and move on.
+func (w *Watcher) onboardFile(path string) (string, *trace.Trace, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", nil, fmt.Errorf("read: %w", err)
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return "", nil, fmt.Errorf("file is empty")
+	}
+	if !looksLikeText(data) {
+		return "", nil, fmt.Errorf("file does not look like UTF-8 text")
+	}
+
+	// Preserve whatever fields a partial parse can salvage. Parse
+	// fails cleanly on "no frontmatter delimiter" — in that case we
+	// treat the whole file as body.
+	var (
+		title, body, traceType, author string
+		tags                           []string
+	)
+	if partial, err := trace.Parse(data); err == nil && partial != nil {
+		title = strings.TrimSpace(partial.Title)
+		body = partial.Body
+		traceType = partial.Type
+		author = partial.Author
+		tags = partial.Tags
+	} else {
+		body = string(data)
+	}
+
+	// Title source priority: existing frontmatter title > first '#'
+	// heading in the body > filename stem with any trailing
+	// timestamp suffix stripped > literal "Untitled" as a last resort.
+	if title == "" {
+		title = extractH1(body)
+	}
+	if title == "" {
+		title = cleanFilenameStem(filepath.Base(path))
+	}
+	if title == "" {
+		title = "Untitled"
+	}
+
+	// Type defaults to 'note'. If the partial had a recognised type,
+	// keep it; otherwise overwrite. Web-clipped reference material
+	// could plausibly be 'context', but picking automatically is
+	// lossy either way and users can edit later.
+	if !trace.IsValidType(traceType) {
+		traceType = string(trace.TypeNote)
+	}
+
+	// Provenance banner so the user can tell the file was adopted,
+	// not authored under the Noema convention. Original filename is
+	// preserved in the banner for searchability.
+	banner := fmt.Sprintf("> Auto-onboarded from `%s`\n\n", filepath.Base(path))
+	body = banner + strings.TrimLeft(body, "\n")
+
+	t := trace.New(title, traceType, author, tags, body)
+	newPath := w.cx.TraceFile(t.ID, false)
+
+	// Avoid overwriting an existing trace at the generated path. A
+	// title collision in the same second is rare but real (NewID is
+	// deterministic per-title-per-day), and overwriting would lose
+	// a legitimate prior trace. Decline instead; next event will
+	// try again with the new title if the user renamed, or a human
+	// can resolve manually.
+	if _, err := os.Stat(newPath); err == nil && newPath != path {
+		return "", nil, fmt.Errorf("target path already exists: %s", newPath)
+	}
+
+	if err := t.Write(newPath); err != nil {
+		return "", nil, fmt.Errorf("write rescued trace: %w", err)
+	}
+
+	// Remove the original only when it's actually a different path;
+	// the filename-equals-ID case can slip through when the user's
+	// filename happened to be slug-shaped already, in which case
+	// Write already updated the file in place.
+	if newPath != path {
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			// Best-effort — leave the stale file in place and log.
+			// The cortex still has the rescued copy so the user
+			// sees their content land as a real trace.
+			return newPath, t, fmt.Errorf("remove original after rescue: %w", err)
+		}
+	}
+	return newPath, t, nil
+}
+
+// extractH1 returns the first Markdown level-1 heading in body, or ""
+// if none is present. Only the first '# ' line is considered — later
+// headings aren't title material. Trailing '#' characters and
+// surrounding whitespace are trimmed.
+func extractH1(body string) string {
+	for _, line := range strings.Split(body, "\n") {
+		s := strings.TrimSpace(line)
+		if strings.HasPrefix(s, "# ") {
+			return strings.TrimSpace(strings.TrimRight(s[2:], "#"))
+		}
+	}
+	return ""
+}
+
+// timestampSuffix matches the " - YYYY-MM-DDTHHMMSS±NNNN" tail that
+// Obsidian Web Clipper appends to clipped titles by default, plus the
+// handful of other ISO-ish shapes common in export filenames. Matching
+// the suffix lets us recover the human-readable title from the
+// filename rather than slugifying the whole thing (including the
+// noisy timestamp).
+var timestampSuffix = regexp.MustCompile(`(?i)\s*[-_]\s*\d{4}-\d{2}-\d{2}(?:[T ]\d{2}[:\-]?\d{2}[:\-]?\d{2}(?:[.,]\d+)?(?:[+\-]\d{2}:?\d{2}|Z)?)?$`)
+
+// cleanFilenameStem strips the ".md" extension and any trailing ISO-
+// style timestamp suffix from a filename, returning the best human-
+// readable title candidate. Returns empty string if nothing useful
+// remains after trimming.
+func cleanFilenameStem(base string) string {
+	stem := strings.TrimSuffix(base, filepath.Ext(base))
+	stem = timestampSuffix.ReplaceAllString(stem, "")
+	return strings.TrimSpace(stem)
+}
+
+// looksLikeText is a cheap binary-file filter: no NUL bytes in the
+// first 8KB. Auto-onboarding a PDF or image as a "note" would produce
+// garbage frontmatter and a useless trace.
+func looksLikeText(data []byte) bool {
+	head := data
+	if len(head) > 8192 {
+		head = head[:8192]
+	}
+	return !bytes.ContainsRune(head, 0)
+}

--- a/internal/watch/onboard_test.go
+++ b/internal/watch/onboard_test.go
@@ -1,0 +1,242 @@
+package watch_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Fail-Safe/Noema/internal/cortex"
+	"github.com/Fail-Safe/Noema/internal/trace"
+	"github.com/Fail-Safe/Noema/internal/watch"
+)
+
+// setupOnboardWatcher is like setupWatcher but starts with an empty
+// cortex so the onboarded trace is the only resident. Keeps the test
+// assertions tight.
+func setupOnboardWatcher(t *testing.T) (*cortex.Cortex, *watch.Watcher) {
+	t.Helper()
+	dir := t.TempDir()
+	if _, err := cortex.Create("wt", dir); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cx, err := cortex.Open("wt", filepath.Join(dir, "wt"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	cfg := &cortex.WatchConfig{DebounceMs: int(testDebounce / time.Millisecond)}
+	w, err := watch.New(cx, cfg)
+	if err != nil {
+		t.Fatalf("watch.New: %v", err)
+	}
+	if err := w.Start(); err != nil {
+		t.Fatalf("watch.Start: %v", err)
+	}
+	t.Cleanup(func() {
+		w.Stop()
+		cx.Close()
+	})
+	return cx, w
+}
+
+// dropFile writes body to <traces>/<name> and returns the full path.
+// Intentionally does not go through Cortex or trace.Write — this is
+// simulating an external tool writing raw bytes.
+func dropFile(t *testing.T, cx *cortex.Cortex, name, body string) string {
+	t.Helper()
+	path := filepath.Join(cx.TracesDir(), name)
+	if err := os.WriteFile(path, []byte(body), 0o640); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return path
+}
+
+// listTraceFilenames returns the non-dot .md files currently in the
+// active traces directory. Auto-onboarding should add exactly one and
+// remove the original.
+func listTraceFilenames(t *testing.T, cx *cortex.Cortex) []string {
+	t.Helper()
+	entries, err := os.ReadDir(cx.TracesDir())
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		n := e.Name()
+		if strings.HasPrefix(n, ".") || !strings.HasSuffix(n, ".md") {
+			continue
+		}
+		names = append(names, n)
+	}
+	return names
+}
+
+// ---- Obsidian Web Clipper scenario ----
+
+func TestAutoOnboard_ObsidianWebClipperFile(t *testing.T) {
+	cx, _ := setupOnboardWatcher(t)
+
+	// Shape of what Obsidian Web Clipper drops: human filename with
+	// timestamp suffix, optional frontmatter with no `id` field, body
+	// with a level-1 heading.
+	body := `---
+title: FastMail API Documentation
+source: https://api.fastmail.com/
+---
+
+# FastMail API Documentation
+
+The FastMail API is based on the JMAP protocol.
+`
+	original := dropFile(t, cx, "FastMail API Documentation - 2026-04-19T235252-0400.md", body)
+	time.Sleep(settleTime)
+
+	files := listTraceFilenames(t, cx)
+	if len(files) != 1 {
+		t.Fatalf("expected one onboarded file, got %v", files)
+	}
+	if strings.Contains(files[0], "235252") {
+		t.Errorf("onboarded filename still carries timestamp tail: %q", files[0])
+	}
+
+	// Original file is gone.
+	if _, err := os.Stat(original); !os.IsNotExist(err) {
+		t.Errorf("original file still exists: err=%v", err)
+	}
+
+	// The trace is in the DB with sensible fields.
+	rows, err := cx.List(cortex.ListOptions{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected one trace, got %d", len(rows))
+	}
+	r := rows[0]
+	if r.Title != "FastMail API Documentation" {
+		t.Errorf("title = %q, want the frontmatter title", r.Title)
+	}
+	if r.Type != string(trace.TypeNote) {
+		t.Errorf("type = %q, want note (default for onboarded)", r.Type)
+	}
+
+	// Body has the provenance banner.
+	tr, err := trace.ParseFile(filepath.Join(cx.TracesDir(), files[0]))
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	if !strings.HasPrefix(tr.Body, "> Auto-onboarded from `FastMail API Documentation - 2026-04-19T235252-0400.md`") {
+		t.Errorf("body missing provenance banner:\n%s", tr.Body)
+	}
+	if !strings.Contains(tr.Body, "JMAP protocol") {
+		t.Errorf("original body lost during onboarding:\n%s", tr.Body)
+	}
+}
+
+func TestAutoOnboard_FileWithNoFrontmatter(t *testing.T) {
+	cx, _ := setupOnboardWatcher(t)
+	dropFile(t, cx, "my-raw-note.md", "# Meeting with Alice\n\nWe discussed the roadmap.\n")
+	time.Sleep(settleTime)
+
+	rows, err := cx.List(cortex.ListOptions{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Title != "Meeting with Alice" {
+		t.Errorf("expected onboarded trace with title from h1, got %+v", rows)
+	}
+}
+
+func TestAutoOnboard_FilenameOnlyTitle(t *testing.T) {
+	// No frontmatter, no h1 — filename (with .md stripped) is the
+	// title candidate. Confirms the title-source fallback chain
+	// works end-to-end.
+	cx, _ := setupOnboardWatcher(t)
+	dropFile(t, cx, "Project Charter.md", "body content with no heading")
+	time.Sleep(settleTime)
+
+	rows, err := cx.List(cortex.ListOptions{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(rows) != 1 || rows[0].Title != "Project Charter" {
+		t.Errorf("expected title derived from filename, got %+v", rows)
+	}
+}
+
+func TestAutoOnboard_EmptyFileNotIngested(t *testing.T) {
+	cx, _ := setupOnboardWatcher(t)
+	dropFile(t, cx, "nothing-to-see.md", "")
+	time.Sleep(settleTime)
+
+	rows, err := cx.List(cortex.ListOptions{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("empty file should not produce a trace, got %+v", rows)
+	}
+}
+
+func TestAutoOnboard_BinaryFileNotIngested(t *testing.T) {
+	cx, _ := setupOnboardWatcher(t)
+	// NUL byte early in the file triggers the binary filter.
+	dropFile(t, cx, "binary.md", "\x00\x01\x02 not text")
+	time.Sleep(settleTime)
+
+	rows, err := cx.List(cortex.ListOptions{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("binary file should not produce a trace, got %+v", rows)
+	}
+}
+
+func TestAutoOnboard_DisabledFallsBackToSkip(t *testing.T) {
+	// When auto_onboard: false, the watcher restores the prior
+	// skip-and-log behaviour. The file stays in place and no trace
+	// is created.
+	dir := t.TempDir()
+	if _, err := cortex.Create("wt", dir); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cx, err := cortex.Open("wt", filepath.Join(dir, "wt"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	off := false
+	cfg := &cortex.WatchConfig{
+		DebounceMs:  int(testDebounce / time.Millisecond),
+		AutoOnboard: &off,
+	}
+	w, err := watch.New(cx, cfg)
+	if err != nil {
+		t.Fatalf("watch.New: %v", err)
+	}
+	if err := w.Start(); err != nil {
+		t.Fatalf("watch.Start: %v", err)
+	}
+	t.Cleanup(func() {
+		w.Stop()
+		cx.Close()
+	})
+
+	path := dropFile(t, cx, "Not a valid name.md", "# Title\n\nbody\n")
+	time.Sleep(settleTime)
+
+	rows, err := cx.List(cortex.ListOptions{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("auto_onboard=false should not create traces, got %+v", rows)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("original file should still exist when auto-onboard disabled: %v", err)
+	}
+}

--- a/internal/watch/reconcile.go
+++ b/internal/watch/reconcile.go
@@ -101,17 +101,44 @@ func (w *Watcher) reconcile(path string) error {
 // Covers: brand-new file drops, in-place edits, and cross-directory moves
 // (user dragged a file from traces/ to archive/ in Finder).
 func (w *Watcher) reconcileExisting(path, id string, dir traceDir, row *cortex.Row, inDB bool) error {
-	t, err := trace.ParseFile(path)
-	if err != nil {
-		log.Printf("[watch] skipping %s: %v", path, err)
-		return nil
-	}
-	if t.ID == "" || t.ID != id {
-		log.Printf("[watch] skipping %s: frontmatter id %q does not match filename", path, t.ID)
-		return nil
-	}
-	if err := trace.Validate(t); err != nil {
-		log.Printf("[watch] skipping %s: %v", path, err)
+	t, parseErr := trace.ParseFile(path)
+	malformed := parseErr != nil ||
+		t.ID == "" || t.ID != id ||
+		trace.Validate(t) != nil
+
+	// Rescue path: a malformed file dropped into traces/ that isn't
+	// in the DB yet is almost always a tool (Obsidian Web Clipper,
+	// Drafts, a shortcut) that doesn't know Noema's filename-ID
+	// convention. Synthesise valid frontmatter, rename the file to
+	// match, and ingest. Anything else (malformed file already
+	// tracked, or malformed file in archive/trash) still gets the
+	// skip-and-log treatment; auto-rewriting a tracked trace behind
+	// the operator's back would be surprising.
+	if malformed {
+		if w.autoOnboard && dir == dirActive && !inDB {
+			newPath, onboarded, err := w.onboardFile(path)
+			if err != nil {
+				w.logSkip(path, fmt.Sprintf("auto-onboard failed: %v", err))
+				return nil
+			}
+			if err := w.cx.Add(onboarded); err != nil {
+				return fmt.Errorf("add onboarded: %w", err)
+			}
+			w.forgetSkip(path)
+			log.Printf("[watch] auto-onboarded %s -> %s", filepath.Base(path), onboarded.ID)
+			_ = newPath
+			return nil
+		}
+		// Not eligible for rescue — fall back to the historical
+		// skip-and-log behaviour, now throttled per-path.
+		switch {
+		case parseErr != nil:
+			w.logSkip(path, parseErr.Error())
+		case t.ID == "" || t.ID != id:
+			w.logSkip(path, fmt.Sprintf("frontmatter id %q does not match filename", t.ID))
+		default:
+			w.logSkip(path, trace.Validate(t).Error())
+		}
 		return nil
 	}
 	bodyHash := trace.ContentHash(t.Body)
@@ -119,12 +146,13 @@ func (w *Watcher) reconcileExisting(path, id string, dir traceDir, row *cortex.R
 	if !inDB {
 		// New file dropped into the cortex.
 		if dir != dirActive {
-			log.Printf("[watch] skipping new trace %s in non-active dir", id)
+			w.logSkip(path, "new trace in non-active dir")
 			return nil
 		}
 		if err := w.cx.Add(t); err != nil {
 			return fmt.Errorf("add: %w", err)
 		}
+		w.forgetSkip(path)
 		log.Printf("[watch] ingested external create: %s", id)
 		return nil
 	}

--- a/internal/watch/watcher.go
+++ b/internal/watch/watcher.go
@@ -27,8 +27,9 @@ import (
 // federation.Syncer: construct, Start, Stop (cancels context and waits for
 // the goroutine to drain).
 type Watcher struct {
-	cx       *cortex.Cortex
-	debounce time.Duration
+	cx          *cortex.Cortex
+	debounce    time.Duration
+	autoOnboard bool
 
 	ctx    context.Context
 	cancel context.CancelFunc
@@ -38,6 +39,13 @@ type Watcher struct {
 
 	mu      sync.Mutex
 	pending map[string]*time.Timer
+
+	// lastSkipErr dedupes skip-and-log messages for the same file —
+	// external sync loops (iCloud, Obsidian reload) fire several
+	// watcher events per user action, and logging the identical
+	// error 5-10 times per file is noise. A new error string for
+	// the same path is always logged.
+	lastSkipErr map[string]string
 }
 
 // New creates a Watcher for the given cortex. An empty cfg is equivalent
@@ -50,13 +58,39 @@ func New(cx *cortex.Cortex, cfg *cortex.WatchConfig) (*Watcher, error) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	return &Watcher{
-		cx:       cx,
-		debounce: cfg.EffectiveDebounce(),
-		ctx:      ctx,
-		cancel:   cancel,
-		fsn:      fsn,
-		pending:  make(map[string]*time.Timer),
+		cx:          cx,
+		debounce:    cfg.EffectiveDebounce(),
+		autoOnboard: cfg.AutoOnboardEnabled(),
+		ctx:         ctx,
+		cancel:      cancel,
+		fsn:         fsn,
+		pending:     make(map[string]*time.Timer),
+		lastSkipErr: make(map[string]string),
 	}, nil
+}
+
+// logSkip records and throttles a skip-and-log event. A file that keeps
+// producing the same error (common with iCloud sync or a Web Clipper
+// re-write loop) is logged once; the next distinct error for the same
+// path is logged afresh. Keeps the skip log honest without flooding.
+func (w *Watcher) logSkip(path, msg string) {
+	w.mu.Lock()
+	prev, seen := w.lastSkipErr[path]
+	w.lastSkipErr[path] = msg
+	w.mu.Unlock()
+	if seen && prev == msg {
+		return
+	}
+	log.Printf("[watch] skipping %s: %s", path, msg)
+}
+
+// forgetSkip drops the throttle entry for path. Call when a path
+// transitions from skipped to successfully handled so the next skip
+// (if any) is logged even if the message matches an older one.
+func (w *Watcher) forgetSkip(path string) {
+	w.mu.Lock()
+	delete(w.lastSkipErr, path)
+	w.mu.Unlock()
 }
 
 // Start registers the three trace directories with fsnotify and spawns the


### PR DESCRIPTION
## Summary

Obsidian Web Clipper, Drafts, shortcut macros, and other tools drop
markdown into `traces/` without knowing Noema's filename-ID convention.
The watcher used to skip-and-log those files forever, spamming the log
once per iCloud sync tick and leaving the user with no trace in the
cortex. This change rescues non-conforming files instead of rejecting
them:

- Parse whatever frontmatter is salvageable (title, type, tags, author).
- Pick a title from the best available signal: existing frontmatter
  title > first `#` heading in the body > filename stem with timestamp
  suffix stripped > `Untitled`.
- Generate a proper trace ID via `trace.NewID(title)`, write the rescued
  trace at the canonical path, remove the original, and prepend a
  `> Auto-onboarded from <filename>` provenance banner to the body so
  the onboarding is visible to the user.
- Hand the rescued trace to `Cortex.Add` as if a well-formed external
  create had happened — event log gets an `ActionCreate`, federation
  picks it up normally.

Binary files (NUL-byte heuristic) and empty files are refused so a PDF
dropped in `traces/` doesn't become a garbage note. A collision guard
declines onboarding when the target path already exists, preventing
silent overwrites.

Opt-out via `cortex.md`:

```yaml
watch:
  auto_onboard: false
```

**Secondary fix, same PR:** `lastSkipErr` dedupes the `[watch]
skipping` log messages per-path so a stuck file logs once per distinct
error, not every 30s forever. The motivating symptom was ~10 identical
log lines per minute for a single iCloud-synced file.

## Test plan

- [x] Unit tests cover: Obsidian Web Clipper shape, raw markdown with h1
  title, filename-as-title fallback, empty file rejection, binary file
  rejection, opt-out behavior
- [ ] Manually drop a Web Clipper `.md` file into a running `noema
  serve` cortex and confirm it appears as a proper trace
- [ ] Verify the provenance banner shows up in the resulting trace's body
- [ ] Toggle `auto_onboard: false` in cortex.md and confirm the prior
  skip-and-log behavior returns
- [ ] Leave a deliberately-broken file in `traces/` and confirm log
  throttling — only one line per session regardless of watcher event
  count

🤖 Generated with [Claude Code](https://claude.com/claude-code)