### PR TITLE
fix(federation): compare peer versions at patch level, not just minor

### DIFF
--- a/internal/cli/cmd_federation.go
+++ b/internal/cli/cmd_federation.go
@@ -656,52 +656,62 @@ func healthHint(reason string) string {
 	return ""
 }
 
-// versionSeriesMatches compares the major/minor prefix of two Noema
-// version strings. Returns true when both strings lead with the same
-// `vX.Y` prefix, or when either side is unparseable (e.g. "dev" or a
-// commit-tagged build without a stable semver prefix) — skipping the
-// warning for unparseable versions avoids shouting at every dev
-// build.
+// versionSeriesMatches compares the released-version baseline of two
+// Noema version strings. Returns true when both describe builds
+// against the same released tag — i.e. they share a `vX.Y.Z` prefix,
+// ignoring any `-N-gSHA[-dirty]` dev-build suffix that git describe
+// appends.
+//
+// Returns true when either side is unparseable ("dev", a bare commit
+// hash, ad-hoc build strings) so the warning doesn't fire on builds
+// that don't carry a meaningful baseline. The goal is to flag peer-
+// vs-local skew that operators can act on — a dev build is already
+// a known unknown.
+//
+// Earlier implementation compared only `vX.Y`, which let patch-level
+// drift slip through silently. A peer on v0.9.1 while the local
+// binary is v0.9.2-based is exactly the scenario this diagnostic
+// exists to surface, so the comparison now runs at the full patch
+// level.
 func versionSeriesMatches(a, b string) bool {
-	ap, aok := semverSeries(a)
-	bp, bok := semverSeries(b)
+	ap, aok := semverBaseline(a)
+	bp, bok := semverBaseline(b)
 	if !aok || !bok {
 		return true
 	}
 	return ap == bp
 }
 
-// semverSeries returns the `vX.Y` prefix of a version string when
-// present. Tolerates an optional leading `v` and a trailing suffix
-// (patch segment, commit hash, -dirty marker). Returns ok=false for
-// inputs that don't lead with two dot-separated numeric segments.
-func semverSeries(v string) (string, bool) {
+// semverBaseline returns the `X.Y.Z` (or `X.Y`) released-version
+// prefix of a version string. Everything past the first `-` is
+// stripped because `git describe --tags` formats dev builds as
+// `vX.Y.Z-N-gSHA[-dirty]` and that suffix identifies the dev commit,
+// not the released baseline the build descends from.
+//
+// Returns ok=false for strings that don't lead with at least two
+// dot-separated all-numeric segments (so "dev", "v", "1", and
+// arbitrary branch names don't pass as parseable versions).
+func semverBaseline(v string) (string, bool) {
 	s := strings.TrimPrefix(v, "v")
 	if s == "" {
 		return "", false
 	}
-	dot1 := strings.IndexByte(s, '.')
-	if dot1 <= 0 {
+	if dash := strings.IndexByte(s, '-'); dash >= 0 {
+		s = s[:dash]
+	}
+	parts := strings.Split(s, ".")
+	if len(parts) < 2 {
 		return "", false
 	}
-	rest := s[dot1+1:]
-	dot2 := strings.IndexAny(rest, ".-")
-	minor := rest
-	if dot2 >= 0 {
-		minor = rest[:dot2]
-	}
-	if minor == "" {
-		return "", false
-	}
-	for _, r := range s[:dot1] {
-		if r < '0' || r > '9' {
+	for _, p := range parts {
+		if p == "" {
 			return "", false
 		}
-	}
-	for _, r := range minor {
-		if r < '0' || r > '9' {
-			return "", false
+		for _, r := range p {
+			if r < '0' || r > '9' {
+				return "", false
+			}
 		}
 	}
-	return s[:dot1] + "." + minor, true
+	return s, true
 }

--- a/internal/cli/cmd_federation_health_test.go
+++ b/internal/cli/cmd_federation_health_test.go
@@ -8,14 +8,23 @@ func TestVersionSeriesMatches(t *testing.T) {
 		a, b string
 		want bool
 	}{
-		{"same series", "v0.4.1-19-g1cc3be6", "v0.4.1-20-gabcd123", true},
-		{"different minor", "v0.4.1", "v0.5.0", false},
-		{"different major", "v1.0.0", "v0.9.0", false},
-		{"without v prefix", "0.4.1", "v0.4.2", true},
-		{"dev build on one side — don't warn", "dev", "v0.4.1", true},
-		{"commit hash on one side — don't warn", "1cc3be6-dirty", "v0.4.1", true},
-		{"both dev — don't warn", "dev", "dev", true},
-		{"both empty — don't warn", "", "", true},
+		// --- same baseline, no warning ---
+		{"exact tagged match", "v0.9.2", "v0.9.2", true},
+		{"dev commits on same baseline", "v0.9.2-10-g2473442", "v0.9.2-5-gabcd123", true},
+		{"tag vs dev build on same baseline", "v0.9.2", "v0.9.2-10-g2473442", true},
+		{"without v prefix on one side", "0.9.2", "v0.9.2", true},
+
+		// --- different baseline, warn ---
+		{"patch drift (the bug this test file is pinning)", "v0.9.1", "v0.9.2", false},
+		{"patch drift with dev suffix on local", "v0.9.1", "v0.9.2-10-g2473442", false},
+		{"minor drift", "v0.9.0", "v0.10.0", false},
+		{"major drift", "v0.9.0", "v1.0.0", false},
+
+		// --- unparseable on either side, skip warning ---
+		{"dev on one side — no warning", "dev", "v0.9.1", true},
+		{"commit hash on one side — no warning", "1cc3be6-dirty", "v0.9.1", true},
+		{"both dev — no warning", "dev", "dev", true},
+		{"both empty — no warning", "", "", true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -26,26 +35,35 @@ func TestVersionSeriesMatches(t *testing.T) {
 	}
 }
 
-func TestSemverSeries(t *testing.T) {
+func TestSemverBaseline(t *testing.T) {
 	cases := []struct {
-		in     string
-		prefix string
-		ok     bool
+		in       string
+		baseline string
+		ok       bool
 	}{
-		{"v0.4.1", "0.4", true},
-		{"0.5.0-rc1", "0.5", true},
-		{"v1.2", "1.2", true},
-		{"v0.4.1-19-g1cc3be6", "0.4", true},
-		{"v0.4.1-dirty", "0.4", true},
+		// --- clean tagged versions ---
+		{"v0.9.2", "0.9.2", true},
+		{"v0.9.1", "0.9.1", true},
+		{"0.9.0", "0.9.0", true},
+		{"v1.2", "1.2", true}, // allows major.minor only
+
+		// --- dev builds: strip the -N-gSHA suffix ---
+		{"v0.9.2-10-g2473442", "0.9.2", true},
+		{"v0.9.2-10-g2473442-dirty", "0.9.2", true},
+		{"v0.9.2-dirty", "0.9.2", true},
+
+		// --- unparseable ---
 		{"dev", "", false},
 		{"", "", false},
 		{"abc", "", false},
+		{"v", "", false},
 		{"v.1", "", false},
+		{"1", "", false},
 	}
 	for _, tc := range cases {
-		got, ok := semverSeries(tc.in)
-		if got != tc.prefix || ok != tc.ok {
-			t.Errorf("semverSeries(%q) = (%q, %v), want (%q, %v)", tc.in, got, ok, tc.prefix, tc.ok)
+		got, ok := semverBaseline(tc.in)
+		if got != tc.baseline || ok != tc.ok {
+			t.Errorf("semverBaseline(%q) = (%q, %v), want (%q, %v)", tc.in, got, ok, tc.baseline, tc.ok)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Caught while testing v0.9.2 against still-running-v0.9.1 peers: the
version-skew warning in \`noema federation status\` was silent on
patch-level drift because it compared only the \`vX.Y\` prefix.
v0.9.1 peers vs v0.9.2+dev locally — both in the v0.9 series, no
warning surfaced, even though patch releases ship real behavior
changes and operators should know about the drift.

### Change

Replaces the major/minor comparison with a baseline comparison that
strips the dev-build suffix (\`-N-gSHA[-dirty]\`) and compares the
released \`vX.Y.Z\` prefix.

| Scenario | Before | After |
|---|---|---|
| v0.9.1 vs v0.9.2 | no warn (bug) | ⚠ warn |
| v0.9.2 vs v0.9.2-10-g2473442 | no warn | no warn |
| v0.9.2-5-gabc vs v0.9.2-10-gdef | no warn | no warn |
| dev / bare hash on either side | no warn | no warn |

The dev-suffix strip is deliberate: a developer running ad-hoc builds
against peers on a release tag is a known state and doesn't need a
diagnostic. The warning exists to catch peers that fell behind a
published release, which this PR now actually does.

### Release

Patch bump to **v0.9.3** — tiny fix, same-day follow-up to v0.9.2.

## Test plan

- [x] Unit tests for the new baseline-comparison semantics
- [x] Patch-drift scenario explicitly pinned as a regression test
- [x] Dev-suffix scenarios pinned so CI builds don't flag themselves
- [ ] Deploy to live federation and confirm the warning now fires
  correctly when a peer lags by a patch release

🤖 Generated with [Claude Code](https://claude.com/claude-code)