### PR TITLE
feat(release): add parallel noema-beta homebrew formula

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -194,6 +194,39 @@ brews:
     install: |
       bin.install "noema"
 
+  # Beta channel: a parallel formula that publishes ONLY on prerelease
+  # tags (v*-beta*, v*-rc*, v*-alpha*). Inverts the stable formula's
+  # skip_upload rule — stable uploads when !Prerelease, beta uploads
+  # when Prerelease. Install with:
+  #
+  #   brew install Fail-Safe/tap/noema-beta
+  #
+  # Declares `conflicts_with "noema"` so users can only have one channel
+  # installed at a time — brew surfaces a clear message if they try to
+  # install both, and `brew upgrade` on the beta picks up each new
+  # prerelease automatically.
+  - name: noema-beta
+    repository:
+      owner: Fail-Safe
+      name: homebrew-tap
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    directory: Formula
+    homepage: "https://github.com/Fail-Safe/Noema"
+    description: "The intentional memory layer for your AI agents (beta channel)"
+    license: "MIT"
+    skip_upload: "{{ if .Prerelease }}false{{ else }}true{{ end }}"
+    commit_author:
+      name: goreleaserbot
+      email: bot@goreleaser.com
+    commit_msg_template: "brews: update {{ .ProjectName }}-beta to {{ .Tag }}"
+    conflicts:
+      - noema
+    test: |
+      system "#{bin}/noema", "version"
+    install: |
+      bin.install "noema"
+
 homebrew_casks:
   - name: noema
     binaries:

--- a/README.md
+++ b/README.md
@@ -81,6 +81,28 @@ brew install noema          # formula (macOS + Linux)
 brew install --cask noema   # cask (macOS only)
 ```
 
+#### Beta channel
+
+Prerelease builds (`v*-beta*`, `v*-rc*`, `v*-alpha*`) publish to a
+parallel formula so you can track the edge without the stable channel
+moving under you:
+
+```bash
+brew install Fail-Safe/tap/noema-beta
+```
+
+`noema-beta` installs the same `noema` binary and conflicts with the
+stable formula — Homebrew will refuse to install both at once. To
+switch channels:
+
+```bash
+brew uninstall noema      # (or noema-beta)
+brew install Fail-Safe/tap/noema-beta   # (or noema)
+```
+
+`brew upgrade` on `noema-beta` pulls the newest prerelease; stable tags
+(`v0.10.0` vs `v0.10.0-beta.1`) stay on their respective channels.
+
 ### Download a pre-built binary
 
 Grab the archive for your OS/arch from the


### PR DESCRIPTION
## Summary
- Adds a second `brews:` entry `noema-beta` that templates `skip_upload` to upload **only** on prerelease tags (`v*-beta*`, `v*-rc*`, `v*-alpha*`) — inverse of the stable formula
- Declares `conflicts_with "noema"` so users can track exactly one channel at a time, with a clear brew-surfaced error if they try to install both
- Adds a README "Beta channel" subsection under the Homebrew instructions with install/switch recipes
- No changes to stable formula, cask, or other release artifacts — additive only

After merge + the next prerelease tag (`v0.10.0-beta.2` or later), users can pull the beta with:

```
brew install Fail-Safe/tap/noema-beta
```

## Test plan
- [x] `goreleaser check` validates the config
- [ ] Next prerelease tag publishes the `noema-beta` formula to `Fail-Safe/homebrew-tap`
- [ ] `brew install Fail-Safe/tap/noema-beta` pulls the latest prerelease
- [ ] Next stable tag publishes only `noema` formula (not `noema-beta`)
- [ ] Installing both at once surfaces brew's conflict error

🤖 Generated with [Claude Code](https://claude.com/claude-code)