### PR TITLE
fix(mcp): surface trace tier in list_traces, search_traces, and get_trace

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -99,8 +99,8 @@ func NewServer(cx *cortex.Cortex, noemaVersion string, federationMode string) *s
 		if err != nil {
 			return nil, err
 		}
-		out := fmt.Sprintf("ID: %s\nTitle: %s\nType: %s\nAuthor: %s\nTags: %s\nCreated: %s\nUpdated: %s",
-			row.ID, row.Title, row.Type, row.Author,
+		out := fmt.Sprintf("ID: %s\nTitle: %s\nType: %s\nTier: %s\nAuthor: %s\nTags: %s\nCreated: %s\nUpdated: %s",
+			row.ID, row.Title, row.Type, row.Tier, row.Author,
 			strings.Join(row.Tags, ", "),
 			row.CreatedAt, row.UpdatedAt,
 		)
@@ -1015,6 +1015,9 @@ federation events. source_hash records the origin's content_hash at publish time
 consumers can detect drift.
 
 get_trace shows Source Locked, Source Hash, and Content Hash fields when present.
+Both list_traces and search_traces prefix each row with a tier glyph (s=short,
+m=mid, L=long) so you can see the tier without a second lookup. get_trace surfaces
+the full tier name on a dedicated "Tier:" line in the metadata block.
 
 ## External Filesystem Edits
 Whenever noema serve is running (stdio OR http), a background watcher
@@ -1063,7 +1066,7 @@ func formatRows(rows []cortex.Row) string {
 		if r.Type == string(trace.TypeDivergence) {
 			typeLabel = "DIVERGENCE"
 		}
-		sb.WriteString(fmt.Sprintf("[%s] %s (%s)", typeLabel, r.ID, r.CreatedAt[:10]))
+		sb.WriteString(fmt.Sprintf("[%s] [%s] %s (%s)", tierGlyph(r.Tier), typeLabel, r.ID, r.CreatedAt[:10]))
 		if r.Author != "" {
 			sb.WriteString(fmt.Sprintf(" — %s", r.Author))
 		}
@@ -1074,4 +1077,22 @@ func formatRows(rows []cortex.Row) string {
 		sb.WriteString(fmt.Sprintf("  %s\n", r.Title))
 	}
 	return sb.String()
+}
+
+// tierGlyph returns the one-letter tier indicator used in MCP list/search
+// output, matching the TUI convention (lowercase for short/mid,
+// uppercase L for long to make long-term traces easy to spot). Unknown
+// tiers render as "?" so a missing tier column surfaces visibly rather
+// than blending in.
+func tierGlyph(tier string) string {
+	switch tier {
+	case trace.TierShort:
+		return "s"
+	case trace.TierMid:
+		return "m"
+	case trace.TierLong:
+		return "L"
+	default:
+		return "?"
+	}
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -11,7 +11,70 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 
 	"github.com/Fail-Safe/Noema/internal/cortex"
+	"github.com/Fail-Safe/Noema/internal/trace"
 )
+
+// --------- tier visibility in MCP output ---------
+//
+// Pins the contract that list_traces / search_traces / get_trace must
+// expose the tier of every trace to MCP consumers. Agents reason about
+// immutability and curation based on tier; the TUI and CLI both surface
+// it, so MCP parity is required. A regression here would make agents
+// tier-blind again.
+
+func TestFormatRows_IncludesTierGlyph(t *testing.T) {
+	rows := []cortex.Row{
+		{ID: "20260424-a", Title: "short one", Type: "note", CreatedAt: "2026-04-24T00:00:00Z", Tier: trace.TierShort},
+		{ID: "20260424-b", Title: "mid one", Type: "note", CreatedAt: "2026-04-24T00:00:00Z", Tier: trace.TierMid},
+		{ID: "20260424-c", Title: "long one", Type: "note", CreatedAt: "2026-04-24T00:00:00Z", Tier: trace.TierLong},
+	}
+	out := formatRows(rows)
+	for _, want := range []string{"[s]", "[m]", "[L]"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("formatRows output missing tier glyph %q; got:\n%s", want, out)
+		}
+	}
+}
+
+func TestGetTrace_IncludesTierLine(t *testing.T) {
+	// Integration-level: seed a trace at mid tier through the Cortex,
+	// invoke get_trace over MCP, and assert the output carries a
+	// "Tier: mid" line. Pre-fix this failed because the metadata block
+	// only surfaced ID/Title/Type/Author/Tags/Created/Updated with no
+	// tier slot at all.
+	cx := newTestCortex(t)
+	tr := trace.New("tier-vis", "note", "agent", nil, "body")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := cx.Promote(tr.ID, trace.TierMid); err != nil {
+		t.Fatalf("Promote: %v", err)
+	}
+
+	s := NewServer(cx, "test-version", "")
+	text, isErr := callTool(t, s, "get_trace", map[string]any{"id": tr.ID})
+	if isErr {
+		t.Fatalf("get_trace returned error: %s", text)
+	}
+	if !strings.Contains(text, "Tier: mid") {
+		t.Errorf("get_trace output missing 'Tier: mid' line; got:\n%s", text)
+	}
+}
+
+func TestTierGlyph(t *testing.T) {
+	cases := map[string]string{
+		trace.TierShort: "s",
+		trace.TierMid:   "m",
+		trace.TierLong:  "L",
+		"":              "?",
+		"bogus":         "?",
+	}
+	for in, want := range cases {
+		if got := tierGlyph(in); got != want {
+			t.Errorf("tierGlyph(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
 
 // --------- renderInstructions (pure helper) ---------
 


### PR DESCRIPTION
Closes #57.

## Summary
- `formatRows` (shared by `list_traces` and `search_traces`) now prefixes every row with a one-letter tier glyph matching the TUI idiom: `[s]` / `[m]` / `[L]`
- `get_trace` metadata block now includes a dedicated `Tier: <tier>` line alongside the existing `Type:` / `Author:` / etc.
- `get_instructions` reference block updated to document the new output contract
- Unknown tier renders as `[?]` so a blank DB value surfaces visibly

## Before / After

Before:
```
[note] 20260424-foo (2026-04-24) — agent [tag1]
  My trace
```

After:
```
[s] [note] 20260424-foo (2026-04-24) — agent [tag1]
  My trace
```

`get_trace` gains one metadata line:
```
ID: 20260424-foo
Title: My trace
Type: note
Tier: mid          ← NEW
Author: agent
...
```

## Test plan
- [x] `TestFormatRows_IncludesTierGlyph` — all three glyphs appear in output
- [x] `TestTierGlyph` — pins s/m/L/? mapping, including empty-string and bogus-value fallback
- [x] `TestGetTrace_IncludesTierLine` — integration test: seeded trace promoted to mid, `get_trace` through MCP returns `Tier: mid`
- [x] `go build ./...`, `go vet ./...`, `go test ./...` all green

## Why this matters
Agents reasoning about memory through MCP couldn't tell which traces are immutable (long, protected by the DB trigger) vs. curation candidates (mid) vs. fresh pool (short). This closed a real observability gap that surfaced today when an agent was asked about a trace's tier and correctly reported it had no way to see one. Fix is additive — existing consumers see an extra `[s]` / `[m]` / `[L]` token at the start of each list row, and an extra `Tier:` line in detail output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)