### PR TITLE
feat(federation): sync_read_signal MCP tool + syncer phase (PR B of 2)

### DIFF
--- a/internal/cortex/trace_usage_test.go
+++ b/internal/cortex/trace_usage_test.go
@@ -196,11 +196,13 @@ func TestTraceUsage_AggregateSumsAcrossPeers(t *testing.T) {
 		}
 	}
 
-	// Simulate a remote peer's deltas already synced in.
+	// Simulate a remote peer's deltas already synced in. Far-future
+	// timestamp so "remote is newer than local" holds regardless of
+	// wall-clock drift between local GetAs() bumps and this line.
 	remote := "01REMOTEFEDPEER0000000000"
 	if _, err := cx.DB.Exec(`
 		INSERT INTO trace_usage (trace_id, peer_cortex_id, read_count, modify_count, last_read_at, updated_at)
-		VALUES (?, ?, 5, 0, '2026-04-23T19:00:00Z', '2026-04-23T19:00:00Z')`,
+		VALUES (?, ?, 5, 0, '2099-01-01T00:00:00Z', '2099-01-01T00:00:00Z')`,
 		tr.ID, remote,
 	); err != nil {
 		t.Fatalf("seed remote: %v", err)
@@ -217,7 +219,7 @@ func TestTraceUsage_AggregateSumsAcrossPeers(t *testing.T) {
 	if totalReads != 8 {
 		t.Errorf("aggregate read_count = %d, want 8 (3 local + 5 remote)", totalReads)
 	}
-	if maxLast != "2026-04-23T19:00:00Z" {
-		t.Errorf("aggregate last_read_at = %q, want 2026-04-23T19:00:00Z (remote newer)", maxLast)
+	if maxLast != "2099-01-01T00:00:00Z" {
+		t.Errorf("aggregate last_read_at = %q, want 2099-01-01T00:00:00Z (remote newer)", maxLast)
 	}
 }

--- a/internal/cortex/usage.go
+++ b/internal/cortex/usage.go
@@ -1,0 +1,101 @@
+package cortex
+
+import (
+	"fmt"
+
+	"github.com/Fail-Safe/Noema/internal/federation"
+)
+
+// LocalUsageSince returns trace_usage rows owned by the local peer
+// (peer_cortex_id = c.ID) with updated_at > since, ordered by
+// updated_at so callers can advance their cursor to the last row's
+// UpdatedAt on each batch. A peer only publishes its own deltas; remote
+// rows we've synced in are never re-broadcast (prevents amplification
+// loops and keeps bandwidth linear).
+//
+// A zero-value since returns everything this peer owns.
+func (c *Cortex) LocalUsageSince(since string, limit int) ([]federation.TraceUsage, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := c.DB.Query(`
+		SELECT trace_id, peer_cortex_id, read_count, modify_count, last_read_at, updated_at
+		FROM trace_usage
+		WHERE peer_cortex_id = ? AND updated_at > ?
+		ORDER BY updated_at ASC
+		LIMIT ?`,
+		c.ID, since, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("querying local usage deltas: %w", err)
+	}
+	defer rows.Close()
+
+	var out []federation.TraceUsage
+	for rows.Next() {
+		var r federation.TraceUsage
+		var lastRead *string
+		if err := rows.Scan(&r.TraceID, &r.PeerCortexID, &r.ReadCount, &r.ModifyCount, &lastRead, &r.UpdatedAt); err != nil {
+			return nil, err
+		}
+		if lastRead != nil {
+			r.LastReadAt = *lastRead
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// MergeRemoteUsage upserts a batch of rows from a remote peer into
+// trace_usage using CRDT MAX-merge semantics. Safe against out-of-order
+// arrivals and duplicate deliveries — an older row re-arriving after a
+// newer one leaves the stored values untouched. A peer must never call
+// this with rows whose peer_cortex_id matches its own (that would let a
+// remote overwrite the local peer's authoritative counters); the caller
+// is responsible for that invariant, but as a guard we skip any such
+// rows instead of applying them.
+//
+// Rows for trace_ids that don't exist locally yet are inserted anyway —
+// the corresponding create event will arrive separately via sync_events
+// and the FK enforces consistency eventually. If the create never shows
+// up (peer disagrees about trace existence) the orphan is harmless; the
+// aggregate query joins traces as LEFT so it's simply ignored.
+func (c *Cortex) MergeRemoteUsage(rows []federation.TraceUsage) error {
+	if len(rows) == 0 {
+		return nil
+	}
+	tx, err := c.DB.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	stmt, err := tx.Prepare(`
+		INSERT INTO trace_usage (trace_id, peer_cortex_id, read_count, modify_count, last_read_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(trace_id, peer_cortex_id) DO UPDATE SET
+			read_count   = MAX(read_count,   excluded.read_count),
+			modify_count = MAX(modify_count, excluded.modify_count),
+			last_read_at = MAX(COALESCE(last_read_at, ''), COALESCE(excluded.last_read_at, '')),
+			updated_at   = MAX(updated_at,   excluded.updated_at)`)
+	if err != nil {
+		return fmt.Errorf("preparing upsert: %w", err)
+	}
+	defer stmt.Close()
+
+	for _, r := range rows {
+		if r.PeerCortexID == c.ID {
+			// Defensive: a peer should never ship us rows under our own
+			// cortex ID. Skip rather than let them stomp local writes.
+			continue
+		}
+		var last any
+		if r.LastReadAt != "" {
+			last = r.LastReadAt
+		}
+		if _, err := stmt.Exec(r.TraceID, r.PeerCortexID, r.ReadCount, r.ModifyCount, last, r.UpdatedAt); err != nil {
+			return fmt.Errorf("merging row (trace=%s peer=%s): %w", r.TraceID, r.PeerCortexID, err)
+		}
+	}
+	return tx.Commit()
+}

--- a/internal/cortex/usage_test.go
+++ b/internal/cortex/usage_test.go
@@ -1,0 +1,176 @@
+package cortex_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Fail-Safe/Noema/internal/cortex"
+	"github.com/Fail-Safe/Noema/internal/federation"
+	"github.com/Fail-Safe/Noema/internal/trace"
+)
+
+// TestLocalUsageSince_FiltersToLocalPeerOnly pins the publish
+// contract: a peer only exposes its own rows via sync_read_signal.
+// Remote rows we've synced in are never re-broadcast.
+func TestLocalUsageSince_FiltersToLocalPeerOnly(t *testing.T) {
+	cx := setup(t)
+	tr := trace.New("owned", "note", "", nil, "body")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	// Local read bumps the local peer's row.
+	if _, err := cx.GetAs(tr.ID, cortex.ActorAgent); err != nil {
+		t.Fatalf("GetAs: %v", err)
+	}
+
+	// Inject a row attributed to a remote peer — this must NOT appear
+	// in LocalUsageSince output.
+	if _, err := cx.DB.Exec(`
+		INSERT INTO trace_usage (trace_id, peer_cortex_id, read_count, modify_count, last_read_at, updated_at)
+		VALUES (?, ?, 99, 99, '2099-01-01T00:00:00Z', '2099-01-01T00:00:00Z')`,
+		tr.ID, "01REMOTEPEER000000000000",
+	); err != nil {
+		t.Fatalf("seed remote: %v", err)
+	}
+
+	rows, err := cx.LocalUsageSince("", 100)
+	if err != nil {
+		t.Fatalf("LocalUsageSince: %v", err)
+	}
+	for _, r := range rows {
+		if r.PeerCortexID != cx.ID {
+			t.Errorf("remote peer row leaked into LocalUsageSince output: %+v", r)
+		}
+	}
+	if len(rows) != 1 {
+		t.Errorf("expected 1 local row, got %d", len(rows))
+	}
+}
+
+// TestLocalUsageSince_CursorAdvancesMonotonically pins the sync
+// contract: rows are returned in UpdatedAt ASC order so callers can
+// use the tail row's UpdatedAt as the next cursor.
+func TestLocalUsageSince_CursorAdvancesMonotonically(t *testing.T) {
+	cx := setup(t)
+	for range 3 {
+		tr := trace.New("t"+time.Now().Format("150405.000000"), "note", "", nil, "body")
+		if err := cx.Add(tr); err != nil {
+			t.Fatalf("Add: %v", err)
+		}
+		if _, err := cx.GetAs(tr.ID, cortex.ActorAgent); err != nil {
+			t.Fatalf("GetAs: %v", err)
+		}
+		time.Sleep(time.Second + 10*time.Millisecond) // RFC3339 granularity is 1s
+	}
+
+	rows, err := cx.LocalUsageSince("", 100)
+	if err != nil {
+		t.Fatalf("LocalUsageSince: %v", err)
+	}
+	if len(rows) < 3 {
+		t.Fatalf("expected at least 3 rows, got %d", len(rows))
+	}
+	for i := 1; i < len(rows); i++ {
+		if rows[i-1].UpdatedAt > rows[i].UpdatedAt {
+			t.Errorf("rows not in ascending UpdatedAt order: %s then %s", rows[i-1].UpdatedAt, rows[i].UpdatedAt)
+		}
+	}
+
+	// Resume using the middle cursor — should get only the tail.
+	mid := rows[len(rows)/2].UpdatedAt
+	after, err := cx.LocalUsageSince(mid, 100)
+	if err != nil {
+		t.Fatalf("LocalUsageSince(mid): %v", err)
+	}
+	for _, r := range after {
+		if r.UpdatedAt <= mid {
+			t.Errorf("cursor leaked a row with UpdatedAt=%s (should be > %s)", r.UpdatedAt, mid)
+		}
+	}
+}
+
+// TestMergeRemoteUsage_RefusesLocalIDAttribution pins the safety
+// invariant: even if a malicious or buggy peer ships us rows under
+// our own cortex_id, we refuse to apply them. Otherwise a remote
+// could rewrite our local counters.
+func TestMergeRemoteUsage_RefusesLocalIDAttribution(t *testing.T) {
+	cx := setup(t)
+	tr := trace.New("selfguard", "note", "", nil, "body")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	// Establish a local row via a legit read.
+	if _, err := cx.GetAs(tr.ID, cortex.ActorAgent); err != nil {
+		t.Fatalf("GetAs: %v", err)
+	}
+
+	// Attempt to overwrite the local row via MergeRemoteUsage.
+	if err := cx.MergeRemoteUsage([]federation.TraceUsage{{
+		TraceID:      tr.ID,
+		PeerCortexID: cx.ID, // local ID — should be refused
+		ReadCount:    9999,
+		ModifyCount:  9999,
+		LastReadAt:   "2099-01-01T00:00:00Z",
+		UpdatedAt:    "2099-01-01T00:00:00Z",
+	}}); err != nil {
+		t.Fatalf("MergeRemoteUsage: %v", err)
+	}
+
+	// Local row must still have read_count = 1 (unchanged).
+	var reads int
+	if err := cx.DB.QueryRow(
+		`SELECT read_count FROM trace_usage WHERE trace_id = ? AND peer_cortex_id = ?`,
+		tr.ID, cx.ID,
+	).Scan(&reads); err != nil {
+		t.Fatalf("read local row: %v", err)
+	}
+	if reads != 1 {
+		t.Errorf("local row was overwritten by MergeRemoteUsage: read_count=%d, want 1", reads)
+	}
+}
+
+// TestMergeRemoteUsage_MaxMergeOnRepeat pins the CRDT contract:
+// re-applying an older row after a newer one is a no-op.
+func TestMergeRemoteUsage_MaxMergeOnRepeat(t *testing.T) {
+	cx := setup(t)
+	tr := trace.New("maxmerge", "note", "", nil, "body")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	remote := "01REMOTEPEER000000000000"
+	rows := []federation.TraceUsage{
+		{TraceID: tr.ID, PeerCortexID: remote, ReadCount: 10, ModifyCount: 3, LastReadAt: "2099-02-01T00:00:00Z", UpdatedAt: "2099-02-01T00:00:00Z"},
+	}
+	if err := cx.MergeRemoteUsage(rows); err != nil {
+		t.Fatalf("first merge: %v", err)
+	}
+
+	// Regression delivery: older values arrive. MAX-merge must
+	// preserve the newer values we already have.
+	regression := []federation.TraceUsage{
+		{TraceID: tr.ID, PeerCortexID: remote, ReadCount: 4, ModifyCount: 1, LastReadAt: "2099-01-01T00:00:00Z", UpdatedAt: "2099-02-15T00:00:00Z"},
+	}
+	if err := cx.MergeRemoteUsage(regression); err != nil {
+		t.Fatalf("regression merge: %v", err)
+	}
+
+	var reads, mods int
+	var last string
+	if err := cx.DB.QueryRow(
+		`SELECT read_count, modify_count, last_read_at FROM trace_usage WHERE trace_id = ? AND peer_cortex_id = ?`,
+		tr.ID, remote,
+	).Scan(&reads, &mods, &last); err != nil {
+		t.Fatalf("read merged row: %v", err)
+	}
+	if reads != 10 {
+		t.Errorf("read_count after regression = %d, want 10 (MAX merge should resist downgrade)", reads)
+	}
+	if mods != 3 {
+		t.Errorf("modify_count after regression = %d, want 3", mods)
+	}
+	if last != "2099-02-01T00:00:00Z" {
+		t.Errorf("last_read_at after regression = %q, want 2099-02-01T00:00:00Z", last)
+	}
+}

--- a/internal/federation/state.go
+++ b/internal/federation/state.go
@@ -76,6 +76,15 @@ func PeerSeenKey(peerName string) string {
 	return "peer:" + peerName + ":last_seen"
 }
 
+// PeerUsageCursorKey returns the federation_state key for a peer's
+// last_usage cursor (highest trace_usage.updated_at this peer's ever
+// seen from the named peer). Separate from the event cursor because
+// the two streams advance independently — a peer can be quiet on
+// mutations but chatty on reads, or vice versa.
+func PeerUsageCursorKey(peerName string) string {
+	return "peer:" + peerName + ":last_usage"
+}
+
 // PeerCortexIDKey returns the federation_state key under which a peer's verified
 // cortex ULID is pinned after the first successful identity handshake. The
 // syncer refuses to talk to a peer whose advertised ID has changed from what

--- a/internal/federation/syncer.go
+++ b/internal/federation/syncer.go
@@ -20,10 +20,15 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 )
 
-// EventReplayer materializes a remote event on the local cortex.
+// EventReplayer materializes a remote event on the local cortex and
+// merges peer-owned tier-usage rows into the local trace_usage table.
+// Named for historical reasons (used to be events-only); the merge
+// hook was added when the federation started carrying read-signal
+// deltas alongside events. Implemented by *cortex.Cortex.
 type EventReplayer interface {
 	ReplayEvent(event.Event) error
 	MergeClock(VClock) error
+	MergeRemoteUsage([]TraceUsage) error
 }
 
 // Syncer polls remote peers for new events and replays them locally.
@@ -357,31 +362,123 @@ func (s *Syncer) syncPeer(peer PeerConfig) (string, error) {
 	}
 
 	if text == "" || text == "[]" {
-		// No new events.
-		now := time.Now().UTC().Format(time.RFC3339)
-		s.state.SetPeerSeen(peer.Name, now)
-		return peerVersion, nil
+		// No new events, but still attempt usage sync below.
+	} else {
+		// Guard against a hostile peer returning an oversized payload.
+		// 100 events * 1 MB body each = 100 MB is a generous upper bound.
+		const maxSyncResponseBytes = 100 * 1024 * 1024 // 100 MiB
+		if len(text) > maxSyncResponseBytes {
+			return peerVersion, fmt.Errorf("sync_events response too large (%d bytes, max %d)", len(text), maxSyncResponseBytes)
+		}
+
+		var events []event.Event
+		if err := json.Unmarshal([]byte(text), &events); err != nil {
+			return peerVersion, fmt.Errorf("parsing sync_events response: %w", err)
+		}
+
+		if err := s.replayBatch(peer.Name, events); err != nil {
+			return peerVersion, err
+		}
 	}
 
-	// Guard against a hostile peer returning an oversized payload.
-	// 100 events * 1 MB body each = 100 MB is a generous upper bound.
-	const maxSyncResponseBytes = 100 * 1024 * 1024 // 100 MiB
-	if len(text) > maxSyncResponseBytes {
-		return peerVersion, fmt.Errorf("sync_events response too large (%d bytes, max %d)", len(text), maxSyncResponseBytes)
-	}
-
-	var events []event.Event
-	if err := json.Unmarshal([]byte(text), &events); err != nil {
-		return peerVersion, fmt.Errorf("parsing sync_events response: %w", err)
-	}
-
-	if err := s.replayBatch(peer.Name, events); err != nil {
-		return peerVersion, err
+	// Phase 2: pull usage deltas. A failure here is logged but does
+	// not fail the poll — events already succeeded, the usage cursor
+	// stays at its last-applied position, and the next cycle retries.
+	// Pre-PR-B peers (no sync_read_signal tool) return -32601; we
+	// treat that as a known non-error and keep going.
+	if err := s.syncReadSignalPhase(peer, mcpClient); err != nil {
+		log.Printf("[federation] peer %q: read-signal sync failed (events already applied): %v", peer.Name, err)
 	}
 
 	now := time.Now().UTC().Format(time.RFC3339)
 	s.state.SetPeerSeen(peer.Name, now)
 	return peerVersion, nil
+}
+
+// syncReadSignalPhase is the PR B addition to each per-peer poll:
+// after sync_events completes, pull the peer's trace_usage deltas
+// (rows where peer_cortex_id = theirs and updated_at > our cursor)
+// and merge with CRDT MAX semantics so the aggregate heuristic view
+// reflects every peer's attention, not just the local slice.
+//
+// Returns nil on success including the "peer doesn't have the tool"
+// case — that's the pre-PR-B fallback and shouldn't poison the rest
+// of the sync cycle.
+func (s *Syncer) syncReadSignalPhase(peer PeerConfig, mcpClient *client.Client) error {
+	cursor, err := s.state.Get(PeerUsageCursorKey(peer.Name))
+	if err != nil {
+		return fmt.Errorf("loading usage cursor: %w", err)
+	}
+
+	args := map[string]any{"limit": 500}
+	if cursor != "" {
+		args["since"] = cursor
+	}
+
+	result, err := mcpClient.CallTool(s.ctx, mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name:      "sync_read_signal",
+			Arguments: args,
+		},
+	})
+	if err != nil {
+		// JSON-RPC "method not found" surfaces as -32601 in the
+		// error message. Peers on pre-PR-B binaries return this;
+		// treat as a clean no-op (logged once by the caller if it
+		// keeps happening, not here).
+		if strings.Contains(err.Error(), "-32601") ||
+			strings.Contains(err.Error(), "method not found") ||
+			strings.Contains(err.Error(), "Method not found") {
+			return nil
+		}
+		return fmt.Errorf("calling sync_read_signal: %w", err)
+	}
+
+	var text string
+	for _, c := range result.Content {
+		if tc, ok := c.(mcp.TextContent); ok {
+			text = tc.Text
+			break
+		}
+	}
+
+	if result.IsError {
+		// Mode-gate refusals (e.g. subscribe peer refuses to serve):
+		// treat as a clean skip for this cycle. No data lost — we
+		// just don't get their usage this round.
+		return fmt.Errorf("peer sync_read_signal refused: %s", text)
+	}
+
+	if text == "" || text == "[]" {
+		return nil
+	}
+
+	const maxUsageResponseBytes = 16 * 1024 * 1024 // 16 MiB is plenty for 500 rows
+	if len(text) > maxUsageResponseBytes {
+		return fmt.Errorf("sync_read_signal response too large (%d bytes, max %d)", len(text), maxUsageResponseBytes)
+	}
+
+	var rows []TraceUsage
+	if err := json.Unmarshal([]byte(text), &rows); err != nil {
+		return fmt.Errorf("parsing sync_read_signal response: %w", err)
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+
+	if err := s.replayer.MergeRemoteUsage(rows); err != nil {
+		return fmt.Errorf("merging remote usage: %w", err)
+	}
+
+	// Advance the cursor to the last row's UpdatedAt. Rows are
+	// ordered ASC by UpdatedAt on the server side (see
+	// cortex.LocalUsageSince), so the tail element holds the
+	// max timestamp we've now seen from this peer.
+	newCursor := rows[len(rows)-1].UpdatedAt
+	if err := s.state.Set(PeerUsageCursorKey(peer.Name), newCursor); err != nil {
+		return fmt.Errorf("saving usage cursor: %w", err)
+	}
+	return nil
 }
 
 // classifyIdentityError maps errors returned from verifyPeerIdentity

--- a/internal/federation/syncer_test.go
+++ b/internal/federation/syncer_test.go
@@ -12,9 +12,10 @@ import (
 // optionally fails on a specific event ID. Used to drive replayBatch
 // without standing up a real cortex.
 type fakeReplayer struct {
-	failOn   string // ID of the event that should fail; "" means never fail
-	replayed []string
-	merged   []VClock
+	failOn       string // ID of the event that should fail; "" means never fail
+	replayed     []string
+	merged       []VClock
+	usageBatches [][]TraceUsage
 }
 
 func (f *fakeReplayer) ReplayEvent(e event.Event) error {
@@ -27,6 +28,11 @@ func (f *fakeReplayer) ReplayEvent(e event.Event) error {
 
 func (f *fakeReplayer) MergeClock(vc VClock) error {
 	f.merged = append(f.merged, vc)
+	return nil
+}
+
+func (f *fakeReplayer) MergeRemoteUsage(rows []TraceUsage) error {
+	f.usageBatches = append(f.usageBatches, rows)
 	return nil
 }
 

--- a/internal/federation/usage.go
+++ b/internal/federation/usage.go
@@ -1,0 +1,21 @@
+package federation
+
+// TraceUsage mirrors one row of the trace_usage table as exchanged
+// over the sync_read_signal MCP tool. It lives in the federation
+// package (not cortex) because the federation-side replayer interface
+// needs to name this type, and federation → cortex would be a
+// dependency cycle (cortex already imports federation).
+//
+// Read and modify counters are CRDT G-counters (grow-only, merged via
+// MAX). LastReadAt is CRDT LWW (merged via MAX over RFC3339 strings,
+// which sort correctly). UpdatedAt is the sync cursor — each peer
+// stamps its own local writes with an RFC3339 timestamp and callers
+// pull rows where UpdatedAt > since.
+type TraceUsage struct {
+	TraceID      string `json:"trace_id"`
+	PeerCortexID string `json:"peer_cortex_id"`
+	ReadCount    int    `json:"read_count"`
+	ModifyCount  int    `json:"modify_count"`
+	LastReadAt   string `json:"last_read_at,omitempty"`
+	UpdatedAt    string `json:"updated_at"`
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -603,6 +603,31 @@ func NewServer(cx *cortex.Cortex, noemaVersion string, federationMode string) *s
 		return mcp.NewToolResultText(string(data)), nil
 	})
 
+	s.AddTool(mcp.NewTool("sync_read_signal",
+		mcp.WithDescription("Returns per-peer tier-usage deltas (read_count, modify_count, last_read_at) for federation sync. Each peer publishes only its own rows — the ring aggregates by SUMing over every peer's contribution, so consolidation decisions operate on a federation-wide signal rather than the local slice. Returns a JSON array of trace_usage rows owned by this cortex with updated_at > since."),
+		mcp.WithString("since", mcp.Description("RFC3339 cursor — return only rows with updated_at > this value. Empty returns everything this peer owns.")),
+		mcp.WithNumber("limit", mcp.Description("Max rows to return (default 100, max 1000)")),
+	), func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		if federationMode == cortex.FederationModeSubscribe {
+			return mcp.NewToolResultError(
+				"this cortex is in subscribe mode and does not serve read signal"), nil
+		}
+		since := req.GetString("since", "")
+		limit := req.GetInt("limit", 100)
+		if limit <= 0 || limit > 1000 {
+			limit = 100
+		}
+		rows, err := cx.LocalUsageSince(since, limit)
+		if err != nil {
+			return nil, err
+		}
+		data, err := json.Marshal(rows)
+		if err != nil {
+			return nil, fmt.Errorf("marshaling usage rows: %w", err)
+		}
+		return mcp.NewToolResultText(string(data)), nil
+	})
+
 	s.AddTool(mcp.NewTool("federation_status",
 		mcp.WithDescription("Show federation configuration, peer sync state, and local vector clock."),
 	), func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -432,3 +432,28 @@ func TestSyncMode_AllowsEverything(t *testing.T) {
 		t.Errorf("sync_events should work in sync mode, got: %s", text)
 	}
 }
+
+func TestSubscribeMode_BlocksSyncReadSignal(t *testing.T) {
+	cx := newTestCortex(t)
+	s := NewServer(cx, "test", "subscribe")
+	initServer(t, s)
+
+	text, isErr := callTool(t, s, "sync_read_signal", nil)
+	if !isErr {
+		t.Errorf("sync_read_signal should be blocked in subscribe mode, got: %s", text)
+	}
+	if !strings.Contains(text, "subscribe mode") {
+		t.Errorf("error should mention subscribe mode, got: %s", text)
+	}
+}
+
+func TestPublishMode_AllowsSyncReadSignal(t *testing.T) {
+	cx := newTestCortex(t)
+	s := NewServer(cx, "test", "publish")
+	initServer(t, s)
+
+	text, isErr := callTool(t, s, "sync_read_signal", nil)
+	if isErr {
+		t.Errorf("sync_read_signal should be served in publish mode, got error: %s", text)
+	}
+}


### PR DESCRIPTION
## Summary

Completes the tier-usage federation work. PR A moved usage counters into the per-peer `trace_usage` table; this PR adds the cross-peer transport so the consolidator sees the full ring's attention instead of a local slice.

### Protocol

- **New MCP tool `sync_read_signal(since, limit)`** — returns rows from `trace_usage` where `peer_cortex_id = this peer's cortex_id AND updated_at > since`, ordered by `updated_at ASC` so callers use the tail row's `UpdatedAt` as the next cursor. A peer never re-broadcasts remote rows — bandwidth stays O(own writes), not O(ring × writes).
- **Syncer loop gains a second phase** — after `sync_events` completes for a peer (even on "no new events"), call `sync_read_signal` with the per-peer cursor from `federation_state:peer:<name>:last_usage`. Merge received rows with CRDT MAX semantics (`read_count` + `modify_count` grow-only, `last_read_at` LWW). Advance cursor on success.
- **Mode policy mirrors `sync_events`**:
  | Mode | Serves `sync_read_signal` | Polls others |
  |---|---|---|
  | `sync` | ✓ | ✓ |
  | `publish` | ✓ | ✗ |
  | `subscribe` | ✗ | ✓ |
  | `paused` | - | ✗ |

### Robustness

- **Pre-PR-B peers** (no `sync_read_signal` tool) return JSON-RPC `-32601`. Treated as clean no-op — the syncer logs, skips, continues. Events flow unaffected. Once the ring fully upgrades, usage sync activates on the next cycle with no coordination.
- **Usage-phase failures don't fail the overall cycle** — events already succeeded, the usage cursor stays put, next cycle retries. Event and usage streams advance independently.
- **16 MiB response cap** (vs 100 MiB for events) — 500 rows × 32 KiB/row is plenty even for chatty rings.
- **`MergeRemoteUsage` self-guard** — defensively skips rows claiming `peer_cortex_id = local cortex's ID` so a malicious or buggy peer can't rewrite local counters.

### Tests

- `TestLocalUsageSince_FiltersToLocalPeerOnly` — publish contract (remote rows never leak out of this peer)
- `TestLocalUsageSince_CursorAdvancesMonotonically` — ASC ordering + mid-cursor resumption
- `TestMergeRemoteUsage_RefusesLocalIDAttribution` — self-guard
- `TestMergeRemoteUsage_MaxMergeOnRepeat` — CRDT regression-delivery resilience
- `TestSubscribeMode_BlocksSyncReadSignal` + `TestPublishMode_AllowsSyncReadSignal` — mode-gate symmetry with `sync_events`
- `fakeReplayer` in `syncer_test` gains `MergeRemoteUsage` so existing syncer tests compile against the broader `EventReplayer` interface

### Architecture note

`TraceUsage` as a type lives in `internal/federation/usage.go` rather than `internal/cortex/`. Reason: the `EventReplayer` interface (federation-owned) needs to name the type, and `federation → cortex` would be a dependency cycle (cortex already imports federation). Both `cortex.LocalUsageSince` and `cortex.MergeRemoteUsage` reference `federation.TraceUsage`. The MCP server marshals it to JSON over the wire.

### What's deferred

- **`noema memory status` and doctor** surfacing federation-wide usage numbers — trivial follow-up once operators want it.
- **Dropping the legacy `traces.{read_count,modify_count,last_read_at}` columns** — safe now that they haven't been written since PR A landed, but a dedicated cleanup migration deserves its own PR.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` full suite green
- [x] 6 new tests across cortex (usage helpers) and mcp (mode gates)
- [x] Existing syncer tests pass against the widened `EventReplayer` interface
- [ ] Spot-check on a real federated cortex (agentbrain ring): deploy the binary to all peers, observe that `trace_usage` on the Mac peer starts to populate rows with `peer_cortex_id` values from ai-1 / ai-2 / ai-3 within one `federation.interval`

🤖 Generated with [Claude Code](https://claude.com/claude-code)