### PR TITLE
fix(consolidation): retry cron pass when no peer ran the window (#56)

### DIFF
--- a/internal/cli/cmd_serve.go
+++ b/internal/cli/cmd_serve.go
@@ -440,10 +440,25 @@ func startConsolidator(cx *cortex.Cortex, cfg *cortex.ConsolidationConfig, fed *
 			len(peerNames), 2*interval)
 	}
 
+	// Cron retry-on-idle (issue #56) only makes sense when the
+	// election gate is in play: gated passes can defer (peer won)
+	// without actually running, and retry-on-idle re-fires until a
+	// success event lands. On a single-node cortex the pass always
+	// runs to completion when called, so leaving CronRetryWindow=0
+	// preserves the historical "mark day done immediately" behaviour.
+	cronRetryWindow := time.Duration(0)
+	cronMaxRetries := 0
+	if fed != nil && len(fed.Peers) > 0 {
+		cronRetryWindow = 5 * time.Minute
+		cronMaxRetries = 3
+	}
+
 	a := consolidation.New(cx, consolidation.Config{
-		Cron:           cfg.Cron,
-		IdleMinutes:    cfg.IdleMinutes,
-		ThresholdShort: cfg.ThresholdShort,
+		Cron:            cfg.Cron,
+		IdleMinutes:     cfg.IdleMinutes,
+		ThresholdShort:  cfg.ThresholdShort,
+		CronRetryWindow: cronRetryWindow,
+		CronMaxRetries:  cronMaxRetries,
 	}, pass, logger)
 	a.Start()
 	fmt.Fprintf(os.Stderr, "[consolidation] agent started (cron=%q idle=%dm threshold=%d window=%s)\n",

--- a/internal/consolidation/agent.go
+++ b/internal/consolidation/agent.go
@@ -20,6 +20,11 @@ import (
 type Cortex interface {
 	LastMutationTime() (time.Time, error)
 	ShortTierCount() (int, error)
+	// HasConsolidationSuccessAfter is queried by the cron retry path
+	// to detect whether a fired trigger actually resulted in a pass
+	// running (locally or on any peer that replayed a success event
+	// back to us via federation). See checkCronRetry for the protocol.
+	HasConsolidationSuccessAfter(cutoff time.Time) (bool, error)
 }
 
 // PassFn is the consolidation work itself. trigger identifies which
@@ -45,6 +50,22 @@ type Config struct {
 	// minute of the configured time, loose enough that the agent is
 	// effectively free of background cost.
 	PollInterval time.Duration
+	// CronRetryWindow is how long to wait after a cron trigger fires
+	// before checking whether it actually resulted in a consolidation
+	// pass running (locally or on a peer). If no success event has
+	// landed within this window, the trigger re-fires up to
+	// CronMaxRetries times. Zero disables retries entirely — useful for
+	// single-node cortexes whose passes don't emit success events, and
+	// for tests that drive evaluateAndMaybeRun directly. Issue #56:
+	// without this, a staggered-restart election can have every peer
+	// defer to another, nobody runs, and the cron opportunity is burned
+	// until tomorrow.
+	CronRetryWindow time.Duration
+	// CronMaxRetries bounds how many times a single cron fire will
+	// re-attempt before the agent gives up and marks the day as failed.
+	// Zero treated as "no retries", same as CronRetryWindow=0. Defaults
+	// applied in cmd_serve, not here, so tests can probe the zero case.
+	CronMaxRetries int
 }
 
 // Agent runs cadence evaluation and dispatches passes to the PassFn.
@@ -64,9 +85,22 @@ type Agent struct {
 	mu             sync.Mutex
 	lastRun        time.Time // most recent pass fire time (any trigger)
 	thresholdArmed bool      // true while short count > threshold
-	lastCronDay    string    // date of most recent cron fire (YYYY-MM-DD) so
-	// we don't double-fire cron when the clock is near the scheduled time
-	// and the poll ticks more than once within the minute.
+	lastCronDay    string    // date of most recent successfully-completed
+	// cron pass (YYYY-MM-DD). Set after a consolidation_success has been
+	// observed for the trigger fire (or after retries are exhausted, so
+	// we don't loop the same day forever). Until then cron is allowed to
+	// re-fire — this is what closes the issue #56 split-brain hole.
+
+	// Cron retry state. cronAwaiting is true between the moment a cron
+	// trigger fires and the moment we either observe a success event or
+	// give up on retries. cronFireTime is the most recent fire time used
+	// as the cutoff for HasConsolidationSuccessAfter; it advances on
+	// each retry so the success check ignores events older than the
+	// current attempt.
+	cronAwaiting    bool
+	cronFireTime    time.Time
+	cronRetriesLeft int
+	cronTargetDay   string
 }
 
 // New constructs an agent. Call Start to begin the loop. Passing a nil
@@ -117,6 +151,7 @@ func (a *Agent) loop() {
 
 	// Check once on startup so cron / threshold triggers that are
 	// already due don't wait a full poll interval for their first fire.
+	a.checkCronRetry()
 	a.evaluateAndMaybeRun()
 
 	for {
@@ -124,6 +159,7 @@ func (a *Agent) loop() {
 		case <-a.ctx.Done():
 			return
 		case <-ticker.C:
+			a.checkCronRetry()
 			a.evaluateAndMaybeRun()
 		}
 	}
@@ -134,16 +170,109 @@ func (a *Agent) evaluateAndMaybeRun() {
 	if trigger == "" {
 		return
 	}
+	now := a.now()
 	a.mu.Lock()
-	a.lastRun = a.now()
+	a.lastRun = now
 	if trigger == "cron" {
-		a.lastCronDay = a.now().Format("2006-01-02")
+		// Don't mark lastCronDay yet — we'll mark it from
+		// checkCronRetry once a consolidation_success event has
+		// landed (locally or replayed from a peer), or once retries
+		// are exhausted. Until then cron is allowed to re-fire from
+		// checkCronRetry's retry path.
+		if a.cfg.CronRetryWindow > 0 && a.cfg.CronMaxRetries > 0 {
+			a.cronAwaiting = true
+			a.cronFireTime = now
+			a.cronRetriesLeft = a.cfg.CronMaxRetries
+			a.cronTargetDay = now.Format("2006-01-02")
+		} else {
+			// Retry disabled — fall back to the historical
+			// "mark day done immediately" behaviour. Used in
+			// single-node cortexes (whose passes don't emit
+			// success events) and in tests that don't want to
+			// model the retry path.
+			a.lastCronDay = now.Format("2006-01-02")
+		}
 	}
 	a.mu.Unlock()
 
 	a.log("[consolidation] pass firing (trigger=%s)", trigger)
 	if err := a.pass(a.ctx, trigger); err != nil {
 		a.log("[consolidation] pass error (trigger=%s): %v", trigger, err)
+	}
+}
+
+// checkCronRetry runs at the start of every loop tick (after the
+// initial fire on startup). When a cron trigger is awaiting its
+// success event, this method either:
+//
+//   - clears the waiting state if a success has landed (we won, a peer
+//     ran the pass and we replayed it, or an idle/threshold trigger
+//     happened to consolidate the same window before our retry);
+//   - re-fires the cron pass if the retry window has elapsed and we
+//     still have retries left;
+//   - or marks the day as failed (sets lastCronDay so cron sleeps
+//     until tomorrow) if retries are exhausted.
+//
+// All three states converge to "we either succeeded or we'll wait
+// until tomorrow" — bounded retries cap the worst-case noise from a
+// genuinely sick ring.
+//
+// The pass invocation happens outside the agent's mutex (mirrors
+// evaluateAndMaybeRun's pattern) so a long-running pass doesn't
+// block status reads from other goroutines.
+func (a *Agent) checkCronRetry() {
+	a.mu.Lock()
+	if !a.cronAwaiting {
+		a.mu.Unlock()
+		return
+	}
+	now := a.now()
+	if now.Sub(a.cronFireTime) < a.cfg.CronRetryWindow {
+		a.mu.Unlock()
+		return
+	}
+	cutoff := a.cronFireTime
+	targetDay := a.cronTargetDay
+	a.mu.Unlock()
+
+	// HasConsolidationSuccessAfter is the source of truth: any peer's
+	// success event since the last fire counts, since federation
+	// replay surfaces remote successes in our local log. Errors here
+	// are non-fatal — log and treat as "no success yet" so the next
+	// tick retries the check.
+	found, err := a.cx.HasConsolidationSuccessAfter(cutoff)
+	if err != nil {
+		a.log("[consolidation] cron retry check failed for day=%s: %v",
+			targetDay, err)
+		return
+	}
+
+	a.mu.Lock()
+	if found {
+		a.cronAwaiting = false
+		a.lastCronDay = targetDay
+		a.mu.Unlock()
+		a.log("[consolidation] cron pass succeeded for day=%s", targetDay)
+		return
+	}
+	if a.cronRetriesLeft <= 0 {
+		a.cronAwaiting = false
+		a.lastCronDay = targetDay // give up for today
+		a.mu.Unlock()
+		a.log("[consolidation] cron pass exhausted retries for day=%s; giving up until tomorrow",
+			targetDay)
+		return
+	}
+	a.cronRetriesLeft--
+	a.cronFireTime = now
+	a.lastRun = now
+	retriesLeft := a.cronRetriesLeft
+	a.mu.Unlock()
+
+	a.log("[consolidation] cron pass retry firing (retries_left=%d trigger=cron)",
+		retriesLeft)
+	if err := a.pass(a.ctx, "cron"); err != nil {
+		a.log("[consolidation] cron retry pass error: %v", err)
 	}
 }
 
@@ -176,8 +305,14 @@ func (a *Agent) cronTriggered() bool {
 
 	a.mu.Lock()
 	alreadyFiredToday := a.lastCronDay == today
+	awaitingThisDay := a.cronAwaiting && a.cronTargetDay == today
 	a.mu.Unlock()
-	if alreadyFiredToday {
+	if alreadyFiredToday || awaitingThisDay {
+		// Awaiting state means cron has already fired and we're
+		// either watching for the success event or scheduling a
+		// retry via checkCronRetry. The trigger path must stay out
+		// of this window; only checkCronRetry is allowed to re-fire
+		// cron, and only after CronRetryWindow has elapsed.
 		return false
 	}
 	// Fire when the local clock has passed today's scheduled HH:MM.

--- a/internal/consolidation/agent_test.go
+++ b/internal/consolidation/agent_test.go
@@ -9,9 +9,14 @@ import (
 
 // fakeCortex lets tests drive the cadence inputs without a real DB.
 type fakeCortex struct {
-	mu        sync.Mutex
-	lastEvent time.Time
-	shortN    int
+	mu             sync.Mutex
+	lastEvent      time.Time
+	shortN         int
+	successAfterAt time.Time // sentinel: HasConsolidationSuccessAfter
+	// returns true when its cutoff is strictly < successAfterAt. Zero
+	// (default) means "no successes recorded" — every call returns false,
+	// which is the worst case the retry path needs to handle and matches
+	// the behaviour of a cortex whose pass deferred without emitting.
 }
 
 func (f *fakeCortex) LastMutationTime() (time.Time, error) {
@@ -26,6 +31,15 @@ func (f *fakeCortex) ShortTierCount() (int, error) {
 	return f.shortN, nil
 }
 
+func (f *fakeCortex) HasConsolidationSuccessAfter(cutoff time.Time) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.successAfterAt.IsZero() {
+		return false, nil
+	}
+	return f.successAfterAt.After(cutoff), nil
+}
+
 func (f *fakeCortex) setShortN(n int) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -36,6 +50,12 @@ func (f *fakeCortex) setLastEvent(t time.Time) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.lastEvent = t
+}
+
+func (f *fakeCortex) setSuccessAt(t time.Time) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.successAfterAt = t
 }
 
 // recorderPass captures each pass invocation so tests can assert
@@ -224,14 +244,14 @@ func TestIdle_FiresAfterCooldown(t *testing.T) {
 
 	// Simulate a mutation at noon, then advance clock 29 minutes — not yet idle enough.
 	cx.setLastEvent(now)
-	clock.set(now.Add(29*time.Minute))
+	clock.set(now.Add(29 * time.Minute))
 	a.evaluateAndMaybeRun()
 	if n := rec.count(); n != 0 {
 		t.Errorf("idle fired before cooldown: %d", n)
 	}
 
 	// 30 minutes since last mutation: fire.
-	clock.set(now.Add(30*time.Minute))
+	clock.set(now.Add(30 * time.Minute))
 	a.evaluateAndMaybeRun()
 	if n := rec.count(); n != 1 {
 		t.Fatalf("idle did not fire at cooldown: %d", n)
@@ -242,14 +262,14 @@ func TestIdle_FiresAfterCooldown(t *testing.T) {
 
 	// Another 29 minutes (total 59m since last mutation, 29m since last run):
 	// NOT enough for cooldown to elapse.
-	clock.set(now.Add(59*time.Minute))
+	clock.set(now.Add(59 * time.Minute))
 	a.evaluateAndMaybeRun()
 	if n := rec.count(); n != 1 {
 		t.Errorf("idle re-fired within cooldown: %d", n)
 	}
 
 	// Another minute (60m since last mutation, 30m since last run): re-fire.
-	clock.set(now.Add(60*time.Minute))
+	clock.set(now.Add(60 * time.Minute))
 	a.evaluateAndMaybeRun()
 	if n := rec.count(); n != 2 {
 		t.Errorf("idle did not re-fire after cooldown elapsed: %d", n)
@@ -298,4 +318,202 @@ func TestStopWithoutStart_NoPanic(t *testing.T) {
 	cx := &fakeCortex{}
 	a := New(cx, Config{}, nil, nil)
 	a.Stop() // should be a no-op, not a panic
+}
+
+// ---- Cron retry-on-idle (issue #56) ----
+
+// retryConfig is the canonical config used by the cron-retry tests:
+// 5-minute retry window, 3 retries. Tight enough to drive multiple
+// retries inside a test by stepping the clock, loose enough to mirror
+// realistic production defaults.
+func retryConfig() Config {
+	return Config{
+		Cron:            "03:00",
+		CronRetryWindow: 5 * time.Minute,
+		CronMaxRetries:  3,
+	}
+}
+
+func TestCronRetry_DefersMarkUntilSuccess(t *testing.T) {
+	// With retries enabled, a cron fire must not mark lastCronDay
+	// until checkCronRetry observes a success event. cronTriggered
+	// must also stay quiet during the awaiting window so the regular
+	// trigger path can't double-fire.
+	cx := &fakeCortex{}
+	a, rec, clock := newTestAgent(t, retryConfig(), cx)
+
+	// 03:00 — first fire.
+	clock.set(time.Date(2026, 4, 19, 3, 0, 0, 0, time.UTC))
+	a.evaluateAndMaybeRun()
+	if rec.count() != 1 {
+		t.Fatalf("first fire = %d, want 1", rec.count())
+	}
+
+	// 03:01 — within retry window, no success yet. The trigger
+	// path must not re-fire (awaiting state guards it) and the
+	// retry check is too early to act.
+	clock.set(time.Date(2026, 4, 19, 3, 1, 0, 0, time.UTC))
+	a.checkCronRetry()
+	a.evaluateAndMaybeRun()
+	if rec.count() != 1 {
+		t.Errorf("re-fired during awaiting window: count = %d", rec.count())
+	}
+}
+
+func TestCronRetry_SuccessClearsState(t *testing.T) {
+	// A success event landing during the retry window clears the
+	// awaiting state and marks lastCronDay so cron stops trying
+	// today and the agent goes back to its normal cadence.
+	cx := &fakeCortex{}
+	a, rec, clock := newTestAgent(t, retryConfig(), cx)
+
+	clock.set(time.Date(2026, 4, 19, 3, 0, 0, 0, time.UTC))
+	a.evaluateAndMaybeRun()
+	if rec.count() != 1 {
+		t.Fatalf("first fire = %d, want 1", rec.count())
+	}
+
+	// Simulate a success event arriving from a peer (or our own
+	// pass) at 03:02.
+	cx.setSuccessAt(time.Date(2026, 4, 19, 3, 2, 0, 0, time.UTC))
+
+	// 03:06 — first retry check past the window, success is found.
+	clock.set(time.Date(2026, 4, 19, 3, 6, 0, 0, time.UTC))
+	a.checkCronRetry()
+	if rec.count() != 1 {
+		t.Errorf("retry fired after success: count = %d", rec.count())
+	}
+
+	// 03:07 — trigger evaluation must now skip cron because
+	// lastCronDay is set.
+	clock.set(time.Date(2026, 4, 19, 3, 7, 0, 0, time.UTC))
+	a.evaluateAndMaybeRun()
+	if rec.count() != 1 {
+		t.Errorf("cron re-fired after success: count = %d", rec.count())
+	}
+}
+
+func TestCronRetry_RefiresAfterWindow(t *testing.T) {
+	// No success event lands within the retry window, so each
+	// successive retry check past the window re-fires the pass
+	// until retries are exhausted.
+	cx := &fakeCortex{}
+	cfg := retryConfig() // 3 retries, 5-min window
+	a, rec, clock := newTestAgent(t, cfg, cx)
+
+	// 03:00 — first fire.
+	clock.set(time.Date(2026, 4, 19, 3, 0, 0, 0, time.UTC))
+	a.evaluateAndMaybeRun()
+	if rec.count() != 1 {
+		t.Fatalf("first fire = %d, want 1", rec.count())
+	}
+
+	// 03:06 — retry #1 (1st of 3 retries fires).
+	clock.set(time.Date(2026, 4, 19, 3, 6, 0, 0, time.UTC))
+	a.checkCronRetry()
+	if rec.count() != 2 {
+		t.Errorf("retry 1 count = %d, want 2", rec.count())
+	}
+
+	// 03:12 — retry #2.
+	clock.set(time.Date(2026, 4, 19, 3, 12, 0, 0, time.UTC))
+	a.checkCronRetry()
+	if rec.count() != 3 {
+		t.Errorf("retry 2 count = %d, want 3", rec.count())
+	}
+
+	// 03:18 — retry #3 (last available).
+	clock.set(time.Date(2026, 4, 19, 3, 18, 0, 0, time.UTC))
+	a.checkCronRetry()
+	if rec.count() != 4 {
+		t.Errorf("retry 3 count = %d, want 4", rec.count())
+	}
+}
+
+func TestCronRetry_ExhaustedMarksDay(t *testing.T) {
+	// After the configured retry budget is spent without a success
+	// event, the agent gives up and marks lastCronDay so cron sleeps
+	// until tomorrow rather than looping forever.
+	cx := &fakeCortex{}
+	cfg := retryConfig()
+	a, rec, clock := newTestAgent(t, cfg, cx)
+
+	// First fire + 3 retries = 4 total invocations.
+	clock.set(time.Date(2026, 4, 19, 3, 0, 0, 0, time.UTC))
+	a.evaluateAndMaybeRun()
+
+	for i := 1; i <= 3; i++ {
+		clock.set(time.Date(2026, 4, 19, 3, i*6, 0, 0, time.UTC))
+		a.checkCronRetry()
+	}
+	if rec.count() != 4 {
+		t.Fatalf("total fires after retries = %d, want 4", rec.count())
+	}
+
+	// 03:24 — fourth check; retries are now exhausted, so this
+	// must NOT fire again. lastCronDay should be set so cron
+	// also doesn't fire from the normal trigger path today.
+	clock.set(time.Date(2026, 4, 19, 3, 24, 0, 0, time.UTC))
+	a.checkCronRetry()
+	a.evaluateAndMaybeRun()
+	if rec.count() != 4 {
+		t.Errorf("fired after retry exhaustion: count = %d", rec.count())
+	}
+
+	// Tomorrow at 03:00 — cron must fire again, the day mark
+	// only suppresses cron for the day it was set.
+	clock.set(time.Date(2026, 4, 20, 3, 0, 0, 0, time.UTC))
+	a.evaluateAndMaybeRun()
+	if rec.count() != 5 {
+		t.Errorf("cron did not fire next day: count = %d", rec.count())
+	}
+}
+
+func TestCronRetry_SuccessFromAnyPeerCounts(t *testing.T) {
+	// HasConsolidationSuccessAfter is the source of truth for
+	// "did a pass happen". A success event with a remote cortex_id
+	// (replayed via federation) satisfies the local retry check
+	// just as well as a local success — that's the point of the
+	// retry path. We model this with the fake cortex's
+	// successAfterAt timestamp without caring about origin.
+	cx := &fakeCortex{}
+	a, rec, clock := newTestAgent(t, retryConfig(), cx)
+
+	clock.set(time.Date(2026, 4, 19, 3, 0, 0, 0, time.UTC))
+	a.evaluateAndMaybeRun()
+
+	// Peer ran the pass and we replayed a success at 03:03.
+	cx.setSuccessAt(time.Date(2026, 4, 19, 3, 3, 0, 0, time.UTC))
+
+	// 03:06 — retry check finds the peer's success and stops here.
+	clock.set(time.Date(2026, 4, 19, 3, 6, 0, 0, time.UTC))
+	a.checkCronRetry()
+	if rec.count() != 1 {
+		t.Errorf("retried despite peer success: count = %d", rec.count())
+	}
+}
+
+func TestCronRetry_DisabledWhenWindowZero(t *testing.T) {
+	// Single-node cortexes (whose passes don't emit success events)
+	// and tests that don't want to model the retry path opt out by
+	// leaving CronRetryWindow at zero. In that case the historical
+	// "mark day done immediately" behaviour applies — exactly one
+	// fire per day, no retries, no awaiting state.
+	cx := &fakeCortex{}
+	a, rec, clock := newTestAgent(t, Config{Cron: "03:00"}, cx)
+
+	clock.set(time.Date(2026, 4, 19, 3, 0, 0, 0, time.UTC))
+	a.evaluateAndMaybeRun()
+	if rec.count() != 1 {
+		t.Fatalf("first fire = %d, want 1", rec.count())
+	}
+
+	// checkCronRetry must be a no-op when retry is disabled even
+	// though we're past where a retry window would have been.
+	clock.set(time.Date(2026, 4, 19, 3, 30, 0, 0, time.UTC))
+	a.checkCronRetry()
+	a.evaluateAndMaybeRun()
+	if rec.count() != 1 {
+		t.Errorf("retry-disabled fired again: count = %d", rec.count())
+	}
 }

--- a/internal/cortex/stats.go
+++ b/internal/cortex/stats.go
@@ -93,3 +93,32 @@ func (c *Cortex) LastMutationTime() (time.Time, error) {
 	}
 	return time.Parse(time.RFC3339, ts.String)
 }
+
+// HasConsolidationSuccessAfter reports whether at least one
+// consolidation_success event exists in the local log with timestamp
+// strictly greater than the given cutoff. Used by the consolidation
+// agent's cron retry-on-idle path to decide whether the most recent
+// trigger fire actually resulted in a pass running, locally or on
+// any peer (peer events arrive via federation replay).
+//
+// The cutoff is compared as RFC3339 strings — lexicographic order
+// matches chronological order for that format with consistent UTC
+// suffix, matching how the events table stores timestamps. A LIMIT 1
+// keeps the query cheap; we only care about existence, not count.
+func (c *Cortex) HasConsolidationSuccessAfter(cutoff time.Time) (bool, error) {
+	var marker int
+	err := c.DB.QueryRow(
+		`SELECT 1 FROM events
+		 WHERE action = 'consolidation_success'
+		   AND timestamp > ?
+		 LIMIT 1`,
+		cutoff.UTC().Format(time.RFC3339),
+	).Scan(&marker)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}


### PR DESCRIPTION
Closes #56.

## Summary

Adds cron retry-on-idle to the consolidation agent. When a cron trigger fires but no `consolidation_success` event lands within the retry window, the trigger re-fires up to N times before giving up for the day.

## Background

PR #59 (the election fixes from earlier today) covered the case where a single peer wins, claims, then goes silent mid-pass — the watchdog closes the orphaned claim and the next election cycle picks a new leader. But it didn't cover #56's pathology: every peer mutually defers, **nobody** ever becomes a winner, and the day's opportunity is burned because `lastCronDay` was marked immediately on fire.

## Approach

At the trigger layer, defer the `lastCronDay` mark until either:

- a `consolidation_success` event is observed for the trigger fire (locally or replayed via federation — any peer's success satisfies the local retry check), or
- the configured retries are exhausted.

A new `checkCronRetry` method runs at the start of each loop tick. While awaiting, it either clears the state on success, re-fires the pass after each retry window, or marks the day as failed when retries run out. `cronTriggered` is updated to skip during the awaiting window so the regular trigger path can't double-fire.

`HasConsolidationSuccessAfter` is added to the Cortex narrow interface and to `cortex.Cortex`. It's the source of truth — any peer's success since the trigger fire counts.

## Defaults

- 5-minute retry window
- 3 retries
- Only enabled when `len(federation.peers) > 0` (single-node cortexes don't emit success events from heuristic-only passes, so retry would loop forever; their historical "mark day done immediately" behaviour is preserved)

Both knobs are internal constants in `cmd_serve.go`. They can be promoted to manifest config in a future change if real deployments need to tune them.

## Tradeoff vs. option 1 in the issue

The issue body suggested two approaches. This PR implements **option 2** (retry-on-idle). **Option 1** (deterministic tiebreaker on observed claims) is the structurally-correct fix but touches the heart of the election protocol. Retry-on-idle is the orthogonal complement to the watchdog from #59 — together they cover both stall modes (silent winner / no winner ever) without modifying the gate's tricky claim/recheck logic.

Option 1 remains future work for v0.11.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` — all green, including 6 new retry tests:
  - `TestCronRetry_DefersMarkUntilSuccess`
  - `TestCronRetry_SuccessClearsState`
  - `TestCronRetry_RefiresAfterWindow`
  - `TestCronRetry_ExhaustedMarksDay`
  - `TestCronRetry_SuccessFromAnyPeerCounts`
  - `TestCronRetry_DisabledWhenWindowZero`
- [x] Existing cron / threshold / idle tests still pass — retry path is opt-in via `CronRetryWindow > 0 && CronMaxRetries > 0`, all existing tests leave both at zero so they exercise the unchanged behaviour.
- [ ] Deploy to a multi-peer ring, force a staggered restart within 60s, confirm the cron pass actually completes (via retry) instead of being burned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)