### PR TITLE
feat(tui): session-toggle voting so +/- follows Reddit-style cycle

### DIFF
--- a/internal/cortex/promote_test.go
+++ b/internal/cortex/promote_test.go
@@ -210,13 +210,39 @@ func TestVote_AccumulatesBothDirections(t *testing.T) {
 func TestVote_RejectsBadDelta(t *testing.T) {
 	cx := setup(t)
 	id := seed(t, cx, "bad delta", trace.TierShort)
-	for _, bad := range []int{0, 2, -2, 10} {
+	// ±1 and ±2 are valid (±2 supports the TUI session-toggle flip
+	// case: going from -1 intent to +1 intent in one keypress). 0
+	// and anything beyond ±2 is rejected so the signal can't be
+	// amplified arbitrarily.
+	for _, bad := range []int{0, 3, -3, 10} {
 		if err := cx.Vote(id, bad, cortex.ActorAgent); err == nil {
 			t.Errorf("Vote with delta %d should have failed", bad)
 		}
 	}
 	if got := voteSumOf(t, cx, id); got != 0 {
 		t.Errorf("tier_votes polluted by rejected votes = %d, want 0", got)
+	}
+}
+
+func TestVote_AcceptsFlipDelta(t *testing.T) {
+	cx := setup(t)
+	id := seed(t, cx, "flip delta", trace.TierShort)
+	// -2 flips a -1 intent straight to +1 (or a +1 to -1) in the
+	// TUI session-toggle handler. The DB accumulator just adds.
+	if err := cx.Vote(id, -1, cortex.ActorHuman); err != nil {
+		t.Fatalf("Vote -1: %v", err)
+	}
+	if err := cx.Vote(id, 2, cortex.ActorHuman); err != nil {
+		t.Fatalf("Vote +2 (flip): %v", err)
+	}
+	if got := voteSumOf(t, cx, id); got != 1 {
+		t.Errorf("tier_votes after -1 then +2 = %d, want 1", got)
+	}
+	if err := cx.Vote(id, -2, cortex.ActorHuman); err != nil {
+		t.Fatalf("Vote -2 (flip): %v", err)
+	}
+	if got := voteSumOf(t, cx, id); got != -1 {
+		t.Errorf("tier_votes after flip back = %d, want -1", got)
 	}
 }
 

--- a/internal/cortex/tier.go
+++ b/internal/cortex/tier.go
@@ -75,8 +75,13 @@ func (c *Cortex) TierVotes(id string) (int, error) {
 }
 
 func (c *Cortex) Vote(id string, delta int, actor ReadActor) error {
-	if delta != 1 && delta != -1 {
-		return fmt.Errorf("vote delta must be +1 or -1, got %d", delta)
+	// Allow ±1 for a fresh vote and ±2 for a flip (user was at -1 in a
+	// session-toggle UI, pressing the opposite key swings straight to
+	// +1 — one event log entry instead of two). Anything outside that
+	// range is either a bug or an attempt to amplify the signal, which
+	// is what the refactor to session-toggle was meant to prevent.
+	if delta == 0 || delta < -2 || delta > 2 {
+		return fmt.Errorf("vote delta must be ±1 or ±2, got %d", delta)
 	}
 	if actor == ActorSystem {
 		return fmt.Errorf("system actor cannot cast tier-preference votes")

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -384,6 +384,14 @@ type model struct {
 	cursor       int
 	current      *trace.Trace // cached detail for selected row
 	currentVotes int          // tier_votes for m.current, refreshed whenever m.current reloads
+
+	// sessionVotes tracks this session's vote intent per trace ID: -1,
+	// 0, or +1. The DB column tier_votes is an accumulator that any
+	// actor can contribute to; this map is the TUI's local "what have
+	// I cast in this session" so a single user can't pile up +6 by
+	// holding the + key. Reddit-style three-state cycle: + on a fresh
+	// trace → +1; + again → 0 (clears); + when at -1 → +1 (flip).
+	sessionVotes map[string]int
 	width       int
 	height      int
 	state       viewState
@@ -437,6 +445,7 @@ func initialModel(cx *cortex.Cortex) model {
 		search:       ti,
 		state:        stateList,
 		newRowTTL:    map[string]int{},
+		sessionVotes: map[string]int{},
 		visibleShort: true,
 		visibleMid:   true,
 		visibleLong:  false,
@@ -794,28 +803,22 @@ func (m model) updateList(msg tea.KeyMsg) (model, tea.Cmd) {
 	case "+", "=":
 		// Accept "=" too so users on layouts where "+" requires Shift
 		// can upvote without the modifier. "-" is unambiguous.
+		//
+		// Three-state cycle per trace per TUI session:
+		//   0 → +1   (cast upvote)
+		//  +1 → 0    (clear my upvote — same key cycles off)
+		//  -1 → +1   (flip downvote to upvote)
+		// sessionVotes tracks the intent; the DB delta is new - prev.
 		if len(m.rows) == 0 {
 			return m, nil
 		}
-		row := m.rows[m.cursor]
-		if err := m.cx.Vote(row.ID, 1, cortex.ActorHuman); err != nil {
-			m.err = err
-			return m, nil
-		}
-		m.status = "▲ " + row.ID
-		return m, m.reload()
+		return m.castVote(m.rows[m.cursor].ID, +1, "▲", "cleared ▲ on")
 
 	case "-":
 		if len(m.rows) == 0 {
 			return m, nil
 		}
-		row := m.rows[m.cursor]
-		if err := m.cx.Vote(row.ID, -1, cortex.ActorHuman); err != nil {
-			m.err = err
-			return m, nil
-		}
-		m.status = "▼ " + row.ID
-		return m, m.reload()
+		return m.castVote(m.rows[m.cursor].ID, -1, "▼", "cleared ▼ on")
 
 	case "/":
 		m.state = stateSearch
@@ -1068,6 +1071,46 @@ func (m model) loadCurrentVotes() int {
 		return 0
 	}
 	return votes
+}
+
+// castVote applies the session-toggle cycle for a ±1 keypress. target
+// is the caller's desired direction (+1 for '+'/'=', -1 for '-').
+// The new session intent is:
+//
+//	prev == target → 0        (same key twice clears the vote)
+//	prev == 0      → target   (fresh cast)
+//	prev == -target → target  (flip)
+//
+// The DB delta sent to cx.Vote is (newIntent - prev) and falls in
+// {-2, -1, 0, 1, 2}. Zero is a no-op (shouldn't happen with the logic
+// above but defended for safety). Any non-zero value hits the
+// accumulator and emits one ActionVote event per keypress.
+//
+// castKind / clearKind are the status-line glyphs shown after the
+// cast depending on whether this was a set or a clear.
+func (m model) castVote(traceID string, target int, castKind, clearKind string) (model, tea.Cmd) {
+	prev := m.sessionVotes[traceID]
+	var newIntent int
+	if prev == target {
+		newIntent = 0
+	} else {
+		newIntent = target
+	}
+	delta := newIntent - prev
+	if delta == 0 {
+		return m, nil
+	}
+	if err := m.cx.Vote(traceID, delta, cortex.ActorHuman); err != nil {
+		m.err = err
+		return m, nil
+	}
+	m.sessionVotes[traceID] = newIntent
+	if newIntent == 0 {
+		m.status = clearKind + " " + traceID
+	} else {
+		m.status = castKind + " " + traceID
+	}
+	return m, m.reload()
 }
 
 // paneWidths returns the widths of the list pane and the detail pane

--- a/internal/watch/atomic_save_test.go
+++ b/internal/watch/atomic_save_test.go
@@ -38,11 +38,27 @@ func TestAtomicSaveDoesNotTrash(t *testing.T) {
 	}
 	time.Sleep(settleTime)
 
+	// autoOnboard uses today's UTC date when generating the new ID.
+	// Hardcoding the date prefix (e.g. "20260423") made this test
+	// flake past midnight UTC and break CI runs in UTC-late hours.
+	// Discover the rescued filename from the active traces dir
+	// instead so the test stays date-agnostic.
+	rescued := ""
+	entries, _ := os.ReadDir(cx.TracesDir())
+	for _, e := range entries {
+		if !e.IsDir() && strings.HasSuffix(e.Name(), "-untitled.md") {
+			rescued = filepath.Join(cx.TracesDir(), e.Name())
+			break
+		}
+	}
+	if rescued == "" {
+		t.Fatalf("autoOnboard didn't produce a *-untitled.md file in %s", cx.TracesDir())
+	}
+
 	// Obsidian's tab now points at the renamed file. Subsequent saves
 	// use macOS's "atomic replace" pattern: remove + recreate. The
 	// watcher must treat that gap as a transient save artifact, not
 	// an external delete.
-	rescued := filepath.Join(cx.TracesDir(), "20260423-untitled.md")
 	if err := os.Remove(rescued); err != nil {
 		t.Fatalf("Remove (atomic-save phase 1): %v", err)
 	}
@@ -61,13 +77,14 @@ func TestAtomicSaveDoesNotTrash(t *testing.T) {
 	}
 
 	// Assertion 2: DB row for the rescued trace stays active (no
-	// trashed_at stamp).
+	// trashed_at stamp). Match against the dynamically-discovered ID.
+	rescuedID := strings.TrimSuffix(filepath.Base(rescued), ".md")
 	rows, err := cx.List(cortex.ListOptions{All: true})
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
 	for _, r := range rows {
-		if r.ID == "20260423-untitled" && r.TrashedAt != "" {
+		if r.ID == rescuedID && r.TrashedAt != "" {
 			t.Errorf("trace %s has trashed_at=%q after atomic save; expected empty",
 				r.ID, r.TrashedAt)
 		}


### PR DESCRIPTION
## Summary

Fixes the issue Mark hit in [PR #48](https://github.com/Fail-Safe/Noema/pull/48): the TUI let a single user press \`+\` six times and land on a \`+6\` vote, when the feature was pitched as a \`-1 / 0 / +1\` thing. Three-state semantics now enforced via an in-memory session map.

## The cycle

Each trace has a per-session intent starting at 0 (even if the DB already has accumulated votes from prior sessions or other actors). The keypress transitions are:

| Prior intent | Press \`+\` (or \`=\`) | Press \`-\` |
|:---:|:---:|:---:|
| 0  | +1 (cast)    | −1 (cast)   |
| +1 | 0 (cleared)  | −1 (flip)   |
| −1 | +1 (flip)    | 0 (cleared) |

DB delta = \`newIntent − prevIntent\`. The column \`tier_votes\` stays a pure accumulator — multiple actors can still contribute — but one user in one TUI session can't stack more than ±1.

## Protocol tweak

\`cortex.Vote\` previously rejected anything outside ±1. Now accepts ±1 or ±2 so the flip case (\`-1 → +1\` or \`+1 → -1\`) is a single DB update + single \`ActionVote\` event instead of two. Anything outside ±2 is still rejected.

- \`TestVote_RejectsBadDelta\` updated: \`±2\` moved from the reject list to acceptable.
- New \`TestVote_AcceptsFlipDelta\` pins the ±2 contract end-to-end.

## UX details

- Status line now distinguishes cast vs clear: \`▲ <id>\` / \`▼ <id>\` for a cast, \`cleared ▲ on <id>\` / \`cleared ▼ on <id>\` for a toggle-off.
- The detail pane's \`votes: +N\` display (from PR #48) updates live with the cycle, so the cycle's phases are visible.
- No schema changes. Scope intentionally session-only — persistent per-actor vote state would be a \`trace_votes(trace_id, actor, vote)\` table, deferred until there's real demand for "who voted what" querying.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./...\` full suite green
- [x] \`TestVote_RejectsBadDelta\` updated; \`TestVote_AcceptsFlipDelta\` added
- [ ] Spot-check in the TUI: on a fresh trace, press \`+\` once → \`votes: +1\`, again → \`votes: 0\`, again → \`votes: +1\`; press \`-\` → \`votes: -1\` (one step, flip confirmed); repeat \`-\` → \`votes: 0\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)