### PR TITLE
feat(federation): peer binary version + health diagnostics in status

### DIFF
--- a/internal/cli/cmd_federation.go
+++ b/internal/cli/cmd_federation.go
@@ -145,6 +145,7 @@ func federationStatusCmd() *cobra.Command {
 			fmt.Println()
 
 			state := federation.NewState(cx.DB.DB)
+			localVersion := version()
 			for _, p := range m.Federation.Peers {
 				ps, err := state.GetPeerState(p.Name, p.Endpoint)
 				if err != nil {
@@ -160,8 +161,12 @@ func federationStatusCmd() *cobra.Command {
 					lastEvent = ps.LastEvent
 				}
 				peerMode := p.EffectiveMode()
-				fmt.Printf("  %s\n    endpoint:   %s\n    mode:       %s\n    last_seen:  %s\n    last_event: %s\n",
-					p.Name, p.Endpoint, peerMode, lastSeen, lastEvent)
+				fmt.Printf("  %s\n    endpoint:   %s\n    mode:       %s\n",
+					p.Name, p.Endpoint, peerMode)
+				renderPeerVersion(cmd.OutOrStdout(), ps.Health, localVersion)
+				fmt.Fprintf(cmd.OutOrStdout(), "    last_seen:  %s\n    last_event: %s\n",
+					lastSeen, lastEvent)
+				renderPeerHealth(cmd.OutOrStdout(), ps.Health)
 			}
 
 			vc, err := cx.GetClock()
@@ -579,4 +584,124 @@ func federationAddPeerCmd() *cobra.Command {
 			return nil
 		},
 	}
+}
+
+// renderPeerVersion prints the peer's last-observed binary version,
+// and a short "⚠ differs from local" annotation when the major/minor
+// segments of the two versions don't line up. Exact-match checks
+// would flag every commit-tagged dev build as a warning, which is
+// noise; comparing the leading `vX.Y` is accurate enough to catch
+// skew that actually produces schema-widening bugs.
+func renderPeerVersion(w io.Writer, h federation.PeerHealth, localVersion string) {
+	if h.Version == "" {
+		fmt.Fprintf(w, "    version:    (not yet observed)\n")
+		return
+	}
+	out := h.Version
+	if !versionSeriesMatches(h.Version, localVersion) {
+		out += fmt.Sprintf("    ⚠ differs from local %s", localVersion)
+	}
+	fmt.Fprintf(w, "    version:    %s\n", out)
+}
+
+// renderPeerHealth prints a multi-line "health:" block whenever the
+// peer is in a degraded state. Silent when everything is green so
+// healthy peers stay compact in the listing.
+func renderPeerHealth(w io.Writer, h federation.PeerHealth) {
+	if h.LastError == nil && h.ConsecutiveFailures == 0 {
+		return
+	}
+	fmt.Fprintf(w, "    health:     ⚠ %d consecutive failures since last success\n", h.ConsecutiveFailures)
+	if h.LastError != nil {
+		fmt.Fprintf(w, "                reason: %s\n", h.LastError.Reason)
+		if h.LastError.EventID != "" {
+			fmt.Fprintf(w, "                event:  %s\n", h.LastError.EventID)
+		}
+		if h.LastError.TraceID != "" {
+			fmt.Fprintf(w, "                trace:  %s\n", h.LastError.TraceID)
+		}
+		if hint := healthHint(h.LastError.Reason); hint != "" {
+			fmt.Fprintf(w, "                %s\n", hint)
+		}
+	}
+}
+
+// healthHint turns a machine-readable reason into a one-line human
+// hint pointing at the likely cause. Lives here rather than on
+// PeerError itself because the mapping is a UI concern — the on-disk
+// enum stays stable while display text can evolve.
+func healthHint(reason string) string {
+	switch reason {
+	case federation.ReasonInvalidTraceID,
+		federation.ReasonUnknownAction,
+		federation.ReasonUnknownType:
+		return "likely cause: peer binary predates schema changes elsewhere on the ring; upgrade the peer"
+	case federation.ReasonInvalidFrontmatter:
+		return "likely cause: peer received an event whose trace shape it doesn't recognise"
+	case federation.ReasonNetworkRefused:
+		return "likely cause: nothing listening on the peer's endpoint; is `noema serve` running?"
+	case federation.ReasonNetworkTimeout:
+		return "likely cause: peer unreachable on the network"
+	case federation.ReasonNetworkDNS:
+		return "likely cause: hostname resolution failed"
+	case federation.ReasonNetworkTLS:
+		return "likely cause: TLS handshake failed — check cert validity and CA trust"
+	case federation.ReasonAuth:
+		return "likely cause: shared-key mismatch between local and peer"
+	case federation.ReasonIdentityMismatch:
+		return "likely cause: peer cortex id changed — `noema federation reset-peer` after verifying"
+	case federation.ReasonIdentityMissing:
+		return "likely cause: peer predates cortex-id federation handshake; upgrade the peer"
+	}
+	return ""
+}
+
+// versionSeriesMatches compares the major/minor prefix of two Noema
+// version strings. Returns true when both strings lead with the same
+// `vX.Y` prefix, or when either side is unparseable (e.g. "dev" or a
+// commit-tagged build without a stable semver prefix) — skipping the
+// warning for unparseable versions avoids shouting at every dev
+// build.
+func versionSeriesMatches(a, b string) bool {
+	ap, aok := semverSeries(a)
+	bp, bok := semverSeries(b)
+	if !aok || !bok {
+		return true
+	}
+	return ap == bp
+}
+
+// semverSeries returns the `vX.Y` prefix of a version string when
+// present. Tolerates an optional leading `v` and a trailing suffix
+// (patch segment, commit hash, -dirty marker). Returns ok=false for
+// inputs that don't lead with two dot-separated numeric segments.
+func semverSeries(v string) (string, bool) {
+	s := strings.TrimPrefix(v, "v")
+	if s == "" {
+		return "", false
+	}
+	dot1 := strings.IndexByte(s, '.')
+	if dot1 <= 0 {
+		return "", false
+	}
+	rest := s[dot1+1:]
+	dot2 := strings.IndexAny(rest, ".-")
+	minor := rest
+	if dot2 >= 0 {
+		minor = rest[:dot2]
+	}
+	if minor == "" {
+		return "", false
+	}
+	for _, r := range s[:dot1] {
+		if r < '0' || r > '9' {
+			return "", false
+		}
+	}
+	for _, r := range minor {
+		if r < '0' || r > '9' {
+			return "", false
+		}
+	}
+	return s[:dot1] + "." + minor, true
 }

--- a/internal/cli/cmd_federation_health_test.go
+++ b/internal/cli/cmd_federation_health_test.go
@@ -1,0 +1,51 @@
+package cli
+
+import "testing"
+
+func TestVersionSeriesMatches(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b string
+		want bool
+	}{
+		{"same series", "v0.4.1-19-g1cc3be6", "v0.4.1-20-gabcd123", true},
+		{"different minor", "v0.4.1", "v0.5.0", false},
+		{"different major", "v1.0.0", "v0.9.0", false},
+		{"without v prefix", "0.4.1", "v0.4.2", true},
+		{"dev build on one side — don't warn", "dev", "v0.4.1", true},
+		{"commit hash on one side — don't warn", "1cc3be6-dirty", "v0.4.1", true},
+		{"both dev — don't warn", "dev", "dev", true},
+		{"both empty — don't warn", "", "", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := versionSeriesMatches(tc.a, tc.b); got != tc.want {
+				t.Errorf("versionSeriesMatches(%q, %q) = %v, want %v", tc.a, tc.b, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSemverSeries(t *testing.T) {
+	cases := []struct {
+		in     string
+		prefix string
+		ok     bool
+	}{
+		{"v0.4.1", "0.4", true},
+		{"0.5.0-rc1", "0.5", true},
+		{"v1.2", "1.2", true},
+		{"v0.4.1-19-g1cc3be6", "0.4", true},
+		{"v0.4.1-dirty", "0.4", true},
+		{"dev", "", false},
+		{"", "", false},
+		{"abc", "", false},
+		{"v.1", "", false},
+	}
+	for _, tc := range cases {
+		got, ok := semverSeries(tc.in)
+		if got != tc.prefix || ok != tc.ok {
+			t.Errorf("semverSeries(%q) = (%q, %v), want (%q, %v)", tc.in, got, ok, tc.prefix, tc.ok)
+		}
+	}
+}

--- a/internal/federation/federation.go
+++ b/internal/federation/federation.go
@@ -46,4 +46,5 @@ type PeerState struct {
 	LastSeen  string // RFC3339, "" if never reached
 	LastEvent string // ULID of last synced event, "" if never synced
 	CortexID  string // pinned ULID after first successful identity handshake
+	Health    PeerHealth
 }

--- a/internal/federation/health.go
+++ b/internal/federation/health.go
@@ -1,0 +1,189 @@
+package federation
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/Fail-Safe/Noema/internal/trace"
+)
+
+// PeerHealth is the runtime diagnostic state recorded for each peer.
+// It is persisted per-peer as JSON in the federation_state KV store
+// and read by `noema federation status` to surface version skew and
+// stalled-sync conditions.
+//
+// Intentionally free of free-form error strings: error classification
+// collapses any replay/sync failure into a small fixed enum
+// (PeerError.Reason) plus a few structured fields (event_id,
+// trace_id). The rendered output on the CLI turns the enum back into
+// human-readable text at display time. See the design discussion in
+// this commit's message for the sensitive-data reasoning.
+type PeerHealth struct {
+	// Version is the peer's binary version advertised via MCP
+	// initialize (serverInfo.Version). Updated on every successful
+	// connection, left blank until first contact.
+	Version string `json:"version,omitempty"`
+
+	// VersionObservedAt is the RFC3339 timestamp of the most recent
+	// successful MCP initialize where the peer reported Version.
+	VersionObservedAt string `json:"version_observed_at,omitempty"`
+
+	// LastSuccess is the RFC3339 timestamp of the most recent poll
+	// iteration that completed without any error (connect, identity
+	// check, fetch, and replay all succeeded).
+	LastSuccess string `json:"last_success,omitempty"`
+
+	// ConsecutiveFailures counts poll iterations since the last
+	// success that produced any error. Zero when the last poll
+	// succeeded.
+	ConsecutiveFailures int `json:"consecutive_failures,omitempty"`
+
+	// LastError is present when the most recent poll failed. Absent
+	// when LastSuccess is newer than the last failure.
+	LastError *PeerError `json:"last_error,omitempty"`
+}
+
+// PeerError is a structured record of one poll failure. Unlike a raw
+// Go error it carries no free-form error text — Reason is a fixed
+// enum and the other fields are limited to stable references
+// (event/trace IDs that already appear in federation_state anyway).
+type PeerError struct {
+	// Reason is one of the Reason* constants below.
+	Reason string `json:"reason"`
+	// EventID is the ULID of the event that failed to replay, if
+	// applicable. Empty for failures that occurred before any event
+	// was fetched.
+	EventID string `json:"event_id,omitempty"`
+	// TraceID is the trace ID carried by the failing event, if any.
+	// Derived from titles via slugification but already exposed
+	// elsewhere in federation_state (peer cursors index the event
+	// log), so storing it here adds no new attack surface.
+	TraceID string `json:"trace_id,omitempty"`
+	// ObservedAt is the RFC3339 timestamp when the failure happened.
+	ObservedAt string `json:"observed_at"`
+}
+
+// Reason enum. Values are stable strings so old health records stay
+// parseable when new values are added.
+const (
+	// Schema-widening reasons: these three signal that the peer is
+	// running a binary that predates the event shapes being produced
+	// elsewhere on the ring. `noema federation status` highlights
+	// these specifically with an "upgrade this peer" hint.
+	ReasonInvalidTraceID     = "invalid_trace_id"
+	ReasonInvalidFrontmatter = "invalid_frontmatter"
+	ReasonUnknownAction      = "unknown_action"
+	ReasonUnknownType        = "unknown_type"
+
+	// Network reasons mirror the syncer's existing categorizeError
+	// tags (refused / timeout / dns / tls / reset / eof), prefixed
+	// so the CLI can group them as "network problems" without
+	// confusing them with replay failures.
+	ReasonNetworkRefused = "network_refused"
+	ReasonNetworkTimeout = "network_timeout"
+	ReasonNetworkDNS     = "network_dns"
+	ReasonNetworkTLS     = "network_tls"
+	ReasonNetworkReset   = "network_reset"
+	ReasonNetworkEOF     = "network_eof"
+
+	// Auth / identity issues.
+	ReasonAuth             = "auth"
+	ReasonIdentityMismatch = "identity_mismatch"
+	ReasonIdentityMissing  = "identity_missing"
+
+	// Fallback bucket for anything we can't classify yet. The CLI
+	// shows "other" verbatim and points the operator at the peer's
+	// logs for detail.
+	ReasonOther = "other"
+)
+
+// IsSchemaWidening reports whether a reason indicates that the peer
+// binary predates schema changes that newer peers are producing. The
+// CLI uses this to inject a specific "upgrade this peer" suggestion.
+func IsSchemaWidening(reason string) bool {
+	switch reason {
+	case ReasonInvalidTraceID, ReasonUnknownAction, ReasonUnknownType:
+		return true
+	}
+	return false
+}
+
+// IsNetwork reports whether a reason belongs to the network-problem
+// family. Kept as a family so the CLI can render a shorter grouped
+// hint rather than a bespoke line per tag.
+func IsNetwork(reason string) bool {
+	return strings.HasPrefix(reason, "network_")
+}
+
+// PollError wraps an error with classification metadata. The syncer
+// returns it from per-peer poll iterations so the outer loop can
+// record the structured outcome without re-parsing the error text.
+type PollError struct {
+	Reason  string
+	EventID string
+	TraceID string
+	Err     error
+}
+
+func (e *PollError) Error() string { return e.Err.Error() }
+func (e *PollError) Unwrap() error { return e.Err }
+
+// ClassifyNetworkError maps connect/fetch-phase errors into the
+// network_* reason set. Returns ReasonOther for anything that doesn't
+// match a known pattern. Kept side-by-side with the syncer's
+// categorizeError (which returns the short tag) to avoid a pointless
+// second categorization.
+func ClassifyNetworkError(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "connection refused"):
+		return ReasonNetworkRefused
+	case strings.Contains(msg, "i/o timeout"),
+		strings.Contains(msg, "context deadline exceeded"),
+		strings.Contains(msg, "deadline exceeded"):
+		return ReasonNetworkTimeout
+	case strings.Contains(msg, "no such host"),
+		strings.Contains(msg, "server misbehaving"),
+		strings.Contains(msg, "no route to host"):
+		return ReasonNetworkDNS
+	case strings.Contains(msg, "x509:"),
+		strings.Contains(msg, "tls:"),
+		strings.Contains(msg, "certificate"):
+		return ReasonNetworkTLS
+	case strings.Contains(msg, "connection reset"):
+		return ReasonNetworkReset
+	case strings.Contains(msg, "EOF"):
+		return ReasonNetworkEOF
+	case strings.Contains(msg, "401"), strings.Contains(msg, "Unauthorized"):
+		return ReasonAuth
+	}
+	return ReasonOther
+}
+
+// ClassifyReplayError maps an error returned from Cortex.ReplayEvent
+// into the appropriate reason. The sentinel trace errors drive the
+// three schema-widening reasons; anything else falls to ReasonOther.
+// Kept in a single function so additions to the trace package's
+// error vocabulary have exactly one place to update here too.
+func ClassifyReplayError(err error) string {
+	switch {
+	case err == nil:
+		return ""
+	case errors.Is(err, trace.ErrInvalidTraceID):
+		return ReasonInvalidTraceID
+	case errors.Is(err, trace.ErrInvalidFrontmatter):
+		return ReasonInvalidFrontmatter
+	}
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "unknown action"):
+		return ReasonUnknownAction
+	case strings.Contains(msg, "unrecognized type"),
+		strings.Contains(msg, "unknown trace type"):
+		return ReasonUnknownType
+	}
+	return ReasonOther
+}

--- a/internal/federation/health_test.go
+++ b/internal/federation/health_test.go
@@ -1,0 +1,94 @@
+package federation
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Fail-Safe/Noema/internal/trace"
+)
+
+func TestClassifyReplayError(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"nil", nil, ""},
+		{"invalid trace id sentinel", trace.ErrInvalidTraceID, ReasonInvalidTraceID},
+		{"wrapped invalid trace id", errorsWrap(trace.ErrInvalidTraceID, "rejecting: %w"), ReasonInvalidTraceID},
+		{"invalid frontmatter sentinel", trace.ErrInvalidFrontmatter, ReasonInvalidFrontmatter},
+		{"unknown action text", errors.New("unknown action foo"), ReasonUnknownAction},
+		{"unrecognized type text", errors.New("unrecognized type bar"), ReasonUnknownType},
+		{"something else", errors.New("disk full"), ReasonOther},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ClassifyReplayError(tc.err); got != tc.want {
+				t.Errorf("ClassifyReplayError(%v) = %q, want %q", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func errorsWrap(inner error, format string) error {
+	return &wrappedErr{inner: inner, msg: format}
+}
+
+type wrappedErr struct {
+	inner error
+	msg   string
+}
+
+func (e *wrappedErr) Error() string { return e.msg }
+func (e *wrappedErr) Unwrap() error { return e.inner }
+
+func TestClassifyNetworkError(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  string
+		want string
+	}{
+		{"refused", "dial tcp 1.2.3.4:3000: connection refused", ReasonNetworkRefused},
+		{"timeout", "Get \"...\": context deadline exceeded", ReasonNetworkTimeout},
+		{"dns", "dial tcp: lookup foo: no such host", ReasonNetworkDNS},
+		{"tls", "x509: certificate signed by unknown authority", ReasonNetworkTLS},
+		{"reset", "read tcp: connection reset by peer", ReasonNetworkReset},
+		{"eof", "unexpected EOF", ReasonNetworkEOF},
+		{"401", "401 Unauthorized", ReasonAuth},
+		{"other", "something random", ReasonOther},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ClassifyNetworkError(errors.New(tc.msg)); got != tc.want {
+				t.Errorf("ClassifyNetworkError(%q) = %q, want %q", tc.msg, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsSchemaWidening(t *testing.T) {
+	wide := []string{ReasonInvalidTraceID, ReasonUnknownAction, ReasonUnknownType}
+	for _, r := range wide {
+		if !IsSchemaWidening(r) {
+			t.Errorf("%q should be schema-widening", r)
+		}
+	}
+	narrow := []string{
+		ReasonAuth, ReasonNetworkTLS, ReasonNetworkRefused,
+		ReasonIdentityMismatch, ReasonInvalidFrontmatter, ReasonOther,
+	}
+	for _, r := range narrow {
+		if IsSchemaWidening(r) {
+			t.Errorf("%q should NOT be schema-widening", r)
+		}
+	}
+}
+
+func TestIsNetwork(t *testing.T) {
+	if !IsNetwork(ReasonNetworkTimeout) {
+		t.Error("network_timeout should be classified as network")
+	}
+	if IsNetwork(ReasonInvalidTraceID) {
+		t.Error("invalid_trace_id should not be classified as network")
+	}
+}

--- a/internal/federation/state.go
+++ b/internal/federation/state.go
@@ -84,6 +84,46 @@ func PeerCortexIDKey(peerName string) string {
 	return "peer:" + peerName + ":cortex_id"
 }
 
+// PeerHealthKey returns the federation_state key holding the JSON-
+// encoded PeerHealth for this peer. Deliberately separate from the
+// other peer:* keys so health snapshots can be reset without touching
+// the cursor or pinned identity.
+func PeerHealthKey(peerName string) string {
+	return "peer:" + peerName + ":health"
+}
+
+// GetPeerHealth loads the structured health snapshot for a peer. A
+// missing key or empty value both return an empty PeerHealth — callers
+// treat that as "no data yet" identically to "first poll is about to
+// happen". Malformed JSON is tolerated the same way: the snapshot is
+// advisory, not load-bearing, and a parse error shouldn't block the
+// CLI from rendering the rest of federation status.
+func (s *State) GetPeerHealth(name string) (PeerHealth, error) {
+	val, err := s.Get(PeerHealthKey(name))
+	if err != nil {
+		return PeerHealth{}, err
+	}
+	if val == "" {
+		return PeerHealth{}, nil
+	}
+	var h PeerHealth
+	if err := json.Unmarshal([]byte(val), &h); err != nil {
+		return PeerHealth{}, nil
+	}
+	return h, nil
+}
+
+// SetPeerHealth persists the snapshot for a peer. Callers build the
+// full PeerHealth (usually by reading the previous value, adjusting,
+// and writing back) so partial updates don't need their own API.
+func (s *State) SetPeerHealth(name string, h PeerHealth) error {
+	data, err := json.Marshal(h)
+	if err != nil {
+		return err
+	}
+	return s.Set(PeerHealthKey(name), string(data))
+}
+
 // GetPeerState loads the runtime state for a peer.
 func (s *State) GetPeerState(name, endpoint string) (PeerState, error) {
 	ps := PeerState{Name: name, Endpoint: endpoint}
@@ -97,6 +137,10 @@ func (s *State) GetPeerState(name, endpoint string) (PeerState, error) {
 		return ps, err
 	}
 	ps.CortexID, err = s.Get(PeerCortexIDKey(name))
+	if err != nil {
+		return ps, err
+	}
+	ps.Health, err = s.GetPeerHealth(name)
 	return ps, err
 }
 

--- a/internal/federation/state_health_test.go
+++ b/internal/federation/state_health_test.go
@@ -1,0 +1,92 @@
+package federation_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/Fail-Safe/Noema/internal/cortex"
+	"github.com/Fail-Safe/Noema/internal/federation"
+)
+
+// newStateForTest opens an on-disk SQLite database inside a cortex
+// so PeerHealth round-trip tests exercise the real federation_state
+// table, not an in-memory stub. Returns the configured state.
+func newStateForTest(t *testing.T) *federation.State {
+	t.Helper()
+	dir := t.TempDir()
+	if _, err := cortex.Create("fed", dir); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cx, err := cortex.Open("fed", filepath.Join(dir, "fed"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { cx.Close() })
+	return federation.NewState(cx.DB.DB)
+}
+
+func TestPeerHealth_RoundTrip(t *testing.T) {
+	s := newStateForTest(t)
+
+	want := federation.PeerHealth{
+		Version:             "v0.4.1-19-g1cc3be6",
+		VersionObservedAt:   "2026-04-20T12:00:00Z",
+		LastSuccess:         "2026-04-20T11:59:00Z",
+		ConsecutiveFailures: 3,
+		LastError: &federation.PeerError{
+			Reason:     federation.ReasonInvalidTraceID,
+			EventID:    "01KPGER...",
+			TraceID:    "20260418-abc",
+			ObservedAt: "2026-04-20T12:00:30Z",
+		},
+	}
+
+	if err := s.SetPeerHealth("ai-2", want); err != nil {
+		t.Fatalf("SetPeerHealth: %v", err)
+	}
+	got, err := s.GetPeerHealth("ai-2")
+	if err != nil {
+		t.Fatalf("GetPeerHealth: %v", err)
+	}
+	if got.Version != want.Version {
+		t.Errorf("Version: got %q, want %q", got.Version, want.Version)
+	}
+	if got.ConsecutiveFailures != want.ConsecutiveFailures {
+		t.Errorf("ConsecutiveFailures: got %d, want %d", got.ConsecutiveFailures, want.ConsecutiveFailures)
+	}
+	if got.LastError == nil {
+		t.Fatal("LastError is nil after round-trip")
+	}
+	if got.LastError.Reason != want.LastError.Reason {
+		t.Errorf("Reason: got %q, want %q", got.LastError.Reason, want.LastError.Reason)
+	}
+	if got.LastError.EventID != want.LastError.EventID {
+		t.Errorf("EventID: got %q, want %q", got.LastError.EventID, want.LastError.EventID)
+	}
+}
+
+func TestPeerHealth_MissingReturnsEmpty(t *testing.T) {
+	s := newStateForTest(t)
+	got, err := s.GetPeerHealth("never-contacted")
+	if err != nil {
+		t.Fatalf("GetPeerHealth: %v", err)
+	}
+	if got.Version != "" || got.LastError != nil || got.ConsecutiveFailures != 0 {
+		t.Errorf("expected zero-value PeerHealth for missing peer, got %+v", got)
+	}
+}
+
+func TestGetPeerState_IncludesHealth(t *testing.T) {
+	s := newStateForTest(t)
+	err := s.SetPeerHealth("ai-3", federation.PeerHealth{Version: "v0.5.0"})
+	if err != nil {
+		t.Fatalf("SetPeerHealth: %v", err)
+	}
+	ps, err := s.GetPeerState("ai-3", "https://ai-3:3000")
+	if err != nil {
+		t.Fatalf("GetPeerState: %v", err)
+	}
+	if ps.Health.Version != "v0.5.0" {
+		t.Errorf("expected health to be loaded into PeerState, got %+v", ps.Health)
+	}
+}

--- a/internal/federation/syncer.go
+++ b/internal/federation/syncer.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -79,7 +80,8 @@ func (s *Syncer) syncLoop(peer PeerConfig) {
 		default:
 		}
 
-		err := s.syncPeer(peer)
+		version, err := s.syncPeer(peer)
+		s.recordPollOutcome(peer, version, err)
 		if err != nil {
 			category := categorizeError(err)
 			backoff = min(backoff*2, 5*time.Minute)
@@ -102,6 +104,68 @@ func (s *Syncer) syncLoop(peer PeerConfig) {
 			return
 		case <-time.After(backoff):
 		}
+	}
+}
+
+// recordPollOutcome writes the structured health snapshot for a peer
+// after every poll iteration. Reads the previous snapshot so success
+// preserves the most-recent version (blank version would overwrite
+// the known-good value on a transient network failure) and failures
+// carry the right consecutive-failure count. Treats persistence errors
+// as advisory — a health-write failure should not derail the next
+// poll.
+func (s *Syncer) recordPollOutcome(peer PeerConfig, version string, err error) {
+	prev, loadErr := s.state.GetPeerHealth(peer.Name)
+	if loadErr != nil {
+		log.Printf("[federation] peer %q: could not load prior health: %v", peer.Name, loadErr)
+	}
+	next := prev
+
+	if version != "" {
+		next.Version = version
+		next.VersionObservedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+
+	if err == nil {
+		next.LastSuccess = time.Now().UTC().Format(time.RFC3339)
+		next.ConsecutiveFailures = 0
+		next.LastError = nil
+	} else {
+		next.ConsecutiveFailures = prev.ConsecutiveFailures + 1
+		next.LastError = classifyPollError(err)
+	}
+
+	if saveErr := s.state.SetPeerHealth(peer.Name, next); saveErr != nil {
+		log.Printf("[federation] peer %q: could not persist health: %v", peer.Name, saveErr)
+	}
+}
+
+// classifyPollError maps any error from syncPeer into the structured
+// PeerError recorded in health. Replay failures surfaced through
+// PollError carry their own classification and event/trace refs;
+// everything else is treated as a network-or-initialize failure
+// classified by ClassifyNetworkError.
+func classifyPollError(err error) *PeerError {
+	if err == nil {
+		return nil
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	var pe *PollError
+	if errors.As(err, &pe) {
+		reason := pe.Reason
+		if reason == "" {
+			reason = ReasonOther
+		}
+		return &PeerError{
+			Reason:     reason,
+			EventID:    pe.EventID,
+			TraceID:    pe.TraceID,
+			ObservedAt: now,
+		}
+	}
+	return &PeerError{
+		Reason:     ClassifyNetworkError(err),
+		ObservedAt: now,
 	}
 }
 
@@ -187,11 +251,11 @@ func briefPeerError(peer PeerConfig, category string, backoff time.Duration) str
 	return fmt.Sprintf("[federation] peer %q still unreachable (%s); next retry in %s", peer.Name, category, backoff)
 }
 
-func (s *Syncer) syncPeer(peer PeerConfig) error {
+func (s *Syncer) syncPeer(peer PeerConfig) (string, error) {
 	// Load cursor for this peer.
 	cursor, err := s.state.Get(PeerCursorKey(peer.Name))
 	if err != nil {
-		return fmt.Errorf("loading cursor: %w", err)
+		return "", fmt.Errorf("loading cursor: %w", err)
 	}
 
 	// Connect to remote MCP server. Noema speaks Streamable HTTP (the
@@ -202,7 +266,7 @@ func (s *Syncer) syncPeer(peer PeerConfig) error {
 	if peer.CA != "" {
 		httpClient, err := tlsClientWithCA(peer.CA)
 		if err != nil {
-			return fmt.Errorf("loading CA for peer %s: %w", peer.Name, err)
+			return "", fmt.Errorf("loading CA for peer %s: %w", peer.Name, err)
 		}
 		clientOpts = append(clientOpts, transport.WithHTTPBasicClient(httpClient))
 	}
@@ -217,15 +281,15 @@ func (s *Syncer) syncPeer(peer PeerConfig) error {
 	}
 	mcpClient, err := client.NewStreamableHttpClient(mcpURL, clientOpts...)
 	if err != nil {
-		return fmt.Errorf("creating Streamable HTTP client: %w", err)
+		return "", fmt.Errorf("creating Streamable HTTP client: %w", err)
 	}
 	defer mcpClient.Close()
 
 	if err := mcpClient.Start(s.ctx); err != nil {
-		return fmt.Errorf("starting Streamable HTTP connection: %w", err)
+		return "", fmt.Errorf("starting Streamable HTTP connection: %w", err)
 	}
 
-	_, err = mcpClient.Initialize(s.ctx, mcp.InitializeRequest{
+	initResult, err := mcpClient.Initialize(s.ctx, mcp.InitializeRequest{
 		Params: mcp.InitializeParams{
 			ProtocolVersion: mcp.LATEST_PROTOCOL_VERSION,
 			ClientInfo: mcp.Implementation{
@@ -235,15 +299,16 @@ func (s *Syncer) syncPeer(peer PeerConfig) error {
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("MCP initialize: %w", err)
+		return "", fmt.Errorf("MCP initialize: %w", err)
 	}
+	peerVersion := initResult.ServerInfo.Version
 
 	// Verify the remote peer's identity before exchanging any events. On the
 	// first successful handshake, the peer's ULID is pinned in federation_state.
 	// Every subsequent sync re-checks the advertised ID against the pinned one
 	// and refuses to proceed on a mismatch — see docs/design/cortex-uuid-plan.md.
 	if err := s.verifyPeerIdentity(mcpClient, peer); err != nil {
-		return err
+		return peerVersion, &PollError{Reason: classifyIdentityError(err), Err: err}
 	}
 
 	// Call sync_events on the remote peer.
@@ -259,7 +324,7 @@ func (s *Syncer) syncPeer(peer PeerConfig) error {
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("calling sync_events: %w", err)
+		return peerVersion, fmt.Errorf("calling sync_events: %w", err)
 	}
 
 	// Parse the JSON response.
@@ -274,28 +339,50 @@ func (s *Syncer) syncPeer(peer PeerConfig) error {
 		// No new events.
 		now := time.Now().UTC().Format(time.RFC3339)
 		s.state.SetPeerSeen(peer.Name, now)
-		return nil
+		return peerVersion, nil
 	}
 
 	// Guard against a hostile peer returning an oversized payload.
 	// 100 events * 1 MB body each = 100 MB is a generous upper bound.
 	const maxSyncResponseBytes = 100 * 1024 * 1024 // 100 MiB
 	if len(text) > maxSyncResponseBytes {
-		return fmt.Errorf("sync_events response too large (%d bytes, max %d)", len(text), maxSyncResponseBytes)
+		return peerVersion, fmt.Errorf("sync_events response too large (%d bytes, max %d)", len(text), maxSyncResponseBytes)
 	}
 
 	var events []event.Event
 	if err := json.Unmarshal([]byte(text), &events); err != nil {
-		return fmt.Errorf("parsing sync_events response: %w", err)
+		return peerVersion, fmt.Errorf("parsing sync_events response: %w", err)
 	}
 
 	if err := s.replayBatch(peer.Name, events); err != nil {
-		return err
+		return peerVersion, err
 	}
 
 	now := time.Now().UTC().Format(time.RFC3339)
 	s.state.SetPeerSeen(peer.Name, now)
-	return nil
+	return peerVersion, nil
+}
+
+// classifyIdentityError maps errors returned from verifyPeerIdentity
+// into the structured reason set. Pattern-matches on the substrings
+// the verifyPeerIdentity callsites use when constructing the wrapped
+// error (kept here rather than on the error type itself to avoid
+// adding a new package-scoped sentinel for every condition).
+func classifyIdentityError(err error) string {
+	if err == nil {
+		return ""
+	}
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "identity mismatch"):
+		return ReasonIdentityMismatch
+	case strings.Contains(msg, "no cortex id"),
+		strings.Contains(msg, "pre-dates the cortex-id"):
+		return ReasonIdentityMissing
+	case strings.Contains(msg, "schema version"):
+		return ReasonInvalidFrontmatter
+	}
+	return ReasonOther
 }
 
 // replayBatch replays a batch of events received from a peer, advancing
@@ -320,7 +407,18 @@ func (s *Syncer) replayBatch(peerName string, events []event.Event) error {
 			)
 			now := time.Now().UTC().Format(time.RFC3339)
 			s.state.SetPeerSeen(peerName, now)
-			return nil
+			// Return a structured error so the outer loop can
+			// record event_id / trace_id / reason in peer health
+			// without re-parsing the error text. The log line
+			// above already carries the full error for operators
+			// tailing journalctl; health storage is the stripped-
+			// down, safe-for-persistence version.
+			return &PollError{
+				Reason:  ClassifyReplayError(err),
+				EventID: e.ID,
+				TraceID: e.TraceID,
+				Err:     fmt.Errorf("replay event %s: %w", e.ID, err),
+			}
 		}
 
 		// Merge the remote vector clock.

--- a/internal/federation/syncer_test.go
+++ b/internal/federation/syncer_test.go
@@ -73,8 +73,16 @@ func TestReplayBatch_PinsCursorOnFailure(t *testing.T) {
 	fr := &fakeReplayer{failOn: "01EVENT0000000000000000003"}
 	s := newSyncerForTest(t, fr)
 
-	if err := s.replayBatch(peerName, events); err != nil {
-		t.Fatalf("replayBatch returned error (should swallow per-event failures): %v", err)
+	err := s.replayBatch(peerName, events)
+	var pe *PollError
+	if !errors.As(err, &pe) {
+		t.Fatalf("replayBatch should return *PollError on replay failure; got %T: %v", err, err)
+	}
+	if pe.EventID != "01EVENT0000000000000000003" {
+		t.Errorf("PollError.EventID = %q, want the failing event's ID", pe.EventID)
+	}
+	if pe.TraceID != "20260407-c" {
+		t.Errorf("PollError.TraceID = %q, want the failing event's trace", pe.TraceID)
 	}
 
 	// Only the events strictly before the failure should have been
@@ -187,8 +195,10 @@ func TestReplayBatch_FirstEventFailure_LeavesCursorUnset(t *testing.T) {
 	fr := &fakeReplayer{failOn: "01FIRSTFAIL0000000000000001"}
 	s := newSyncerForTest(t, fr)
 
-	if err := s.replayBatch(peerName, events); err != nil {
-		t.Fatalf("replayBatch: %v", err)
+	err := s.replayBatch(peerName, events)
+	var pe *PollError
+	if !errors.As(err, &pe) {
+		t.Fatalf("replayBatch should return *PollError on replay failure; got %T: %v", err, err)
 	}
 	if len(fr.replayed) != 0 {
 		t.Errorf("replayed = %v, want empty (first event failed)", fr.replayed)


### PR DESCRIPTION
## Summary

`noema federation status` now surfaces each peer's binary version and a
structured health block when the peer is degraded. Directly motivated by
a recent real incident: two Linux peers silently fell behind because they
were running an older binary whose trace-ID regex rejected a long slug
that newer peers were producing. Cursor-pinned federation, no symptom
visible outside of `journalctl` spelunking. This PR turns that invisible
failure into a one-glance diagnostic.

- The syncer already performs an MCP `initialize` handshake on every
  poll. This change captures `ServerInfo.Version` from the response and
  persists it per-peer in `federation_state` under `peer:<name>:health`.
- Failures during a poll are now returned as a structured `*PollError`
  type carrying `{Reason, EventID, TraceID}`. The outer loop writes a
  `PeerHealth` snapshot with that classification and a consecutive-
  failure counter.
- `replayBatch` no longer swallows per-event failures. Previously a
  poison event (e.g. the long-trace-ID one) would log once per 30s
  forever with no backoff. Now it returns a `*PollError` that the outer
  loop classifies and applies exponential backoff to, preserving the
  cursor-pinned safety behavior while dramatically reducing log spam.

**Security:** no free-form error strings land on disk. The `reason`
field is a fixed enum (`invalid_trace_id`, `unknown_action`,
`unknown_type`, `invalid_frontmatter`, `network_{refused,timeout,dns,tls,
reset,eof}`, `auth`, `identity_{mismatch,missing}`, `other`). Trace IDs
that appear in `PeerError.TraceID` already live in `federation_state`
as peer cursors, so no new attack surface. Human-readable "likely cause"
hints live in the CLI rendering code and are produced at display time
from the on-disk enum.

**CLI output additions per peer:**

```
  ai-2
    endpoint:   https://ai-2.home-dns.com:3000
    version:    v0.4.1-19-g1cc3be6       ⚠ differs from local v0.10.0
    mode:       sync
    last_seen:  2026-04-20T04:51:56Z
    last_event: 01KPGEQMD5DASM467VM4W0V7CK
    health:     ⚠ 5760 consecutive failures since last success
                reason: invalid_trace_id
                event:  01KPGER...
                trace:  20260418-...
                likely cause: peer binary predates schema changes
                elsewhere on the ring; upgrade the peer
```

Version-mismatch annotation compares `vMAJOR.MINOR` only — patch or
commit-suffix differences don't warn (every dev build would trip
exact-match), but `v0.9` vs `v0.10` does. Unparseable versions (`dev`,
bare commit hashes) are treated as "don't warn" so ad-hoc builds don't
get flagged.

**No migration needed.** `federation_state` is already a KV store
(migration 004); `PeerHealth` persists as a JSON blob under a new
`peer:<name>:health` key.

## Test plan

- [x] Unit coverage: replay error classification, network error
  classification, `PeerHealth` round-trip, `GetPeerState` wiring,
  schema-widening detection, version-series comparison edge cases
- [x] Existing `replayBatch` tests updated to assert the new `*PollError`
  contract (cursor still pinned correctly on replay failure)
- [ ] Deploy to a real federated cluster, run `noema federation status`,
  confirm version lines appear per peer after one poll cycle
- [ ] Introduce intentional binary skew (one peer on an older build)
  and confirm the health block surfaces the `invalid_trace_id` hint
- [ ] Inspect `federation_state` SQLite table after health writes to
  confirm no free-form error text landed on disk (only the enum)

🤖 Generated with [Claude Code](https://claude.com/claude-code)