### PR TITLE
feat(tier): move usage counters into per-peer trace_usage table (PR A of 2)

### DIFF
--- a/internal/cortex/actor.go
+++ b/internal/cortex/actor.go
@@ -41,9 +41,11 @@ const (
 // bumps read_count + last_read_at when the caller is ActorAgent. Other
 // actors (ActorHuman, ActorSystem) short-circuit to plain Get behavior.
 //
-// Counter bumps are skipped on tier='long' rows because the DB trigger
-// blocks all UPDATE statements on long-term traces. Long-term usage
-// signal could be revisited in a later phase if it proves valuable.
+// The bump writes to trace_usage keyed on (trace_id, local cortex ID) —
+// CRDT-style per-peer counters. Federated peers receive each other's
+// counters via sync_read_signal and the heuristic queries the aggregate.
+// Long-tier traces skip the bump because the immutability trigger blocks
+// updates; revisit if long-tier usage signal ever proves useful.
 func (c *Cortex) GetAs(id string, actor ReadActor) (*Row, error) {
 	row, err := c.Get(id)
 	if err != nil {
@@ -52,12 +54,8 @@ func (c *Cortex) GetAs(id string, actor ReadActor) (*Row, error) {
 	if actor != ActorAgent || row.Tier == trace.TierLong {
 		return row, nil
 	}
-	now := time.Now().UTC().Format(time.RFC3339)
-	if _, err := c.DB.Exec(
-		`UPDATE traces SET read_count = read_count + 1, last_read_at = ? WHERE id = ?`,
-		now, id,
-	); err != nil {
-		return row, fmt.Errorf("bumping read_count: %w", err)
+	if err := c.bumpReadCount(id); err != nil {
+		return row, err
 	}
 	return row, nil
 }
@@ -67,6 +65,7 @@ func (c *Cortex) GetAs(id string, actor ReadActor) (*Row, error) {
 // FTS refresh, etc.) and bumps modify_count when the caller is
 // ActorAgent. A failed Update short-circuits before the bump.
 //
+// The bump writes to trace_usage keyed on (trace_id, local cortex ID).
 // Long-term traces can never reach the bump step: the immutability trigger
 // aborts the inner Update transaction first.
 func (c *Cortex) UpdateAs(id string, actor ReadActor) error {
@@ -76,9 +75,43 @@ func (c *Cortex) UpdateAs(id string, actor ReadActor) error {
 	if actor != ActorAgent {
 		return nil
 	}
-	if _, err := c.DB.Exec(
-		`UPDATE traces SET modify_count = modify_count + 1 WHERE id = ?`, id,
-	); err != nil {
+	return c.bumpModifyCount(id)
+}
+
+// bumpReadCount upserts a read_count+=1 and last_read_at=now on the
+// local peer's trace_usage row. Creates the row if this is the first
+// read (or the peer's cortex ID is new to this trace_id).
+func (c *Cortex) bumpReadCount(traceID string) error {
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err := c.DB.Exec(`
+		INSERT INTO trace_usage (trace_id, peer_cortex_id, read_count, modify_count, last_read_at, updated_at)
+		VALUES (?, ?, 1, 0, ?, ?)
+		ON CONFLICT(trace_id, peer_cortex_id) DO UPDATE SET
+			read_count   = read_count + 1,
+			last_read_at = excluded.last_read_at,
+			updated_at   = excluded.updated_at`,
+		traceID, c.ID, now, now,
+	)
+	if err != nil {
+		return fmt.Errorf("bumping read_count: %w", err)
+	}
+	return nil
+}
+
+// bumpModifyCount upserts a modify_count+=1 on the local peer's
+// trace_usage row. last_read_at is left untouched — modification is a
+// distinct signal from reading.
+func (c *Cortex) bumpModifyCount(traceID string) error {
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err := c.DB.Exec(`
+		INSERT INTO trace_usage (trace_id, peer_cortex_id, read_count, modify_count, last_read_at, updated_at)
+		VALUES (?, ?, 0, 1, NULL, ?)
+		ON CONFLICT(trace_id, peer_cortex_id) DO UPDATE SET
+			modify_count = modify_count + 1,
+			updated_at   = excluded.updated_at`,
+		traceID, c.ID, now,
+	)
+	if err != nil {
 		return fmt.Errorf("bumping modify_count: %w", err)
 	}
 	return nil

--- a/internal/cortex/actor_test.go
+++ b/internal/cortex/actor_test.go
@@ -13,12 +13,16 @@ import (
 // contract that only ActorAgent bumps counters — the whole point of the
 // attribution system is to keep the consolidation-scoring signal clean.
 
+// readCountOf returns the aggregate (read_count, last_read_at) across
+// all peers for the given trace — the same view the heuristic and
+// scorer consume. Post-PR-A this reads from trace_usage (the new
+// source of truth) rather than the legacy traces columns.
 func readCountOf(t *testing.T, cx *cortex.Cortex, id string) (int, string) {
 	t.Helper()
 	var count int
 	var lastRead *string
 	err := cx.DB.QueryRow(
-		`SELECT read_count, last_read_at FROM traces WHERE id = ?`, id,
+		`SELECT COALESCE(SUM(read_count), 0), MAX(last_read_at) FROM trace_usage WHERE trace_id = ?`, id,
 	).Scan(&count, &lastRead)
 	if err != nil {
 		t.Fatalf("reading counters: %v", err)
@@ -33,7 +37,9 @@ func readCountOf(t *testing.T, cx *cortex.Cortex, id string) (int, string) {
 func modifyCountOf(t *testing.T, cx *cortex.Cortex, id string) int {
 	t.Helper()
 	var count int
-	if err := cx.DB.QueryRow(`SELECT modify_count FROM traces WHERE id = ?`, id).Scan(&count); err != nil {
+	if err := cx.DB.QueryRow(
+		`SELECT COALESCE(SUM(modify_count), 0) FROM trace_usage WHERE trace_id = ?`, id,
+	).Scan(&count); err != nil {
 		t.Fatalf("reading modify_count: %v", err)
 	}
 	return count

--- a/internal/cortex/candidates.go
+++ b/internal/cortex/candidates.go
@@ -34,12 +34,19 @@ func (c *Cortex) GraduationCandidates(minAge time.Duration) ([]PromotionCandidat
 			t.id,
 			t.tier,
 			t.type,
-			t.read_count,
-			t.modify_count,
+			COALESCE(u.total_reads, 0)    AS read_count,
+			COALESCE(u.total_modifies, 0) AS modify_count,
 			t.tier_votes,
 			COALESCE(v.n, 0) AS derived_from_count,
 			t.created_at
 		FROM traces t
+		LEFT JOIN (
+			SELECT trace_id,
+			       SUM(read_count)   AS total_reads,
+			       SUM(modify_count) AS total_modifies
+			FROM trace_usage
+			GROUP BY trace_id
+		) u ON u.trace_id = t.id
 		LEFT JOIN v_derived_from_count v ON v.trace_id = t.id
 		WHERE t.tier = 'mid'
 		  AND t.archived_at IS NULL
@@ -86,12 +93,19 @@ func (c *Cortex) PromotionCandidates(tier string, window time.Duration) ([]Promo
 			t.id,
 			t.tier,
 			t.type,
-			t.read_count,
-			t.modify_count,
+			COALESCE(u.total_reads, 0)    AS read_count,
+			COALESCE(u.total_modifies, 0) AS modify_count,
 			t.tier_votes,
 			COALESCE(v.n, 0) AS derived_from_count,
 			t.created_at
 		FROM traces t
+		LEFT JOIN (
+			SELECT trace_id,
+			       SUM(read_count)   AS total_reads,
+			       SUM(modify_count) AS total_modifies
+			FROM trace_usage
+			GROUP BY trace_id
+		) u ON u.trace_id = t.id
 		LEFT JOIN v_derived_from_count v ON v.trace_id = t.id
 		WHERE t.tier = ?
 		  AND t.archived_at IS NULL

--- a/internal/cortex/cortex.go
+++ b/internal/cortex/cortex.go
@@ -896,7 +896,51 @@ func Open(name, dir string) (*Cortex, error) {
 		fmt.Fprintf(os.Stderr, "[cortex] FTS5 reindex warning: %v\n", err)
 	}
 
+	// One-shot backfill of trace_usage from the legacy traces counters.
+	// Migration 014 creates the table; this backfill populates it from
+	// the per-trace {read_count, modify_count, last_read_at} columns on
+	// the first Open after the migration runs. Gated on "trace_usage is
+	// empty AND traces has rows" so fresh cortexes skip the work and
+	// repeat opens are no-ops. Requires cx.ID to attribute the historical
+	// counters to the local peer.
+	if cx.ID != "" {
+		if err := cx.backfillTraceUsage(); err != nil {
+			fmt.Fprintf(os.Stderr, "[cortex] trace_usage backfill warning: %v\n", err)
+		}
+	}
+
 	return cx, nil
+}
+
+// backfillTraceUsage populates trace_usage from the legacy per-trace
+// counter columns, crediting them to the local cortex ID. Idempotent:
+// skipped when trace_usage already has rows. Safe on fresh cortexes
+// (no traces -> no-op).
+func (c *Cortex) backfillTraceUsage() error {
+	var usageCount, traceCount int
+	if err := c.DB.QueryRow(`SELECT COUNT(*) FROM trace_usage`).Scan(&usageCount); err != nil {
+		return fmt.Errorf("count trace_usage: %w", err)
+	}
+	if usageCount > 0 {
+		return nil
+	}
+	if err := c.DB.QueryRow(`SELECT COUNT(*) FROM traces`).Scan(&traceCount); err != nil {
+		return fmt.Errorf("count traces: %w", err)
+	}
+	if traceCount == 0 {
+		return nil
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err := c.DB.Exec(`
+		INSERT INTO trace_usage (trace_id, peer_cortex_id, read_count, modify_count, last_read_at, updated_at)
+		SELECT id, ?, read_count, modify_count, last_read_at, ?
+		FROM traces`,
+		c.ID, now,
+	)
+	if err != nil {
+		return fmt.Errorf("backfill insert: %w", err)
+	}
+	return nil
 }
 
 // detectCopiedDirectory refuses to start if the events table contains rows

--- a/internal/cortex/trace_usage_test.go
+++ b/internal/cortex/trace_usage_test.go
@@ -1,0 +1,223 @@
+package cortex_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/Fail-Safe/Noema/internal/cortex"
+	"github.com/Fail-Safe/Noema/internal/trace"
+)
+
+// TestTraceUsage_BackfillPopulatesLocalRows pins the one-shot backfill
+// behavior: when a cortex opens with schema 014 applied but an empty
+// trace_usage table and pre-existing traces, the backfill credits the
+// historical {read_count, modify_count, last_read_at} to the local
+// peer's cortex ID. This keeps the heuristic operating on the same
+// signal as before the refactor.
+func TestTraceUsage_BackfillPopulatesLocalRows(t *testing.T) {
+	dir := t.TempDir()
+	m, err := cortex.Create("bk", dir)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cx, err := cortex.Open("bk", filepath.Join(dir, "bk"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { cx.Close() })
+
+	tr := trace.New("backfill me", "note", "", nil, "body")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	// Simulate a pre-PR-A cortex: zero out trace_usage (as if migration
+	// 014 had just been applied for the first time), stamp legacy
+	// counters into traces.{read_count,modify_count,last_read_at}.
+	if _, err := cx.DB.Exec(`DELETE FROM trace_usage`); err != nil {
+		t.Fatalf("clearing trace_usage: %v", err)
+	}
+	if _, err := cx.DB.Exec(
+		`UPDATE traces SET read_count = 7, modify_count = 2, last_read_at = '2026-04-20T00:00:00Z' WHERE id = ?`,
+		tr.ID,
+	); err != nil {
+		t.Fatalf("seeding legacy counters: %v", err)
+	}
+
+	// Close and reopen — backfill should fire on the reopen because
+	// trace_usage is empty and traces has rows.
+	cx.Close()
+	cx2, err := cortex.Open("bk", filepath.Join(dir, "bk"))
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	t.Cleanup(func() { cx2.Close() })
+
+	var reads, mods int
+	var last *string
+	var peerID string
+	err = cx2.DB.QueryRow(
+		`SELECT read_count, modify_count, last_read_at, peer_cortex_id FROM trace_usage WHERE trace_id = ?`,
+		tr.ID,
+	).Scan(&reads, &mods, &last, &peerID)
+	if err != nil {
+		t.Fatalf("read trace_usage after backfill: %v", err)
+	}
+	if reads != 7 {
+		t.Errorf("backfilled read_count = %d, want 7", reads)
+	}
+	if mods != 2 {
+		t.Errorf("backfilled modify_count = %d, want 2", mods)
+	}
+	if last == nil || *last != "2026-04-20T00:00:00Z" {
+		t.Errorf("backfilled last_read_at = %v, want 2026-04-20T00:00:00Z", last)
+	}
+	if peerID != m.ID {
+		t.Errorf("backfill attributed to peer %q, want local cortex ID %q", peerID, m.ID)
+	}
+}
+
+// TestTraceUsage_BackfillIsIdempotent pins the no-op guard: subsequent
+// opens must not re-backfill and double the counters.
+func TestTraceUsage_BackfillIsIdempotent(t *testing.T) {
+	cx := setup(t)
+	tr := trace.New("idempotent", "note", "", nil, "body")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	// Bump once via the normal path.
+	if _, err := cx.GetAs(tr.ID, cortex.ActorAgent); err != nil {
+		t.Fatalf("GetAs: %v", err)
+	}
+
+	// Close and reopen multiple times. If the backfill guard is broken,
+	// each reopen would re-insert the initial-state row with read_count=1
+	// on top of the existing one, or race the DELETE/INSERT somehow.
+	dir := cx.Dir
+	name := cx.Name
+	cx.Close()
+	for i := range 3 {
+		cx2, err := cortex.Open(name, dir)
+		if err != nil {
+			t.Fatalf("reopen %d: %v", i, err)
+		}
+		cx2.Close()
+	}
+
+	cxFinal, err := cortex.Open(name, dir)
+	if err != nil {
+		t.Fatalf("final reopen: %v", err)
+	}
+	t.Cleanup(func() { cxFinal.Close() })
+
+	var reads int
+	if err := cxFinal.DB.QueryRow(
+		`SELECT read_count FROM trace_usage WHERE trace_id = ?`, tr.ID,
+	).Scan(&reads); err != nil {
+		t.Fatalf("read trace_usage: %v", err)
+	}
+	if reads != 1 {
+		t.Errorf("read_count after 4 reopens = %d, want 1 (backfill should be a no-op when trace_usage is non-empty)", reads)
+	}
+}
+
+// TestTraceUsage_CRDTMergeViaUpsert pins the semantics the federation
+// syncer will eventually rely on: an upsert of a remote peer's row
+// applies MAX for monotonic counters and MAX for last_read_at. This
+// is PR B territory functionally, but the SQL contract is testable
+// now with a hand-rolled upsert against the table.
+func TestTraceUsage_CRDTMergeViaUpsert(t *testing.T) {
+	cx := setup(t)
+	tr := trace.New("crdt target", "note", "", nil, "body")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	// Simulate a remote peer's delta arriving twice: the second arrival
+	// carries smaller counter values and an older last_read_at. The
+	// merge should preserve the higher-watermark values from the first
+	// arrival — the CRDT contract PR B will enforce in the syncer.
+	remote := "01REMOTE00000000000000PEER"
+	upsert := `
+		INSERT INTO trace_usage (trace_id, peer_cortex_id, read_count, modify_count, last_read_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(trace_id, peer_cortex_id) DO UPDATE SET
+			read_count   = MAX(read_count,   excluded.read_count),
+			modify_count = MAX(modify_count, excluded.modify_count),
+			last_read_at = MAX(COALESCE(last_read_at, ''), COALESCE(excluded.last_read_at, '')),
+			updated_at   = MAX(updated_at,   excluded.updated_at)
+	`
+	if _, err := cx.DB.Exec(upsert,
+		tr.ID, remote, 10, 3, "2026-04-22T12:00:00Z", "2026-04-22T12:00:00Z",
+	); err != nil {
+		t.Fatalf("initial upsert: %v", err)
+	}
+	// Regression arrival: smaller values.
+	if _, err := cx.DB.Exec(upsert,
+		tr.ID, remote, 4, 1, "2026-04-21T12:00:00Z", "2026-04-23T00:00:00Z",
+	); err != nil {
+		t.Fatalf("regression upsert: %v", err)
+	}
+
+	var reads, mods int
+	var last string
+	if err := cx.DB.QueryRow(
+		`SELECT read_count, modify_count, last_read_at FROM trace_usage WHERE trace_id = ? AND peer_cortex_id = ?`,
+		tr.ID, remote,
+	).Scan(&reads, &mods, &last); err != nil {
+		t.Fatalf("read merged row: %v", err)
+	}
+	if reads != 10 {
+		t.Errorf("read_count after regression upsert = %d, want 10 (MAX merge)", reads)
+	}
+	if mods != 3 {
+		t.Errorf("modify_count after regression upsert = %d, want 3 (MAX merge)", mods)
+	}
+	if last != "2026-04-22T12:00:00Z" {
+		t.Errorf("last_read_at after regression upsert = %q, want 2026-04-22T12:00:00Z (MAX merge)", last)
+	}
+}
+
+// TestTraceUsage_AggregateSumsAcrossPeers pins the heuristic's view:
+// SUM(read_count) and MAX(last_read_at) across every peer_cortex_id
+// row for a trace is the aggregate the promotion/graduation queries
+// consume. A trace with 3 local reads + 5 remote reads should score
+// as if it had 8 reads — the whole point of federating the signal.
+func TestTraceUsage_AggregateSumsAcrossPeers(t *testing.T) {
+	cx := setup(t)
+	tr := trace.New("aggregate target", "note", "", nil, "body")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	for range 3 {
+		if _, err := cx.GetAs(tr.ID, cortex.ActorAgent); err != nil {
+			t.Fatalf("local GetAs: %v", err)
+		}
+	}
+
+	// Simulate a remote peer's deltas already synced in.
+	remote := "01REMOTEFEDPEER0000000000"
+	if _, err := cx.DB.Exec(`
+		INSERT INTO trace_usage (trace_id, peer_cortex_id, read_count, modify_count, last_read_at, updated_at)
+		VALUES (?, ?, 5, 0, '2026-04-23T19:00:00Z', '2026-04-23T19:00:00Z')`,
+		tr.ID, remote,
+	); err != nil {
+		t.Fatalf("seed remote: %v", err)
+	}
+
+	var totalReads int
+	var maxLast string
+	err := cx.DB.QueryRow(
+		`SELECT SUM(read_count), MAX(last_read_at) FROM trace_usage WHERE trace_id = ?`, tr.ID,
+	).Scan(&totalReads, &maxLast)
+	if err != nil {
+		t.Fatalf("aggregate query: %v", err)
+	}
+	if totalReads != 8 {
+		t.Errorf("aggregate read_count = %d, want 8 (3 local + 5 remote)", totalReads)
+	}
+	if maxLast != "2026-04-23T19:00:00Z" {
+		t.Errorf("aggregate last_read_at = %q, want 2026-04-23T19:00:00Z (remote newer)", maxLast)
+	}
+}

--- a/internal/db/migrations/014_trace_usage.sql
+++ b/internal/db/migrations/014_trace_usage.sql
@@ -1,0 +1,29 @@
+-- Per-peer usage counters, CRDT-style. Each (trace_id, peer_cortex_id) row
+-- carries read_count / modify_count / last_read_at owned by one peer —
+-- locally this peer writes to its own row, remote rows are replicas
+-- received via federation sync. The heuristic queries aggregate across all
+-- rows for a trace (SUM for counts, MAX for last_read_at) so the tier
+-- decision operates on the full federation view rather than a local slice.
+--
+-- Backfill from the legacy traces.{read_count,modify_count,last_read_at}
+-- columns happens in Go at cortex.Open() time, not here: we need the
+-- local cortex ID (from cortex.md) to know which peer to credit the
+-- historical counters to, and migrations don't have access to it.
+--
+-- See feat/trace-usage-storage and the CLAUDE.md "Memory tier"
+-- description for full context on why federation-wide signal is the
+-- right input for consolidation-election decisions.
+
+CREATE TABLE trace_usage (
+    trace_id        TEXT NOT NULL,
+    peer_cortex_id  TEXT NOT NULL,
+    read_count      INTEGER NOT NULL DEFAULT 0,
+    modify_count    INTEGER NOT NULL DEFAULT 0,
+    last_read_at    TEXT,
+    updated_at      TEXT NOT NULL,
+    PRIMARY KEY (trace_id, peer_cortex_id),
+    FOREIGN KEY (trace_id) REFERENCES traces(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_trace_usage_updated ON trace_usage(updated_at);
+CREATE INDEX idx_trace_usage_trace   ON trace_usage(trace_id);


### PR DESCRIPTION
## Summary

Groundwork for federating the tier-heuristic signal across peers. This PR is a **refactor only** — it moves the storage shape into place without changing single-peer behavior. PR B will land the federation sync (`sync_read_signal` MCP tool + syncer phase) on top.

### Why

Today the tier heuristic's inputs (`read_count`, `modify_count`, `last_read_at`) live as scalar columns on `traces`, writable only by the local peer. The elected consolidator runs its pass on a local-slice view of attention, which defeats the goal of "one peer runs consolidation against the collective shared brain." Discovered this week when `agentbrain`'s tier counters showed zero reads on the Mac peer despite heavy agent activity — turns out each federated peer maintains its own isolated counters, and agents on ai-1 only ever bumped ai-1's local peer.

### Changes in this PR

- **Migration 014** creates `trace_usage(trace_id, peer_cortex_id, read_count, modify_count, last_read_at, updated_at)` with the composite primary key + indexes for sync (`updated_at`) and aggregate lookups (`trace_id`). `FK(trace_id) ... ON DELETE CASCADE` so a purged trace drops its usage rows too.
- **One-shot backfill in `cortex.Open`** — when `trace_usage` is empty and `traces` has rows, copy the historical per-trace counters into `trace_usage` crediting them to the local cortex ID. Guarded to be a no-op on fresh cortexes and on repeat opens.
- **`GetAs` / `UpdateAs` rewired** — previous `UPDATE traces SET ... + 1` become upserts on `trace_usage` keyed on `(trace_id, local_cortex_id)`.
- **`candidates.go` queries aggregate across peers** — `PromotionCandidates` and `GraduationCandidates` now `LEFT JOIN` a `SUM(read_count), SUM(modify_count)` subquery. For a single-peer cortex this is numerically identical to reading scalar columns; for a federated cortex (once PR B ships) it'll reflect the union.

### Non-goals (deferred to PR B or later)

- No federation protocol yet. `sync_read_signal` MCP tool, syncer phase, and `federation_state` cursor additions are PR B.
- Legacy `traces.{read_count, modify_count, last_read_at}` columns are **not** dropped. They stop being written to, but remain so the backfill source of truth exists if operators need to re-run. A later cleanup migration can remove them.
- No changes to on-disk frontmatter — usage counters have always been DB-only.
- `noema memory status` and similar surfaces don't yet show cross-peer signal; that visibility also belongs in PR B.

### Tests

- Existing `actor_test.go` assertions now read through the aggregate view (`SUM(read_count) FROM trace_usage`) — same numbers, new source of truth. All prior test cases pass unchanged semantically.
- New `trace_usage_test.go`:
  - `TestTraceUsage_BackfillPopulatesLocalRows` — pre-PR-A state is migrated cleanly, with attribution to the local cortex ID.
  - `TestTraceUsage_BackfillIsIdempotent` — four reopens, counter stays correct.
  - `TestTraceUsage_CRDTMergeViaUpsert` — MAX-semantics upsert resists out-of-order remote deltas (pins the merge contract PR B's syncer will use).
  - `TestTraceUsage_AggregateSumsAcrossPeers` — 3 local + 5 remote = 8 in the heuristic's view.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` full suite green
- [x] Four new `TestTraceUsage_*` tests
- [x] Existing `TestGetAs_*` / `TestUpdateAs_*` pass against the new aggregate-view helpers
- [ ] Spot-check on a real cortex: open a schema-13 cortex with this build, verify `trace_usage` gets backfilled and counters continue to move on MCP `get_trace` calls (single-peer behavior identical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)