### PR TITLE
fix(consolidation): unstall federated election; clarify fail reasons; add watchdog

### DIFF
--- a/internal/cli/cmd_serve.go
+++ b/internal/cli/cmd_serve.go
@@ -351,7 +351,7 @@ func startConsolidator(cx *cortex.Cortex, cfg *cortex.ConsolidationConfig, fed *
 	if cfg == nil || !cfg.Enabled {
 		return nil
 	}
-	if cfg.Cron == "" && cfg.IdleMinutes == 0 && cfg.ThresholdShort == 0 {
+	if !cfg.HasTrigger() {
 		fmt.Fprintf(os.Stderr, "[consolidation] enabled but no triggers configured (cron/idle_minutes/threshold_short); agent will not run\n")
 		return nil
 	}
@@ -456,17 +456,18 @@ func startEligibility(cx *cortex.Cortex, cfg *cortex.ConsolidationConfig, fed *c
 		mode = fed.EffectiveMode()
 	}
 	loop := consolidation.NewEligibilityLoop(consolidation.EligibilityConfig{
-		Enabled:        cfg.Enabled,
-		LLMEnabled:     cfg.LLMEnabled,
-		FederationMode: mode,
-		Endpoint:       cfg.LocalLLMEndpoint,
-		CortexID:       cx.ID,
-		State:          federation.NewState(cx.DB.DB),
-		Log:            logger,
+		Enabled:            cfg.Enabled,
+		LLMEnabled:         cfg.LLMEnabled,
+		TriggersConfigured: cfg.HasTrigger(),
+		FederationMode:     mode,
+		Endpoint:           cfg.LocalLLMEndpoint,
+		CortexID:           cx.ID,
+		State:              federation.NewState(cx.DB.DB),
+		Log:                logger,
 	})
 	loop.Start()
-	fmt.Fprintf(os.Stderr, "[consolidation] eligibility loop started (llm_enabled=%t mode=%s endpoint=%q)\n",
-		cfg.LLMEnabled, mode, cfg.LocalLLMEndpoint)
+	fmt.Fprintf(os.Stderr, "[consolidation] eligibility loop started (llm_enabled=%t triggers=%t mode=%s endpoint=%q)\n",
+		cfg.LLMEnabled, cfg.HasTrigger(), mode, cfg.LocalLLMEndpoint)
 	return loop
 }
 

--- a/internal/cli/cmd_serve.go
+++ b/internal/cli/cmd_serve.go
@@ -121,6 +121,7 @@ func serveCmd() *cobra.Command {
 			var watcher *watch.Watcher
 			var consolidator *consolidation.Agent
 			var eligibility *consolidation.EligibilityLoop
+			var watchdog *consolidation.Watchdog
 
 			// Filesystem watcher: on by default so external edits
 			// (Obsidian, VS Code, Finder, iCloud sync, another agent on
@@ -155,6 +156,18 @@ func serveCmd() *cobra.Command {
 			// in local kv) and ready-to-go the moment peers are added.
 			if manifestErr == nil && m.Consolidation != nil && m.Consolidation.Enabled {
 				eligibility = startEligibility(cx, m.Consolidation, m.Federation)
+			}
+
+			// Election watchdog: closes out consolidation_claim events
+			// that never received a matching success/fail (winner crashed,
+			// network-partitioned, hung on the LLM endpoint, etc.) by
+			// emitting a fail with reason=watchdog_expired so the next
+			// election cycle can pick a new leader. Only runs when
+			// federation peers are configured — single-node cortexes
+			// can't have silent winners.
+			if manifestErr == nil && m.Consolidation != nil && m.Consolidation.Enabled &&
+				m.Federation != nil && len(m.Federation.Peers) > 0 {
+				watchdog = startWatchdog(cx)
 			}
 
 			switch transport {
@@ -301,6 +314,9 @@ func serveCmd() *cobra.Command {
 			}
 			if eligibility != nil {
 				eligibility.Stop()
+			}
+			if watchdog != nil {
+				watchdog.Stop()
 			}
 			return err
 		},
@@ -469,6 +485,28 @@ func startEligibility(cx *cortex.Cortex, cfg *cortex.ConsolidationConfig, fed *c
 	fmt.Fprintf(os.Stderr, "[consolidation] eligibility loop started (llm_enabled=%t triggers=%t mode=%s endpoint=%q)\n",
 		cfg.LLMEnabled, cfg.HasTrigger(), mode, cfg.LocalLLMEndpoint)
 	return loop
+}
+
+// startWatchdog launches the election watchdog. The caller has already
+// verified that consolidation is enabled AND federation peers are
+// configured — single-node cortexes never have silent winners and skip
+// the watchdog entirely. Defaults are baked into the watchdog package
+// (10-minute claim staleness ceiling, 1-minute sweep cadence); they
+// can be promoted to manifest config in a future change if real
+// deployments need to tune them.
+func startWatchdog(cx *cortex.Cortex) *consolidation.Watchdog {
+	logger := func(format string, args ...any) {
+		fmt.Fprintf(os.Stderr, format+"\n", args...)
+	}
+	w := consolidation.NewWatchdog(consolidation.WatchdogConfig{
+		DB:            cx.DB.DB,
+		Emitter:       cx,
+		LocalCortexID: cx.ID,
+		Log:           logger,
+	})
+	w.Start()
+	fmt.Fprintf(os.Stderr, "[consolidation] watchdog started\n")
+	return w
 }
 
 // startSyncer converts the manifest's federation config into a running

--- a/internal/consolidation/election.go
+++ b/internal/consolidation/election.go
@@ -155,12 +155,22 @@ type FailData struct {
 // Fail-reason enum, matching the plan's normalized reason strings.
 // Kept as string constants so callers can compose new reasons without
 // a package change.
+//
+// The three "preempted" reasons (PeerOutranked, NoWinnerAtRecheck,
+// ContextCanceled) replace the older catch-all "aborted_by_peer_conflict"
+// reason that was emitted by all three quiet-period exit paths. Telling
+// them apart in the event log lets operators distinguish "ai-3 outranked
+// us during the wait" from "everyone's rank entry expired" from
+// "agent.Stop() interrupted us" — same outcome (no pass), wildly
+// different operational meaning.
 const (
-	FailReasonEndpointDown     = "endpoint_down"
-	FailReasonLLMError         = "llm_error"
-	FailReasonValidationFailed = "validation_failed"
-	FailReasonPreempted        = "aborted_by_peer_conflict"
-	FailReasonWatchdogExpired  = "watchdog_expired"
+	FailReasonEndpointDown      = "endpoint_down"
+	FailReasonLLMError          = "llm_error"
+	FailReasonValidationFailed  = "validation_failed"
+	FailReasonPeerOutranked     = "peer_outranked"
+	FailReasonNoWinnerAtRecheck = "no_winner_at_recheck"
+	FailReasonContextCanceled   = "context_canceled"
+	FailReasonWatchdogExpired   = "watchdog_expired"
 )
 
 // Claim records this peer's intent to run the pass for windowID. Must

--- a/internal/consolidation/eligibility.go
+++ b/internal/consolidation/eligibility.go
@@ -28,6 +28,16 @@ type EligibilityConfig struct {
 	// run distillation passes and so cannot legitimately win a round.
 	LLMEnabled bool
 
+	// TriggersConfigured is true when the cortex has at least one
+	// scheduling trigger (cron / idle_minutes / threshold_short) set.
+	// startConsolidator returns nil without starting the agent when no
+	// trigger is configured; if this loop kept advertising a non-zero
+	// rank in that state, the peer would become a "phantom winner" that
+	// other peers defer to forever — the ring would stall because the
+	// elected leader never claims a window. Forcing Rank=0 here is the
+	// signal to the ring that this peer cannot legitimately run a pass.
+	TriggersConfigured bool
+
 	// FederationMode is the effective federation mode of this cortex
 	// (sync / publish / subscribe). When "subscribe", the loop forces
 	// Rank=0 because a read-only mirror cannot legitimately run a
@@ -157,6 +167,12 @@ func (e *EligibilityLoop) refresh() {
 		// Feature disabled by config. Advertise ineligibility so peers
 		// know this cortex is deliberately not participating.
 		newEntry.Rank = RankIneligible
+	case !e.cfg.TriggersConfigured:
+		// Eligibility was opted in but no scheduling trigger is wired
+		// up, so the agent will never fire. Advertising a non-zero
+		// rank in this state turns this peer into a phantom winner.
+		newEntry.Rank = RankIneligible
+		e.cfg.Log("[consolidation] no triggers configured (cron/idle_minutes/threshold_short); rank=0")
 	case e.cfg.FederationMode == "subscribe":
 		// Read-only mirror mode (plan §14 table). A subscribe-mode
 		// cortex pulls events from others but cannot serve them; by

--- a/internal/consolidation/eligibility_test.go
+++ b/internal/consolidation/eligibility_test.go
@@ -67,11 +67,12 @@ func TestEligibility_SubscribeMode_AdvertisesZero(t *testing.T) {
 	// Rank=0 even when the feature is enabled and the endpoint is alive
 	// — matches the §14 mode-compatibility table.
 	loop, state := buildLoop(t, consolidation.EligibilityConfig{
-		Enabled:        true,
-		LLMEnabled:     true,
-		FederationMode: "subscribe",
-		Endpoint:       "http://example.invalid",
-		Probe:          func(context.Context, string) bool { return true },
+		Enabled:            true,
+		LLMEnabled:         true,
+		TriggersConfigured: true,
+		FederationMode:     "subscribe",
+		Endpoint:           "http://example.invalid",
+		Probe:              func(context.Context, string) bool { return true },
 	})
 	loop.Refresh()
 
@@ -88,11 +89,12 @@ func TestEligibility_SyncMode_AdvertisesRank(t *testing.T) {
 	// Regression guard: the subscribe-mode branch must not accidentally
 	// blacklist sync-mode cortexes.
 	loop, state := buildLoop(t, consolidation.EligibilityConfig{
-		Enabled:        true,
-		LLMEnabled:     true,
-		FederationMode: "sync",
-		Endpoint:       "http://example.invalid",
-		Probe:          func(context.Context, string) bool { return true },
+		Enabled:            true,
+		LLMEnabled:         true,
+		TriggersConfigured: true,
+		FederationMode:     "sync",
+		Endpoint:           "http://example.invalid",
+		Probe:              func(context.Context, string) bool { return true },
 	})
 	loop.Refresh()
 
@@ -128,10 +130,11 @@ func TestEligibility_LLMDisabled_AdvertisesZero(t *testing.T) {
 
 func TestEligibility_ProbeFails_AdvertisesZero(t *testing.T) {
 	loop, state := buildLoop(t, consolidation.EligibilityConfig{
-		Enabled:    true,
-		LLMEnabled: true,
-		Endpoint:   "http://example.invalid",
-		Probe:      func(context.Context, string) bool { return false },
+		Enabled:            true,
+		LLMEnabled:         true,
+		TriggersConfigured: true,
+		Endpoint:           "http://example.invalid",
+		Probe:              func(context.Context, string) bool { return false },
 	})
 	loop.Refresh()
 
@@ -144,12 +147,38 @@ func TestEligibility_ProbeFails_AdvertisesZero(t *testing.T) {
 	}
 }
 
+func TestEligibility_NoTriggersConfigured_AdvertisesZero(t *testing.T) {
+	// Phantom-winner guard: a peer that opted into consolidation but
+	// configured no scheduling trigger (cron / idle_minutes /
+	// threshold_short) will never run a pass. Advertising a non-zero
+	// rank in that state makes other peers defer to a leader that
+	// never claims a window, stalling the ring. The loop must force
+	// Rank=0 in this case even when LLM and probe are healthy.
+	loop, state := buildLoop(t, consolidation.EligibilityConfig{
+		Enabled:            true,
+		LLMEnabled:         true,
+		TriggersConfigured: false,
+		Endpoint:           "http://example.invalid",
+		Probe:              func(context.Context, string) bool { return true },
+	})
+	loop.Refresh()
+
+	got, err := state.GetLocalRank()
+	if err != nil {
+		t.Fatalf("GetLocalRank: %v", err)
+	}
+	if got.Rank != consolidation.RankIneligible {
+		t.Errorf("no triggers: got rank %d, want 0", got.Rank)
+	}
+}
+
 func TestEligibility_AliveAndEnabled_RollsRank(t *testing.T) {
 	loop, state := buildLoop(t, consolidation.EligibilityConfig{
-		Enabled:    true,
-		LLMEnabled: true,
-		Endpoint:   "http://example.invalid",
-		Probe:      func(context.Context, string) bool { return true },
+		Enabled:            true,
+		LLMEnabled:         true,
+		TriggersConfigured: true,
+		Endpoint:           "http://example.invalid",
+		Probe:              func(context.Context, string) bool { return true },
 	})
 	loop.Refresh()
 
@@ -173,10 +202,11 @@ func TestEligibility_ReRollsEveryRefresh(t *testing.T) {
 	// would be flaky; instead, check that across many refreshes we see
 	// at least two distinct values.
 	loop, state := buildLoop(t, consolidation.EligibilityConfig{
-		Enabled:    true,
-		LLMEnabled: true,
-		Endpoint:   "http://example.invalid",
-		Probe:      func(context.Context, string) bool { return true },
+		Enabled:            true,
+		LLMEnabled:         true,
+		TriggersConfigured: true,
+		Endpoint:           "http://example.invalid",
+		Probe:              func(context.Context, string) bool { return true },
 	})
 
 	seen := map[int]bool{}
@@ -199,10 +229,11 @@ func TestEligibility_RollsFreshAfterOutageRecovery(t *testing.T) {
 	// up, rank must land in [1..99] on the next refresh.
 	var alive bool
 	loop, state := buildLoop(t, consolidation.EligibilityConfig{
-		Enabled:    true,
-		LLMEnabled: true,
-		Endpoint:   "http://example.invalid",
-		Probe:      func(context.Context, string) bool { return alive },
+		Enabled:            true,
+		LLMEnabled:         true,
+		TriggersConfigured: true,
+		Endpoint:           "http://example.invalid",
+		Probe:              func(context.Context, string) bool { return alive },
 	})
 
 	alive = true
@@ -234,11 +265,12 @@ func TestEligibility_ObservedAtAdvances(t *testing.T) {
 	// here is about ObservedAt movement specifically.
 	clock := time.Date(2026, 4, 21, 12, 0, 0, 0, time.UTC)
 	loop, state := buildLoop(t, consolidation.EligibilityConfig{
-		Enabled:    true,
-		LLMEnabled: true,
-		Endpoint:   "http://example.invalid",
-		Probe:      func(context.Context, string) bool { return true },
-		Now:        func() time.Time { return clock },
+		Enabled:            true,
+		LLMEnabled:         true,
+		TriggersConfigured: true,
+		Endpoint:           "http://example.invalid",
+		Probe:              func(context.Context, string) bool { return true },
+		Now:                func() time.Time { return clock },
 	})
 
 	loop.Refresh()

--- a/internal/consolidation/pass_gate.go
+++ b/internal/consolidation/pass_gate.go
@@ -20,8 +20,13 @@ import (
 //  2. Emit ActionConsolidationClaim with a fresh window ID.
 //  3. Sleep one QuietPeriod so any parallel-starting claimant has time
 //     to surface in federation_state.
-//  4. Re-decide. If we no longer win (a higher-tiebreak peer also
-//     claimed), emit Fail(aborted_by_peer_conflict) and return.
+//  4. Re-decide. If we no longer win, emit Fail with one of the three
+//     preemption reasons and return:
+//     - FailReasonPeerOutranked: a peer with higher rank (or the
+//     tiebreak) won the recheck.
+//     - FailReasonNoWinnerAtRecheck: no peer qualifies anymore (every
+//     entry got filtered as too-fresh or expired during the wait).
+//     - FailReasonContextCanceled: ctx.Done() fired during the sleep.
 //  5. Invoke inner(ctx, trigger). On error, emit Fail(reason=error
 //     message); on success, emit Success.
 //
@@ -55,7 +60,7 @@ func WithElection(inner PassFn, election *Election, log func(format string, args
 		if election.QuietPeriod() > 0 {
 			select {
 			case <-ctx.Done():
-				_ = election.Fail(windowID, FailReasonPreempted)
+				_ = election.Fail(windowID, FailReasonContextCanceled)
 				return ctx.Err()
 			case <-time.After(election.QuietPeriod()):
 			}
@@ -65,7 +70,11 @@ func WithElection(inner PassFn, election *Election, log func(format string, args
 		if !recheck.ShouldRun || recheck.Winner != election.CortexID() {
 			log("[consolidation] preempted during quiet period (trigger=%s): %s",
 				trigger, recheck.Reason)
-			_ = election.Fail(windowID, FailReasonPreempted)
+			reason := FailReasonPeerOutranked
+			if recheck.Winner == "" {
+				reason = FailReasonNoWinnerAtRecheck
+			}
+			_ = election.Fail(windowID, reason)
 			return nil
 		}
 

--- a/internal/consolidation/pass_gate_test.go
+++ b/internal/consolidation/pass_gate_test.go
@@ -121,8 +121,9 @@ func TestWithElection_EmitsFailOnPassError(t *testing.T) {
 
 func TestWithElection_HonorsContextCancellationDuringQuietPeriod(t *testing.T) {
 	// A context cancelled during the quiet-period sleep should emit
-	// Fail and return ctx.Err so Agent.Stop() drains promptly rather
-	// than blocking on a multi-second sleep.
+	// Fail with the context_canceled reason and return ctx.Err so
+	// Agent.Stop() drains promptly rather than blocking on a multi-
+	// second sleep.
 	state := newElectionState(t)
 	now := time.Date(2026, 4, 21, 12, 0, 0, 0, time.UTC)
 	must(t, state.SetLocalRank(federation.RankEntry{CortexID: "01LOCAL", Rank: 50, ObservedAt: stale(now)}))
@@ -150,6 +151,130 @@ func TestWithElection_HonorsContextCancellationDuringQuietPeriod(t *testing.T) {
 		t.Errorf("pass calls = %d, want 0 (cancelled before run)", inner.calls)
 	}
 	if got := emitter.count(event.ActionConsolidationFail); got != 1 {
-		t.Errorf("fail events = %d, want 1 (preempted)", got)
+		t.Errorf("fail events = %d, want 1 (context canceled)", got)
+	}
+	if reason := failReason(emitter); reason != consolidation.FailReasonContextCanceled {
+		t.Errorf("fail reason = %q, want %q", reason, consolidation.FailReasonContextCanceled)
+	}
+}
+
+// failReason returns the Reason field of the last ActionConsolidationFail
+// event recorded by emitter, or "" if none. Lets the gate tests assert
+// the specific preemption sub-reason now that the wrapper distinguishes
+// peer-outranked vs. no-winner-at-recheck vs. context-canceled.
+func failReason(emitter *fakeEmitter) string {
+	emitter.mu.Lock()
+	defer emitter.mu.Unlock()
+	for i := len(emitter.events) - 1; i >= 0; i-- {
+		if emitter.events[i].Action != event.ActionConsolidationFail {
+			continue
+		}
+		fd, ok := emitter.events[i].Data.(consolidation.FailData)
+		if !ok {
+			return ""
+		}
+		return fd.Reason
+	}
+	return ""
+}
+
+func TestWithElection_EmitsNoWinnerAtRecheck(t *testing.T) {
+	// Recheck-stall guard: if every rank entry expires or gets
+	// filtered between Decide() and the post-quiet recheck, the
+	// gate must surface FailReasonNoWinnerAtRecheck rather than the
+	// peer-outranked reason. Operationally this signals "everyone
+	// dropped out", not "someone else won" — different debugging path.
+	//
+	// Reproduce by handing Decide() a now-time that makes the local
+	// rank fresh enough to count at t=0 but stale enough to be
+	// filtered when the recheck advances the clock past the entry's
+	// validity window. We do this by writing a rank with ObservedAt
+	// well in the past and using a non-zero QuietPeriod such that
+	// recheck filters it out — except the existing minAge check
+	// requires entries to be at least minAge old, not at most.
+	//
+	// Simpler approach: install a hook that flips local rank to 0
+	// between Decide and recheck. We do that by writing the initial
+	// rank, letting the wrapper take its first Decide (we won), then
+	// the test's clock function returns a "now" that drives the
+	// recheck. To make recheck see no eligible peers, overwrite the
+	// rank entry with Rank=0 just before the wrapper resleeps.
+	//
+	// Because the wrapper sleeps real time when QuietPeriod > 0 and
+	// we want no flake, use QuietPeriod = 50ms and overwrite the
+	// rank from the test goroutine after a brief wait.
+	state := newElectionState(t)
+	now := time.Date(2026, 4, 21, 12, 0, 0, 0, time.UTC)
+	must(t, state.SetLocalRank(federation.RankEntry{CortexID: "01LOCAL", Rank: 50, ObservedAt: stale(now)}))
+
+	emitter := &fakeEmitter{}
+	e := consolidation.NewElection(consolidation.ElectionConfig{
+		CortexID:    "01LOCAL",
+		QuietPeriod: 50 * time.Millisecond,
+		Now:         func() time.Time { return now },
+		State:       state,
+		Emitter:     emitter,
+	})
+
+	inner := &callTracker{}
+	wrapped := consolidation.WithElection(inner.pass, e, nil)
+
+	// Demote local rank to 0 partway through the quiet period so the
+	// recheck finds zero eligible peers.
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		_ = state.SetLocalRank(federation.RankEntry{CortexID: "01LOCAL", Rank: 0, ObservedAt: stale(now)})
+	}()
+
+	if err := wrapped(context.Background(), "cron"); err != nil {
+		t.Fatalf("wrapped: %v", err)
+	}
+	if inner.calls != 0 {
+		t.Errorf("pass calls = %d, want 0 (no winner at recheck)", inner.calls)
+	}
+	if got := emitter.count(event.ActionConsolidationFail); got != 1 {
+		t.Errorf("fail events = %d, want 1", got)
+	}
+	if reason := failReason(emitter); reason != consolidation.FailReasonNoWinnerAtRecheck {
+		t.Errorf("fail reason = %q, want %q", reason, consolidation.FailReasonNoWinnerAtRecheck)
+	}
+}
+
+func TestWithElection_EmitsPeerOutrankedAtRecheck(t *testing.T) {
+	// Peer-outranked-at-recheck guard: a peer that wasn't visible at
+	// initial Decide arrives during the quiet period and outranks
+	// us. The wrapper must surface FailReasonPeerOutranked, not the
+	// no-winner reason.
+	state := newElectionState(t)
+	now := time.Date(2026, 4, 21, 12, 0, 0, 0, time.UTC)
+	must(t, state.SetLocalRank(federation.RankEntry{CortexID: "01LOCAL", Rank: 30, ObservedAt: stale(now)}))
+
+	emitter := &fakeEmitter{}
+	e := consolidation.NewElection(consolidation.ElectionConfig{
+		CortexID:    "01LOCAL",
+		PeerNames:   []string{"ai-2"},
+		QuietPeriod: 50 * time.Millisecond,
+		Now:         func() time.Time { return now },
+		State:       state,
+		Emitter:     emitter,
+	})
+
+	inner := &callTracker{}
+	wrapped := consolidation.WithElection(inner.pass, e, nil)
+
+	// Higher-ranked peer surfaces during the quiet wait.
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		_ = state.SetPeerRank("ai-2", federation.RankEntry{CortexID: "01PEER", Rank: 90, ObservedAt: stale(now)})
+	}()
+
+	if err := wrapped(context.Background(), "cron"); err != nil {
+		t.Fatalf("wrapped: %v", err)
+	}
+	if inner.calls != 0 {
+		t.Errorf("pass calls = %d, want 0 (peer outranked us)", inner.calls)
+	}
+	if reason := failReason(emitter); reason != consolidation.FailReasonPeerOutranked {
+		t.Errorf("fail reason = %q, want %q", reason, consolidation.FailReasonPeerOutranked)
 	}
 }

--- a/internal/consolidation/watchdog.go
+++ b/internal/consolidation/watchdog.go
@@ -1,0 +1,232 @@
+package consolidation
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/Fail-Safe/Noema/internal/event"
+)
+
+// Watchdog defaults — see WatchdogConfig fields for the rationale and
+// the consolidation-plan §14 watchdog deferral notes.
+const (
+	defaultWatchdogTimeout  = 10 * time.Minute
+	defaultWatchdogInterval = 1 * time.Minute
+)
+
+// WatchdogConfig is the runtime input for a Watchdog instance. Built in
+// cmd_serve from the Cortex handle and the federation config.
+type WatchdogConfig struct {
+	// DB is the cortex's SQLite connection. Required; the sweep query
+	// joins the events table to itself to find orphaned claims.
+	DB *sql.DB
+
+	// Emitter is the target for the closing fail events. In production
+	// this is the same *cortex.Cortex that EligibilityLoop and Election
+	// share; the narrow interface lets tests substitute a recorder.
+	Emitter EventEmitter
+
+	// LocalCortexID is this cortex's stable ULID. Stamped into every
+	// emitted fail event so observers can attribute the closing
+	// decision to a specific peer for audit purposes.
+	LocalCortexID string
+
+	// Timeout is how old a claim must be (now - claim.timestamp) before
+	// the watchdog treats it as orphaned. Generous by default — the
+	// longest legitimate pass we expect is LLM distillation on a
+	// large window, which still completes well inside this budget.
+	// Zero defaults to defaultWatchdogTimeout.
+	Timeout time.Duration
+
+	// Interval is the sweep cadence. Sweeps are cheap (one indexed
+	// query) so a tight cadence is fine; the trade-off is mostly how
+	// long an actually-stuck pass blocks the ring before being
+	// closed out. Zero defaults to defaultWatchdogInterval.
+	Interval time.Duration
+
+	// Now is injected for tests; zero defaults to time.Now.
+	Now func() time.Time
+
+	// Log is the optional logger; nil is a safe no-op.
+	Log func(format string, args ...any)
+}
+
+// Watchdog scans the local event log for consolidation_claim events with
+// no matching success/fail and emits a closing consolidation_fail event
+// (reason=watchdog_expired) so the next election cycle can move on. One
+// per cortex; lifecycle parallel to Agent + EligibilityLoop.
+//
+// The watchdog runs on every peer, not just election winners. The whole
+// point is that the winner is presumed dead — observers need to notice
+// and break out. Cross-peer duplicate emissions are possible (two
+// observers detect the same stale claim within seconds of each other);
+// events have unique IDs so replay is idempotent and the only cost is a
+// little log noise. Cross-peer locking would be substantially more
+// complex and isn't worth it for what is already a corner case.
+type Watchdog struct {
+	cfg WatchdogConfig
+
+	mu     sync.Mutex // serializes Sweep against itself
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+// NewWatchdog constructs a Watchdog with defaults filled in. Call Start
+// to begin the sweep loop; call Stop to drain.
+func NewWatchdog(cfg WatchdogConfig) *Watchdog {
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = defaultWatchdogTimeout
+	}
+	if cfg.Interval <= 0 {
+		cfg.Interval = defaultWatchdogInterval
+	}
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	if cfg.Log == nil {
+		cfg.Log = func(string, ...any) {}
+	}
+	return &Watchdog{cfg: cfg}
+}
+
+// Start kicks off the background sweep loop. Call exactly once per
+// instance; subsequent Start calls after Stop require a fresh
+// NewWatchdog.
+func (w *Watchdog) Start() {
+	w.ctx, w.cancel = context.WithCancel(context.Background())
+	w.wg.Add(1)
+	go w.loop()
+}
+
+// Stop signals the loop to exit and blocks until it does. Safe to call
+// even if Start never ran.
+func (w *Watchdog) Stop() {
+	if w.cancel == nil {
+		return
+	}
+	w.cancel()
+	w.wg.Wait()
+}
+
+func (w *Watchdog) loop() {
+	defer w.wg.Done()
+
+	// Run an initial sweep so a process that was restarted with stale
+	// claims in its log doesn't have to wait a full Interval before
+	// closing them out.
+	if err := w.Sweep(); err != nil {
+		w.cfg.Log("[watchdog] initial sweep failed: %v", err)
+	}
+
+	ticker := time.NewTicker(w.cfg.Interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-w.ctx.Done():
+			return
+		case <-ticker.C:
+			if err := w.Sweep(); err != nil {
+				w.cfg.Log("[watchdog] sweep failed: %v", err)
+			}
+		}
+	}
+}
+
+// orphanedClaim is the subset of a claim event needed to emit a closing
+// fail. trace_id holds the synthetic window ID for coordination events.
+type orphanedClaim struct {
+	WindowID  string
+	WinnerID  string // cortex_id of the peer that emitted the claim
+	Timestamp string
+}
+
+// Sweep runs one scan synchronously. Exported for tests and for callers
+// that want to force a check without waiting for the next tick.
+//
+// Not safe for concurrent invocation — the loop goroutine is the only
+// expected caller in production. The internal mutex serializes any
+// stray test calls against the loop.
+func (w *Watchdog) Sweep() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	cutoff := w.cfg.Now().Add(-w.cfg.Timeout).UTC().Format(time.RFC3339)
+	orphans, err := w.findOrphans(cutoff)
+	if err != nil {
+		return fmt.Errorf("watchdog query: %w", err)
+	}
+
+	for _, o := range orphans {
+		// Each emission goes through the same EmitCoordinationEvent
+		// path used by Election, so the closing fail lands in the
+		// event log with the local cortex as the emitter and the
+		// silent winner's ID embedded in FailData.CortexID. Future
+		// sweeps see the new fail via the NOT EXISTS clause and
+		// skip the window naturally.
+		fd := FailData{
+			WindowID: o.WindowID,
+			CortexID: o.WinnerID,
+			Reason:   FailReasonWatchdogExpired,
+		}
+		if err := w.cfg.Emitter.EmitCoordinationEvent(
+			event.ActionConsolidationFail, o.WindowID, fd,
+		); err != nil {
+			// Log + continue; one bad emission shouldn't block
+			// the rest of the sweep. The next tick will retry
+			// any windows we couldn't close this round.
+			w.cfg.Log("[watchdog] emit fail for window=%s winner=%s: %v",
+				o.WindowID, o.WinnerID, err)
+			continue
+		}
+		w.cfg.Log("[watchdog] closed orphaned claim window=%s winner=%s claimed=%s",
+			o.WindowID, o.WinnerID, o.Timestamp)
+	}
+	return nil
+}
+
+// findOrphans returns claim events older than cutoff (RFC3339) that
+// have no matching success or fail event in the local log. The query
+// is the join described in the watchdog design — a NOT EXISTS subquery
+// on the same table keyed on trace_id (= window_id for coordination
+// events) means a single ANY-emitted closing event is enough to retire
+// the window from future sweeps, naturally deduping across this peer's
+// own retries and against fail events replayed from other peers.
+func (w *Watchdog) findOrphans(cutoff string) ([]orphanedClaim, error) {
+	const q = `
+SELECT trace_id, cortex_id, timestamp
+FROM events
+WHERE action = ?
+  AND timestamp < ?
+  AND NOT EXISTS (
+      SELECT 1 FROM events e2
+      WHERE e2.trace_id = events.trace_id
+        AND e2.action IN (?, ?)
+  )
+ORDER BY timestamp`
+
+	rows, err := w.cfg.DB.Query(q,
+		string(event.ActionConsolidationClaim),
+		cutoff,
+		string(event.ActionConsolidationSuccess),
+		string(event.ActionConsolidationFail),
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []orphanedClaim
+	for rows.Next() {
+		var o orphanedClaim
+		if err := rows.Scan(&o.WindowID, &o.WinnerID, &o.Timestamp); err != nil {
+			return nil, err
+		}
+		out = append(out, o)
+	}
+	return out, rows.Err()
+}

--- a/internal/consolidation/watchdog_test.go
+++ b/internal/consolidation/watchdog_test.go
@@ -1,0 +1,271 @@
+package consolidation_test
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/Fail-Safe/Noema/internal/consolidation"
+	"github.com/Fail-Safe/Noema/internal/cortex"
+	"github.com/Fail-Safe/Noema/internal/event"
+)
+
+// buildWatchdogCortex stands up a real cortex on a temp dir so the
+// watchdog can query a live events table. Returns the cortex (which
+// implements EventEmitter) and a cleanup-bound handle so tests can
+// inject claims via the same EmitCoordinationEvent path used in
+// production.
+func buildWatchdogCortex(t *testing.T) *cortex.Cortex {
+	t.Helper()
+	dir := t.TempDir()
+	if _, err := cortex.Create("watchdog", dir); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cx, err := cortex.Open("watchdog", filepath.Join(dir, "watchdog"))
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { cx.Close() })
+	return cx
+}
+
+// emitClaim is a small helper that pushes a synthetic claim through the
+// real EmitCoordinationEvent path. Returns the window ID used so the
+// test can assert against it.
+func emitClaim(t *testing.T, cx *cortex.Cortex, winnerID string) string {
+	t.Helper()
+	windowID := event.NewULID()
+	if err := cx.EmitCoordinationEvent(
+		event.ActionConsolidationClaim, windowID,
+		consolidation.ClaimData{WindowID: windowID, CortexID: winnerID},
+	); err != nil {
+		t.Fatalf("emit claim: %v", err)
+	}
+	return windowID
+}
+
+// countActions returns the number of events with the given action in
+// the local log. Used to assert how many fails the watchdog emitted.
+func countActions(t *testing.T, cx *cortex.Cortex, action event.Action) int {
+	t.Helper()
+	events, err := cx.EventsSince("", 1000)
+	if err != nil {
+		t.Fatalf("EventsSince: %v", err)
+	}
+	n := 0
+	for _, e := range events {
+		if e.Action == action {
+			n++
+		}
+	}
+	return n
+}
+
+// findFailReason returns the reason of the (last) fail event for the
+// given window ID, or "" if none. Lets us verify the watchdog stamped
+// the right reason.
+func findFailReason(t *testing.T, cx *cortex.Cortex, windowID string) string {
+	t.Helper()
+	events, err := cx.EventsSince("", 1000)
+	if err != nil {
+		t.Fatalf("EventsSince: %v", err)
+	}
+	for i := len(events) - 1; i >= 0; i-- {
+		e := events[i]
+		if e.Action != event.ActionConsolidationFail || e.TraceID != windowID {
+			continue
+		}
+		// data is JSON: parse the Reason field. We don't decode the
+		// full FailData struct here to avoid coupling the test to its
+		// exact shape — a substring check is enough.
+		body := string(e.Data)
+		// Look for "reason":"<value>" in the JSON payload.
+		const key = `"reason":"`
+		idx := indexOf(body, key)
+		if idx < 0 {
+			return ""
+		}
+		rest := body[idx+len(key):]
+		end := indexOf(rest, `"`)
+		if end < 0 {
+			return ""
+		}
+		return rest[:end]
+	}
+	return ""
+}
+
+func indexOf(haystack, needle string) int {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestWatchdog_StaleClaimEmitsFail(t *testing.T) {
+	// Claim emitted now; sweep with a future "now" past the timeout
+	// so the claim looks stale. The watchdog should emit exactly one
+	// closing fail with reason=watchdog_expired and the silent
+	// winner's cortex_id stamped on the FailData payload.
+	cx := buildWatchdogCortex(t)
+	silentWinner := "01SILENTWINNERPEERIDXXXXXXX"
+	windowID := emitClaim(t, cx, silentWinner)
+
+	future := time.Now().Add(20 * time.Minute)
+	w := consolidation.NewWatchdog(consolidation.WatchdogConfig{
+		DB:            cx.DB.DB,
+		Emitter:       cx,
+		LocalCortexID: cx.ID,
+		Timeout:       10 * time.Minute,
+		Now:           func() time.Time { return future },
+	})
+
+	if err := w.Sweep(); err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+
+	if got, want := countActions(t, cx, event.ActionConsolidationFail), 1; got != want {
+		t.Errorf("fail events = %d, want %d", got, want)
+	}
+	if reason := findFailReason(t, cx, windowID); reason != consolidation.FailReasonWatchdogExpired {
+		t.Errorf("fail reason = %q, want %q", reason, consolidation.FailReasonWatchdogExpired)
+	}
+}
+
+func TestWatchdog_RecentClaimSkipped(t *testing.T) {
+	// Claim well within the timeout window — the watchdog must leave
+	// it alone.
+	cx := buildWatchdogCortex(t)
+	emitClaim(t, cx, "01PEER")
+
+	// Sweep with now = claim time + 30s; timeout = 10m, so the claim
+	// is far from stale.
+	near := time.Now().Add(30 * time.Second)
+	w := consolidation.NewWatchdog(consolidation.WatchdogConfig{
+		DB:      cx.DB.DB,
+		Emitter: cx,
+		Timeout: 10 * time.Minute,
+		Now:     func() time.Time { return near },
+	})
+
+	if err := w.Sweep(); err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if got := countActions(t, cx, event.ActionConsolidationFail); got != 0 {
+		t.Errorf("fail events = %d, want 0 (claim is recent)", got)
+	}
+}
+
+func TestWatchdog_ResolvedClaimSkipped(t *testing.T) {
+	// A claim with a matching success or fail event already in the log
+	// must not be re-closed by the watchdog. The NOT EXISTS clause in
+	// findOrphans handles both cases via the IN list.
+	cx := buildWatchdogCortex(t)
+	winner := "01PEER"
+
+	// Window 1: resolved by success.
+	w1 := emitClaim(t, cx, winner)
+	if err := cx.EmitCoordinationEvent(
+		event.ActionConsolidationSuccess, w1,
+		consolidation.SuccessData{WindowID: w1, CortexID: winner},
+	); err != nil {
+		t.Fatalf("emit success: %v", err)
+	}
+
+	// Window 2: resolved by fail.
+	w2 := emitClaim(t, cx, winner)
+	if err := cx.EmitCoordinationEvent(
+		event.ActionConsolidationFail, w2,
+		consolidation.FailData{WindowID: w2, CortexID: winner, Reason: consolidation.FailReasonLLMError},
+	); err != nil {
+		t.Fatalf("emit fail: %v", err)
+	}
+
+	failsBefore := countActions(t, cx, event.ActionConsolidationFail)
+
+	future := time.Now().Add(20 * time.Minute)
+	w := consolidation.NewWatchdog(consolidation.WatchdogConfig{
+		DB:      cx.DB.DB,
+		Emitter: cx,
+		Timeout: 10 * time.Minute,
+		Now:     func() time.Time { return future },
+	})
+
+	if err := w.Sweep(); err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+
+	// failsBefore captured the existing fail; the watchdog must not
+	// add another one (would mean it tried to re-close window 2).
+	if got, want := countActions(t, cx, event.ActionConsolidationFail), failsBefore; got != want {
+		t.Errorf("fail events = %d, want %d (watchdog should skip resolved windows)", got, want)
+	}
+}
+
+func TestWatchdog_DedupesAcrossSweeps(t *testing.T) {
+	// First sweep closes the orphan; the closing fail then satisfies
+	// the NOT EXISTS clause for subsequent sweeps, so re-running
+	// Sweep must not produce a second fail.
+	cx := buildWatchdogCortex(t)
+	emitClaim(t, cx, "01PEER")
+
+	future := time.Now().Add(20 * time.Minute)
+	w := consolidation.NewWatchdog(consolidation.WatchdogConfig{
+		DB:      cx.DB.DB,
+		Emitter: cx,
+		Timeout: 10 * time.Minute,
+		Now:     func() time.Time { return future },
+	})
+
+	if err := w.Sweep(); err != nil {
+		t.Fatalf("first Sweep: %v", err)
+	}
+	if err := w.Sweep(); err != nil {
+		t.Fatalf("second Sweep: %v", err)
+	}
+
+	if got, want := countActions(t, cx, event.ActionConsolidationFail), 1; got != want {
+		t.Errorf("fail events after two sweeps = %d, want %d (dedupe broken)", got, want)
+	}
+}
+
+func TestWatchdog_StartStopLifecycle(t *testing.T) {
+	// End-to-end: the loop wakes up, runs an initial Sweep, then
+	// drains cleanly when Stop is called. Tight Interval keeps the
+	// test fast; the initial Sweep happens before the first tick so
+	// we get the orphan closure even with a sub-second runtime.
+	cx := buildWatchdogCortex(t)
+	emitClaim(t, cx, "01PEER")
+
+	future := time.Now().Add(20 * time.Minute)
+	w := consolidation.NewWatchdog(consolidation.WatchdogConfig{
+		DB:       cx.DB.DB,
+		Emitter:  cx,
+		Timeout:  10 * time.Minute,
+		Interval: 50 * time.Millisecond,
+		Now:      func() time.Time { return future },
+	})
+
+	w.Start()
+	// Give the initial Sweep + at least one tick a chance to run.
+	time.Sleep(150 * time.Millisecond)
+	w.Stop()
+
+	if got, want := countActions(t, cx, event.ActionConsolidationFail), 1; got != want {
+		t.Errorf("fail events after Start/Stop cycle = %d, want %d", got, want)
+	}
+}
+
+func TestWatchdog_StopWithoutStartIsSafe(t *testing.T) {
+	// Defensive: Stop on a never-Started watchdog must not panic or
+	// block forever. Mirrors the same guarantee EligibilityLoop.Stop
+	// makes for the same reason.
+	cx := buildWatchdogCortex(t)
+	w := consolidation.NewWatchdog(consolidation.WatchdogConfig{
+		DB:      cx.DB.DB,
+		Emitter: cx,
+	})
+	w.Stop() // should be a no-op
+}

--- a/internal/cortex/cortex.go
+++ b/internal/cortex/cortex.go
@@ -75,7 +75,7 @@ const (
 
 // FederationConfig holds peer declarations for cortex.md.
 type FederationConfig struct {
-	Mode     string      `yaml:"mode,omitempty"`     // sync | publish | subscribe
+	Mode     string      `yaml:"mode,omitempty"` // sync | publish | subscribe
 	Peers    []PeerEntry `yaml:"peers,omitempty"`
 	Interval string      `yaml:"interval,omitempty"` // e.g. "30s", "1m"
 }
@@ -92,7 +92,7 @@ func (fc *FederationConfig) EffectiveMode() string {
 type PeerEntry struct {
 	Name     string `yaml:"name"`
 	Endpoint string `yaml:"endpoint"`
-	CA       string `yaml:"ca,omitempty"` // path to CA cert for TLS verification
+	CA       string `yaml:"ca,omitempty"`   // path to CA cert for TLS verification
 	Mode     string `yaml:"mode,omitempty"` // sync | paused
 }
 
@@ -332,6 +332,21 @@ func (cc *ConsolidationConfig) EffectiveModelTier() string {
 		return "large"
 	}
 	return cc.ModelTier
+}
+
+// HasTrigger reports whether at least one scheduling trigger
+// (cron / idle_minutes / threshold_short) is configured. Used by
+// startConsolidator to decide whether to spin up the agent and by
+// startEligibility to decide whether this peer should advertise a
+// non-zero rank: a peer that advertises eligibility but never runs is
+// a phantom winner that other peers defer to indefinitely, stalling
+// the ring. Treating "no triggers" the same as "consolidation off"
+// in the rank loop closes that footgun.
+func (cc *ConsolidationConfig) HasTrigger() bool {
+	if cc == nil {
+		return false
+	}
+	return cc.Cron != "" || cc.IdleMinutes != 0 || cc.ThresholdShort != 0
 }
 
 // ErrSourceLocked is returned when a mutation is attempted on a
@@ -3585,9 +3600,9 @@ func (c *Cortex) RebuildFTSIfStale() error {
 	defer rows.Close()
 
 	type rebuildEntry struct {
-		id, title   string
-		archivedAt  string
-		trashedAt   string
+		id, title  string
+		archivedAt string
+		trashedAt  string
 	}
 	var entries []rebuildEntry
 	for rows.Next() {
@@ -3665,4 +3680,3 @@ func nullIfEmpty(s string) *string {
 	}
 	return &s
 }
-


### PR DESCRIPTION
## Summary

Three commits on this branch, in dependency order:

1. **Phantom-winner guard** — a peer with `consolidation.enabled: true` + reachable LLM but no scheduling trigger was advertising a non-zero rank without ever starting an agent. Other peers deferred to it indefinitely and the ring stalled. The eligibility loop now forces `Rank=0` when no trigger is configured.
2. **Fail-reason split** — replace the catch-all `FailReasonPreempted` (`aborted_by_peer_conflict`) with three specific reasons (`peer_outranked`, `no_winner_at_recheck`, `context_canceled`) so future ring-stall triage doesn't require timestamp forensics on claim/fail pairs.
3. **Election watchdog** — close out `consolidation_claim` events that never received a matching success/fail (winner crashed, network-partitioned, hung on the LLM endpoint, etc.) by emitting a fail with `reason=watchdog_expired` so the next election cycle can move on. Runs on every peer; single-node cortexes skip it. Defaults: 10-min claim staleness ceiling, 1-min sweep cadence.

`ConsolidationConfig.HasTrigger()` becomes the single source of truth so `startConsolidator`'s agent-skip check and `startEligibility`'s rank-skip check cannot drift apart.

## Background

Found while triaging a stall on a federated ring: the highest-ranked peer was emitting zero `consolidation_*` events while lower-ranked peers raced and bounced their claims. Investigation traced the eligibility loop and consolidator agent being independently gated. The fail-reason split surfaced during the same triage — every fail event reported `aborted_by_peer_conflict` regardless of whether a peer actually won, the rank pool emptied, or `Agent.Stop` interrupted the wait. The watchdog covers the residual case where a winner does claim but then never reports — without it the ring still has no in-band recovery for a stuck or dead leader.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — all packages green, including new tests:
  - `TestEligibility_NoTriggersConfigured_AdvertisesZero`
  - `TestWithElection_EmitsNoWinnerAtRecheck`
  - `TestWithElection_EmitsPeerOutrankedAtRecheck`
  - `TestWatchdog_StaleClaimEmitsFail`
  - `TestWatchdog_RecentClaimSkipped`
  - `TestWatchdog_ResolvedClaimSkipped`
  - `TestWatchdog_DedupesAcrossSweeps`
  - `TestWatchdog_StartStopLifecycle`
  - `TestWatchdog_StopWithoutStartIsSafe`
- [x] Existing context-cancellation test updated to assert the specific `FailReasonContextCanceled` reason.
- [ ] Deploy to a multi-peer federation; verify next election cycle either runs to success or surfaces a specific (non-catch-all) fail reason.
- [ ] Force a stuck-winner scenario (e.g., kill `noema serve` between Claim and the post-quiet pass start) and confirm a peer's watchdog closes the orphaned window after the timeout.

## Notes

- Old events on disk keep `reason: "aborted_by_peer_conflict"` — that string is data, not code, so no migration needed. New events use the three specific reasons.
- Cross-peer duplicate watchdog emissions are possible if two observers detect a stale claim within seconds of each other. Events have unique IDs so replay stays idempotent; the noise is the only cost.
- Watchdog timeout/interval are internal constants for now. They can be promoted to manifest config in a future change if real deployments need tuning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)