### PR TITLE
fix(tui): drop the + sign when tier_votes is zero

### DIFF
--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1058,6 +1058,21 @@ func (m model) loadCurrent() *trace.Trace {
 	return t
 }
 
+// formatVotes renders the tier_votes count for the detail pane. Zero
+// is shown bare ("0") rather than "+0" — the signed format %+d stamps
+// a sign on every number including zero, which looks wrong. Positive
+// counts get an explicit + so the sign is always legible at a glance.
+func formatVotes(n int) string {
+	switch {
+	case n > 0:
+		return fmt.Sprintf("+%d", n)
+	case n < 0:
+		return fmt.Sprintf("%d", n) // negative values already carry the sign
+	default:
+		return "0"
+	}
+}
+
 // loadCurrentVotes returns the tier_votes count for the row under the
 // cursor. Renders "0" for an empty list or a row that can't be
 // resolved — the detail pane is blanked in those cases anyway, so the
@@ -1451,7 +1466,7 @@ func (m model) renderDetail(width, height int) string {
 	if tier == "" {
 		tier = "short"
 	}
-	lines = append(lines, metaLine("tier", fmt.Sprintf("%s  (votes: %+d)", tier, m.currentVotes)))
+	lines = append(lines, metaLine("tier", fmt.Sprintf("%s  (votes: %s)", tier, formatVotes(m.currentVotes))))
 	if t.Author != "" {
 		lines = append(lines, metaLine("author", t.Author))
 	}

--- a/internal/tui/tui_tier_test.go
+++ b/internal/tui/tui_tier_test.go
@@ -90,3 +90,27 @@ func TestTierBadge(t *testing.T) {
 		}
 	}
 }
+
+// TestFormatVotes pins the three-state display contract for the
+// tier-votes detail-pane line. Zero renders bare rather than as
+// "+0" (the unsigned zero looks wrong, and was an early iteration
+// bug that confused users into thinking they'd voted). Positive
+// values carry an explicit "+" so the sign is always legible at a
+// glance next to the tier name.
+func TestFormatVotes(t *testing.T) {
+	cases := []struct {
+		n    int
+		want string
+	}{
+		{0, "0"},
+		{1, "+1"},
+		{7, "+7"},
+		{-1, "-1"},
+		{-3, "-3"},
+	}
+	for _, tc := range cases {
+		if got := formatVotes(tc.n); got != tc.want {
+			t.Errorf("formatVotes(%d) = %q, want %q", tc.n, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Tiny follow-up to #48 / #49. A fresh trace was rendering `(votes: +0)` because `%+d` stamps a sign on every integer including zero, which looks wrong. Replace with a three-case helper: `0` / `+N` / `-N`. `TestFormatVotes` pins it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)