### PR TITLE
feat(tui): surface tier, vote count, and +/- keybind in detail pane

### DIFF
--- a/internal/cortex/tier.go
+++ b/internal/cortex/tier.go
@@ -64,6 +64,16 @@ func (c *Cortex) Demote(id, newTier string) error {
 // tier='long' rows while still blocking content and identity fields.
 // Votes on long-term are a meaningful signal that a base-truth memory
 // is still being referenced.
+// TierVotes returns the current tier_votes count for a trace. Surfaced
+// to UIs (TUI detail pane, future CLI `noema memory votes`) so users
+// voting on a trace can see their vote's effect. A missing trace
+// returns sql.ErrNoRows.
+func (c *Cortex) TierVotes(id string) (int, error) {
+	var votes int
+	err := c.DB.QueryRow(`SELECT tier_votes FROM traces WHERE id = ?`, id).Scan(&votes)
+	return votes, err
+}
+
 func (c *Cortex) Vote(id string, delta int, actor ReadActor) error {
 	if delta != 1 && delta != -1 {
 		return fmt.Errorf("vote delta must be +1 or -1, got %d", delta)

--- a/internal/cortex/tier_test.go
+++ b/internal/cortex/tier_test.go
@@ -119,3 +119,46 @@ func TestUpdate_PreservesDBTierAgainstFileDrift(t *testing.T) {
 		t.Errorf("file tier after drifted update = %q, want %q", after.Tier, trace.TierShort)
 	}
 }
+
+// TestTierVotes_ReflectsVoteHistory pins the read path for the TUI's
+// detail-pane vote counter: TierVotes returns the accumulated
+// +1/-1 deltas applied via Vote(). Missing traces surface the
+// underlying sql.ErrNoRows so callers can distinguish "0 votes" from
+// "id doesn't exist."
+func TestTierVotes_ReflectsVoteHistory(t *testing.T) {
+	cx := setup(t)
+	tr := trace.New("vote fixture", "note", "", nil, "body")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	// Fresh trace starts at zero.
+	v, err := cx.TierVotes(tr.ID)
+	if err != nil {
+		t.Fatalf("TierVotes (fresh): %v", err)
+	}
+	if v != 0 {
+		t.Errorf("fresh trace votes = %d, want 0", v)
+	}
+
+	// Two upvotes, one downvote — net +1.
+	for _, d := range []int{1, 1, -1} {
+		if err := cx.Vote(tr.ID, d, cortex.ActorHuman); err != nil {
+			t.Fatalf("Vote(%d): %v", d, err)
+		}
+	}
+	v, err = cx.TierVotes(tr.ID)
+	if err != nil {
+		t.Fatalf("TierVotes (after votes): %v", err)
+	}
+	if v != 1 {
+		t.Errorf("votes after +1+1-1 = %d, want 1", v)
+	}
+
+	// Missing trace returns a non-nil error — TUI callers currently
+	// treat any error as "0" (the detail pane blanks in that case),
+	// but the contract is important for future callers.
+	if _, err := cx.TierVotes("does-not-exist"); err == nil {
+		t.Error("TierVotes on missing id should return an error, got nil")
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -379,10 +379,11 @@ type confirmAction struct {
 }
 
 type model struct {
-	cx          *cortex.Cortex
-	rows        []cortex.Row
-	cursor      int
-	current     *trace.Trace // cached detail for selected row
+	cx           *cortex.Cortex
+	rows         []cortex.Row
+	cursor       int
+	current      *trace.Trace // cached detail for selected row
+	currentVotes int          // tier_votes for m.current, refreshed whenever m.current reloads
 	width       int
 	height      int
 	state       viewState
@@ -1022,6 +1023,7 @@ func (m model) handleRowsLoaded(newRows []cortex.Row) model {
 	m.lastQuery = m.searchQuery
 
 	m.current = m.loadCurrent()
+	m.currentVotes = m.loadCurrentVotes()
 
 	// If the refresh landed on a different trace (sticky-cursor
 	// failed because the row was archived/deleted, or context
@@ -1051,6 +1053,21 @@ func (m model) loadCurrent() *trace.Trace {
 	}
 	t, _ := trace.ParseFile(path)
 	return t
+}
+
+// loadCurrentVotes returns the tier_votes count for the row under the
+// cursor. Renders "0" for an empty list or a row that can't be
+// resolved — the detail pane is blanked in those cases anyway, so the
+// value isn't displayed.
+func (m model) loadCurrentVotes() int {
+	if len(m.rows) == 0 {
+		return 0
+	}
+	votes, err := m.cx.TierVotes(m.rows[m.cursor].ID)
+	if err != nil {
+		return 0
+	}
+	return votes
 }
 
 // paneWidths returns the widths of the list pane and the detail pane
@@ -1162,6 +1179,7 @@ func (m model) selectCursor(idx int) model {
 	}
 	m.cursor = idx
 	m.current = m.loadCurrent()
+	m.currentVotes = m.loadCurrentVotes()
 	var newID string
 	if m.current != nil {
 		newID = m.current.ID
@@ -1382,6 +1400,15 @@ func (m model) renderDetail(width, height int) string {
 	lines = append(lines, metaLine("id", t.ID))
 	lines = append(lines, metaLine("title", t.Title))
 	lines = append(lines, chipLine("type", t.Type))
+	// Tier + current vote count. Surfaced together so a user casting a
+	// +/- vote can see both the tier they're influencing and the count
+	// they're incrementing. Tier defaults to "short" when the field is
+	// omitted from frontmatter (matches DB default).
+	tier := t.Tier
+	if tier == "" {
+		tier = "short"
+	}
+	lines = append(lines, metaLine("tier", fmt.Sprintf("%s  (votes: %+d)", tier, m.currentVotes)))
 	if t.Author != "" {
 		lines = append(lines, metaLine("author", t.Author))
 	}
@@ -1502,7 +1529,7 @@ func (m model) renderFooter() string {
 		case m.showTrashed:
 			hint = "j/k:nav  r:recover  D:purge  t:back  /:search  →/tab:body  f:live  R:refresh  q:quit"
 		default:
-			hint = "j/k:nav  n:new  e:edit  d:archive  u:unarchive  D:trash  t:trash-view  a:all  /:search  →/tab:body  f:live  R:refresh  q:quit"
+			hint = "j/k:nav  n:new  e:edit  +/-:vote  d:archive  u:unarchive  D:trash  t:trash-view  a:all  /:search  →/tab:body  f:live  R:refresh  q:quit"
 		}
 		if m.focus == focusList && m.searchQuery != "" {
 			hint = "esc:clear  " + hint


### PR DESCRIPTION
## Summary

The tier-vote feature (PR #42) wired `+`/`=` and `-` keys to `cortex.Vote(..., ActorHuman)` but didn't make it discoverable through the TUI. A user who hadn't read the source couldn't learn the feature existed, and even if they knew the keys, they had no visual feedback on the current tier or vote count — just a transient `▲`/`▼` status message after a successful vote.

## Changes

### 1. Footer hint mentions `+/-:vote`

\`\`\`diff
- j/k:nav  n:new  e:edit  d:archive  u:unarchive  D:trash  …
+ j/k:nav  n:new  e:edit  +/-:vote  d:archive  u:unarchive  D:trash  …
\`\`\`

### 2. Detail pane shows tier + vote count

A new metadata row rendered between \`type\` and \`author\`:

\`\`\`
  id:     20260421-dadbot-architecture-personality-and-troubleshooting-protocols
  title:  DadBot Architecture, Personality, and Troubleshooting Protocols
  type:   [observation]
  tier:   mid  (votes: +3)
  author: dadbot
  tags:   [dadbot] [autonomous] …
  created: 2026-04-21
\`\`\`

Signed integer formatting (\`%+d\`) so \`-2\` reads cleanly as \`(votes: -2)\` without ambiguity.

### 3. New \`cortex.TierVotes(id) (int, error)\` helper

One-line SELECT against the \`traces\` table. Keeps the diff scoped — didn't expand the broader \`Row\` struct, which would have touched \`List\`/\`Search\`/\`Get\` queries. Future CLIs like \`noema memory votes\` can consume the same helper.

### 4. Model cache

\`model.currentVotes\` caches the vote count alongside \`m.current\`. Refreshed at the same two sites that reload \`m.current\` (\`selectCursor\` and the list reload path), so scrolling keeps both in sync with the highlighted trace.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./...\` full suite green
- [x] New \`TestTierVotes_ReflectsVoteHistory\` pins: fresh trace at 0, +1+1-1 nets to +1, missing id returns non-nil error
- [ ] Spot-check in the TUI: \`noema tui\`, highlight any trace, cast +/- votes, confirm the vote count updates in the detail pane on each keypress

🤖 Generated with [Claude Code](https://claude.com/claude-code)