### PR TITLE
feat(serve): route stdio-mode logs to a file by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,8 @@ noema serve --print-config
 
 The `--cortex` flag, `NOEMA_CORTEX` env, and config default are all respected, so `--print-config` always reflects the cortex you would actually use.
 
+**Log destination.** In stdio mode, operational logs (watcher events, federation sync status, startup messages) are written to `$XDG_STATE_HOME/noema/<cortex>.log` — defaulting to `~/.local/state/noema/<cortex>.log` — so MCP clients that inherit the spawning terminal's stderr (Claude Code, Copilot, Zed, Cursor, Aider, etc.) don't dump logs into your active terminal. The single `[serve] logs -> <path>` line printed at startup tells you exactly where to `tail -f`. Override the destination with `--log-file <path>`, or force logs back to stderr with `--log-stderr` for interactive triage.
+
 ### Streamable HTTP (remote clients, GitHub Copilot, federation peers)
 
 Noema speaks the **Streamable HTTP** transport from the [MCP 2025-03-26 spec](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http) — a single endpoint at `/mcp` that handles JSON-RPC requests and optional SSE streaming on the same path. This is the transport native MCP clients (Zed, Claude Desktop's HTTP support, GitHub Copilot's MCP integration) speak today; the older two-endpoint legacy SSE transport has been removed.

--- a/internal/cli/cmd_serve.go
+++ b/internal/cli/cmd_serve.go
@@ -31,6 +31,8 @@ func serveCmd() *cobra.Command {
 		port              int
 		tlsCert           string
 		tlsKey            string
+		logFile           string
+		logStderr         bool
 		printConfig       bool
 		printSystemdUnit  bool
 		printLaunchdPlist bool
@@ -77,6 +79,27 @@ func serveCmd() *cobra.Command {
 				return err
 			}
 			// Don't defer cx.Close() — server runs until interrupted.
+
+			// Route operational logs. In stdio mode the default is to
+			// redirect to $XDG_STATE_HOME/noema/<cortex>.log so MCP
+			// clients (Claude Code, Copilot, Zed, etc.) that inherit
+			// the spawning tty's stderr don't end up dumping watcher +
+			// federation logs into the user's active terminal. Operators
+			// who want the logs interactive pass --log-stderr; those who
+			// want a specific path pass --log-file. In http mode the
+			// default stays stderr since systemd / launchd capture it.
+			//
+			// Print the destination to stderr BEFORE redirecting so the
+			// user sees exactly one "logs going to X" line in their tty
+			// (stdio case) or in their journald stream (http case).
+			if path, err := setupServeLogging(cx.Name, transport, logFile, logStderr); err != nil {
+				return fmt.Errorf("setting up logging: %w", err)
+			} else if path != "" {
+				fmt.Fprintf(os.Stderr, "[serve] logs -> %s\n", path)
+				if err := redirectStderrToFile(path); err != nil {
+					return fmt.Errorf("redirecting logs: %w", err)
+				}
+			}
 
 			// Surface the bound cortex identity on every serve, so an
 			// operator who started the wrong cortex sees it in the very
@@ -288,6 +311,8 @@ func serveCmd() *cobra.Command {
 	cmd.Flags().IntVar(&port, "port", 3000, "port for HTTP transport")
 	cmd.Flags().StringVar(&tlsCert, "tls-cert", "", "path to TLS certificate file (enables HTTPS)")
 	cmd.Flags().StringVar(&tlsKey, "tls-key", "", "path to TLS private key file")
+	cmd.Flags().StringVar(&logFile, "log-file", "", "write operational logs to this path (default: $XDG_STATE_HOME/noema/<cortex>.log in stdio mode; stderr in http mode)")
+	cmd.Flags().BoolVar(&logStderr, "log-stderr", false, "force logs to stderr even in stdio mode (overrides the default file redirect)")
 	cmd.Flags().BoolVar(&printConfig, "print-config", false, "print MCP client config JSON and exit")
 	cmd.Flags().BoolVar(&printSystemdUnit, "print-systemd-unit", false, "print a systemd service unit for this serve command and exit")
 	cmd.Flags().BoolVar(&printLaunchdPlist, "print-launchd-plist", false, "print a launchd LaunchAgent plist for this serve command and exit")

--- a/internal/cli/serve_logging.go
+++ b/internal/cli/serve_logging.go
@@ -1,0 +1,88 @@
+package cli
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+)
+
+// setupServeLogging resolves the log destination for a `noema serve`
+// invocation given the transport and the --log-file / --log-stderr
+// flags. Returns the resolved file path (empty if logs should stay on
+// stderr). The caller is responsible for actually opening the file and
+// redirecting via redirectStderrToFile; keeping the two steps separate
+// makes the path-resolution logic trivially unit-testable without
+// touching process-level state like os.Stderr.
+//
+// Priority order:
+//
+//  1. --log-stderr takes precedence over everything, including
+//     --log-file. Operators who explicitly want interactive logs
+//     (tailing a crashlog during triage, wiring stderr into their
+//     own logging pipeline, etc.) get that.
+//  2. --log-file overrides the transport default.
+//  3. Transport default: stdio redirects, http stays on stderr.
+//     Stdio's default is $XDG_STATE_HOME/noema/<cortex>.log with the
+//     spec's ~/.local/state fallback when XDG_STATE_HOME is unset.
+func setupServeLogging(cortexName, transport, logFile string, logStderr bool) (string, error) {
+	if logStderr {
+		return "", nil
+	}
+	if logFile != "" {
+		return logFile, nil
+	}
+	// stdio is the default transport. An empty string means stdio too.
+	if transport == "" || transport == "stdio" {
+		return defaultStdioLogPath(cortexName)
+	}
+	// http (and any future transport that streams over a network):
+	// keep stderr. systemd / launchd / docker / journald already
+	// capture it, and there's no interactive-terminal spill risk.
+	return "", nil
+}
+
+// defaultStdioLogPath returns the default log destination for
+// stdio-mode noema. Honors XDG_STATE_HOME per the spec, falling back
+// to ~/.local/state. The cortex name is included in the filename so
+// an operator running multiple stdio cortexes (one per MCP client)
+// gets per-cortex logs instead of interleaved output.
+func defaultStdioLogPath(cortexName string) (string, error) {
+	stateHome := os.Getenv("XDG_STATE_HOME")
+	if stateHome == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolving home dir for default log path: %w", err)
+		}
+		stateHome = filepath.Join(home, ".local", "state")
+	}
+	return filepath.Join(stateHome, "noema", cortexName+".log"), nil
+}
+
+// redirectStderrToFile opens (or creates, appending) the file at path
+// and redirects both the standard logger and os.Stderr to it. Reasons
+// this has to touch both:
+//
+//  - log.Printf (used throughout internal/watch, internal/federation,
+//    internal/consolidation) writes to the default logger's output,
+//    which log.SetOutput switches cleanly.
+//  - fmt.Fprintf(os.Stderr, ...) (used for startup messages and a
+//    few ad-hoc notices in cmd_serve.go) reads os.Stderr at call time.
+//    Reassigning the package-level variable is legal and affects all
+//    subsequent callers that read os.Stderr dynamically.
+//
+// The log directory is created if it doesn't exist. File permissions
+// are 0o640 so other local users on a shared host don't casually
+// tail a running cortex's logs.
+func redirectStderrToFile(path string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
+		return fmt.Errorf("creating log dir: %w", err)
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o640)
+	if err != nil {
+		return fmt.Errorf("opening log file %s: %w", path, err)
+	}
+	log.SetOutput(f)
+	os.Stderr = f
+	return nil
+}

--- a/internal/cli/serve_logging_test.go
+++ b/internal/cli/serve_logging_test.go
@@ -1,0 +1,149 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestSetupServeLogging_LogStderrWins pins the --log-stderr behavior:
+// it must override both --log-file and the stdio default. Operators
+// rely on it during triage to keep logs interactive regardless of how
+// a wrapper invoked noema.
+func TestSetupServeLogging_LogStderrWins(t *testing.T) {
+	got, err := setupServeLogging("cortex", "stdio", "/tmp/explicit.log", true)
+	if err != nil {
+		t.Fatalf("setupServeLogging: %v", err)
+	}
+	if got != "" {
+		t.Errorf("path = %q, want empty (stderr)", got)
+	}
+}
+
+// TestSetupServeLogging_ExplicitFile: --log-file overrides the stdio
+// default but not --log-stderr.
+func TestSetupServeLogging_ExplicitFile(t *testing.T) {
+	got, err := setupServeLogging("cortex", "stdio", "/var/log/noema.log", false)
+	if err != nil {
+		t.Fatalf("setupServeLogging: %v", err)
+	}
+	if got != "/var/log/noema.log" {
+		t.Errorf("path = %q, want /var/log/noema.log", got)
+	}
+}
+
+// TestSetupServeLogging_StdioDefault: no flags means stdio routes to
+// the XDG state path.
+func TestSetupServeLogging_StdioDefault(t *testing.T) {
+	// Isolate XDG_STATE_HOME so we don't pollute the user's real
+	// state dir and don't pick up a stale env var from the shell.
+	tmp := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", tmp)
+
+	got, err := setupServeLogging("agentbrain", "stdio", "", false)
+	if err != nil {
+		t.Fatalf("setupServeLogging: %v", err)
+	}
+	want := filepath.Join(tmp, "noema", "agentbrain.log")
+	if got != want {
+		t.Errorf("path = %q, want %q", got, want)
+	}
+}
+
+// TestSetupServeLogging_EmptyTransportIsStdio: cobra defaults the
+// flag to "stdio" but a library caller could pass the zero value;
+// the logic must treat empty the same as "stdio".
+func TestSetupServeLogging_EmptyTransportIsStdio(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", tmp)
+
+	got, err := setupServeLogging("cortex", "", "", false)
+	if err != nil {
+		t.Fatalf("setupServeLogging: %v", err)
+	}
+	if !strings.HasPrefix(got, tmp) {
+		t.Errorf("empty transport should route like stdio; got %q", got)
+	}
+}
+
+// TestSetupServeLogging_HttpKeepsStderr: http mode intentionally
+// leaves stderr alone so systemd/launchd/docker journald capture is
+// unchanged from pre-feature behavior.
+func TestSetupServeLogging_HttpKeepsStderr(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", tmp)
+
+	got, err := setupServeLogging("cortex", "http", "", false)
+	if err != nil {
+		t.Fatalf("setupServeLogging: %v", err)
+	}
+	if got != "" {
+		t.Errorf("http path = %q, want empty (stderr preserved)", got)
+	}
+}
+
+// TestSetupServeLogging_HttpRespectsExplicitFile: operators running
+// http under a process supervisor that doesn't capture stderr (bare
+// nohup, daemonize, etc.) can still opt into file logging.
+func TestSetupServeLogging_HttpRespectsExplicitFile(t *testing.T) {
+	got, err := setupServeLogging("cortex", "http", "/var/log/n.log", false)
+	if err != nil {
+		t.Fatalf("setupServeLogging: %v", err)
+	}
+	if got != "/var/log/n.log" {
+		t.Errorf("path = %q, want /var/log/n.log", got)
+	}
+}
+
+// TestDefaultStdioLogPath_XDGFallback: when XDG_STATE_HOME is unset,
+// the spec says fall back to ~/.local/state. Exercise that branch.
+func TestDefaultStdioLogPath_XDGFallback(t *testing.T) {
+	t.Setenv("XDG_STATE_HOME", "")
+
+	got, err := defaultStdioLogPath("cortex")
+	if err != nil {
+		t.Fatalf("defaultStdioLogPath: %v", err)
+	}
+	home, _ := os.UserHomeDir()
+	want := filepath.Join(home, ".local", "state", "noema", "cortex.log")
+	if got != want {
+		t.Errorf("fallback path = %q, want %q", got, want)
+	}
+}
+
+// TestRedirectStderrToFile_AppendsNotOverwrites: a restart-heavy
+// MCP workflow (Claude Code reloading its MCP config a few times an
+// hour) must not silently truncate the log file each invocation.
+func TestRedirectStderrToFile_AppendsNotOverwrites(t *testing.T) {
+	// Save and restore os.Stderr so the test doesn't corrupt the go
+	// test runner's own stderr stream.
+	saved := os.Stderr
+	t.Cleanup(func() { os.Stderr = saved })
+
+	path := filepath.Join(t.TempDir(), "run.log")
+	if err := os.WriteFile(path, []byte("prior line\n"), 0o640); err != nil {
+		t.Fatalf("seed log: %v", err)
+	}
+
+	if err := redirectStderrToFile(path); err != nil {
+		t.Fatalf("redirectStderrToFile: %v", err)
+	}
+	if _, err := os.Stderr.WriteString("new line\n"); err != nil {
+		t.Fatalf("stderr write: %v", err)
+	}
+	// Close the file we redirected to before reading back; otherwise
+	// Windows refuses the read on the open handle.
+	_ = os.Stderr.Close()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if !strings.Contains(string(data), "prior line") {
+		t.Errorf("append mode truncated prior content: %q", data)
+	}
+	if !strings.Contains(string(data), "new line") {
+		t.Errorf("redirect didn't reach file: %q", data)
+	}
+}


### PR DESCRIPTION
## Summary

Stops stdio-mode noema from dumping watcher + federation logs into the user's active terminal. MCP clients (Claude Code, Copilot, Zed, Cursor, Aider, etc.) that spawn `noema serve --transport stdio` inherit the spawning tty's stderr, and noema's `log.Printf` calls — particularly the filesystem watcher's `[watch] external ... -> trash:` lines — have been surfacing there unsolicited since the watch-under-stdio and auto-onboard work landed.

### Behavior

| Invocation | Logs go to |
|---|---|
| `noema serve --transport stdio` (default) | `$XDG_STATE_HOME/noema/<cortex>.log` (fallback `~/.local/state/noema/<cortex>.log`) |
| `noema serve --transport stdio --log-stderr` | stderr (previous behavior, opt-in) |
| `noema serve --transport stdio --log-file PATH` | PATH |
| `noema serve --transport http` (default) | stderr (unchanged — systemd / launchd / journald captures it) |
| `noema serve --transport http --log-file PATH` | PATH |

A single `[serve] logs -> <path>` line is printed to the original stderr before the redirect, so the user sees exactly one announcement telling them where to `tail -f`, then silence.

### Implementation

- `log.SetOutput(f)` moves the standard logger used by `internal/watch`, `internal/federation`, and `internal/consolidation`.
- Reassigning `os.Stderr = f` catches the `fmt.Fprintf(os.Stderr, ...)` callers in cmd_serve (startup messages, mode announcements). Go's `os.Stderr` is a package-level `*os.File` variable; reassigning it affects all subsequent reads and is a supported pattern.
- Log file opens `O_APPEND` with `0640` perms so restart-heavy MCP workflows don't silently truncate the log every invocation, and other local users on a shared host can't casually tail a running cortex's logs.
- Log directory created on demand with `0750`.

Path-resolution logic and redirect are separated (`setupServeLogging` + `redirectStderrToFile`) so the routing rules are unit-testable without touching process-level state.

## Test plan

- [x] 8 new unit tests in `internal/cli/serve_logging_test.go` covering flag precedence (`--log-stderr` > `--log-file` > transport default), stdio XDG routing, http-keeps-stderr, empty-transport-is-stdio, the `~/.local/state` fallback, and the append-not-truncate contract
- [x] `go build ./...`, `go vet ./...`, `staticcheck ./...` — all clean
- [x] `go test -race ./... -count=1` — all 11 packages green
- [x] Manual smoke: stdio default writes one announce line to tty, all subsequent logs land in the XDG file; `--log-stderr` preserves current behavior; `--log-file PATH` routes cleanly; http mode logs still hit stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)