### PR TITLE
fix(tui): restore list-pane dim by stripping tier-glyph ANSI under dim

### DIFF
--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -470,13 +470,21 @@ func tierBadge(tier string) string {
 }
 
 // renderTierGlyph returns the tier badge pre-styled with its heat-chart
-// color (warm orange → amber → cool blue for short → mid → long). The
-// result embeds ANSI escape sequences; the outer row style re-paints
-// the background around them but leaves the inner foreground intact.
-// Unknown tiers render without color to keep the "?" reading as a
-// migration-anomaly signal rather than a fourth tier.
-func renderTierGlyph(tier string) string {
+// color (warm orange → amber → cool blue for short → mid → long) when
+// the pane is in focus. When dim=true (list acting as backdrop while
+// the detail pane has focus), the glyph renders as a plain character
+// so the outer styleRowDim can apply uniform dimming across the whole
+// row — the heat-chart ANSI embeds a reset that would otherwise
+// terminate the outer dim mid-line, leaving the title/badge/date
+// rendered at default terminal color.
+//
+// Unknown tiers render without color in both states to keep the "?"
+// reading as a migration-anomaly signal rather than a fourth tier.
+func renderTierGlyph(tier string, dim bool) string {
 	glyph := tierBadge(tier)
+	if dim {
+		return glyph
+	}
 	switch tier {
 	case trace.TierShort:
 		return styleTierShort.Render(glyph)
@@ -1343,7 +1351,12 @@ func (m model) renderList(width, height int) string {
 		// badge is at most 14 chars (longest type: "observation"=11 + 2 = 13)
 		badgeW := 14
 		dateW := 10
-		tierGlyph := renderTierGlyph(r.Tier)
+		// When the detail pane has focus, the list acts as a dim
+		// backdrop — pass that through so the tier glyph skips its
+		// heat-chart ANSI (whose embedded reset would otherwise
+		// terminate the outer dim style mid-line).
+		dim := m.focus == focusDetail
+		tierGlyph := renderTierGlyph(r.Tier, dim)
 		// 1 cursor + 1 space + tier(1) + 1 space + title + 1 space +
 		// badge(14) + 1 space + date(10)
 		titleW := width - 2 - 2 - badgeW - 1 - dateW - 1
@@ -1380,12 +1393,13 @@ func (m model) renderList(width, height int) string {
 			date,
 		)
 
-		// When the detail pane owns focus, every row in the list is
-		// rendered through a dim palette — the entire pane fades like
-		// a modal backdrop, not just the selected row. The cursor row
-		// still sits one brightness step above the rest so the
-		// selection is findable at a glance when tabbing back.
-		dim := m.focus == focusDetail
+		// dim was computed above (alongside tierGlyph) so the tier
+		// glyph could opt out of its heat-chart ANSI when the pane
+		// is a backdrop; now it gates the row styles too. The entire
+		// pane fades like a modal backdrop, not just the selected
+		// row — the cursor row still sits one brightness step above
+		// the rest so the selection is findable at a glance when
+		// tabbing back.
 		switch {
 		case i == m.cursor:
 			if dim {

--- a/internal/tui/tui_tier_test.go
+++ b/internal/tui/tui_tier_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -112,5 +113,37 @@ func TestFormatVotes(t *testing.T) {
 		if got := formatVotes(tc.n); got != tc.want {
 			t.Errorf("formatVotes(%d) = %q, want %q", tc.n, got, tc.want)
 		}
+	}
+}
+
+// TestRenderTierGlyph_DimDropsANSI pins the pane-dim-backdrop
+// interaction. When the list pane is acting as a dim backdrop (the
+// detail pane owns focus), the tier glyph must render as a plain
+// character without any embedded ANSI color — otherwise the heat-
+// chart styling's reset terminates the outer styleRowDim mid-line
+// and everything after the glyph (title, badge, date) fails to dim.
+// This test pins that contract so a future "let's always colorize the
+// tier glyph" refactor has to reckon with the dim case.
+func TestRenderTierGlyph_DimDropsANSI(t *testing.T) {
+	loadPalette("dark")
+
+	cases := []struct {
+		tier string
+	}{{"short"}, {"mid"}, {"long"}}
+
+	for _, tc := range cases {
+		t.Run(tc.tier, func(t *testing.T) {
+			// Non-dim: ANSI color present so the heat chart reads.
+			colored := renderTierGlyph(tc.tier, false)
+			if !strings.Contains(colored, "\x1b[") {
+				t.Errorf("renderTierGlyph(%q, false) should embed ANSI, got %q", tc.tier, colored)
+			}
+			// Dim: must be a plain character so outer dim style can
+			// wrap the whole row uniformly.
+			plain := renderTierGlyph(tc.tier, true)
+			if strings.Contains(plain, "\x1b[") {
+				t.Errorf("renderTierGlyph(%q, true) leaked ANSI, got %q — outer dim will break at the glyph", tc.tier, plain)
+			}
+		})
 	}
 }


### PR DESCRIPTION
The list pane's dim-backdrop treatment (when the detail pane has focus) has been silently broken since the heat-chart tier glyphs landed in `3d6a65a`. The pre-styled tier glyph embedded an ANSI reset mid-row, terminating the outer `styleRowDim` — everything after the glyph kept default terminal color.

Fix: `renderTierGlyph(tier, dim bool)`. When `dim=true`, return the plain character without ANSI so the outer dim style covers the whole row uniformly.

Regression test `TestRenderTierGlyph_DimDropsANSI` pins the contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)