### PR TITLE
fix(serve): coordinate cortex background work via flock + LockFileEx (cross-platform)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/mark3labs/mcp-go v0.46.0
 	github.com/muesli/termenv v0.16.0
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/sys v0.42.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.48.0
 )
@@ -42,7 +43,6 @@ require (
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
-	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.3.8 // indirect
 	modernc.org/libc v1.70.0 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/internal/cli/cmd_serve.go
+++ b/internal/cli/cmd_serve.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"os/user"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -19,6 +20,7 @@ import (
 	"github.com/Fail-Safe/Noema/internal/consolidation"
 	"github.com/Fail-Safe/Noema/internal/cortex"
 	"github.com/Fail-Safe/Noema/internal/federation"
+	"github.com/Fail-Safe/Noema/internal/lock"
 	mcpserver "github.com/Fail-Safe/Noema/internal/mcp"
 	"github.com/Fail-Safe/Noema/internal/watch"
 	mcpgo "github.com/mark3labs/mcp-go/server"
@@ -123,49 +125,67 @@ func serveCmd() *cobra.Command {
 			var eligibility *consolidation.EligibilityLoop
 			var watchdog *consolidation.Watchdog
 
+			// Per-cortex background-work coordination. Concurrent serve
+			// processes on the same cortex (long-lived `--transport http`
+			// systemd service + transient `--transport stdio` subprocesses
+			// spawned by Claude Code, Hermes plugins, etc.) all open the
+			// same DB and previously each ran their own watcher,
+			// consolidator, eligibility loop, and watchdog. The result was
+			// duplicate event emissions, rank churn, and short-lived
+			// processes polluting the consolidation_claim history when
+			// their schedulers fired briefly before the parent killed them.
+			//
+			// flock here picks one process per cortex dir to own the
+			// background work. Losers fall through to "MCP-only" mode —
+			// they still serve their transport's request handlers, just
+			// without redundant background loops. Lock auto-releases on
+			// process exit (any path), so a crash or kill -9 of the
+			// holder lets the next process pick up cleanly.
+			lockPath := filepath.Join(cx.Dir, "db", "background.lock")
+			bgLock, gotLock, lockErr := lock.TryAcquire(lockPath)
+			if lockErr != nil {
+				return fmt.Errorf("acquiring background lock: %w", lockErr)
+			}
+			if !gotLock {
+				fmt.Fprintf(os.Stderr,
+					"[serve] another noema process owns background work for cortex %q; running as MCP-only\n",
+					cx.Name)
+			}
+
 			// Filesystem watcher: on by default so external edits
 			// (Obsidian, VS Code, Finder, iCloud sync, another agent on
-			// the same cortex) emit real mutation events. Runs under
-			// BOTH stdio and http — a stdio serve is not always the
-			// only mutator (the user may be editing in Obsidian while
-			// Claude Code uses stdio; iCloud may be delivering deltas
-			// from another device; another noema process may be writing
-			// via HTTP). Opt out with `watch: { enabled: false }` in
-			// cortex.md.
-			if manifestErr == nil && m.Watch.WatchEnabled() {
+			// the same cortex) emit real mutation events. Gated on the
+			// background-work lock so two processes don't each emit a
+			// trash/update event for the same fsnotify trigger.
+			if gotLock && manifestErr == nil && m.Watch.WatchEnabled() {
 				watcher = startWatcher(cx, m.Watch)
 			}
 
 			// Consolidation agent: opt-in; drives memory-tier
-			// promotions on cron/idle/threshold triggers. Runs under
-			// both stdio and http so an agent connected via either
-			// transport sees the same tier state. Phase 7 ships the
-			// scheduling loop with a no-op pass — Phase 8+ populate
-			// the pass with candidate selection and LLM distillation.
-			if manifestErr == nil && m.Consolidation != nil && m.Consolidation.Enabled {
+			// promotions on cron/idle/threshold triggers. Gated on the
+			// background-work lock so the cron scheduler only fires
+			// once per cortex even when multiple processes are serving
+			// MCP traffic.
+			if gotLock && manifestErr == nil && m.Consolidation != nil && m.Consolidation.Enabled {
 				consolidator = startConsolidator(cx, m.Consolidation, m.Federation)
 			}
 
 			// Eligibility loop: advertises this cortex's consolidation
 			// rank in federation_state so federated peers can observe
 			// whether and how strongly we want to run the next
-			// consolidation window (see consolidation-plan.md §14).
-			// Phase 2 lands the advertisement; Phase 3 wires the
-			// election itself. Runs whenever consolidation.enabled is
-			// true — harmless on a single-node cortex (rank just sits
-			// in local kv) and ready-to-go the moment peers are added.
-			if manifestErr == nil && m.Consolidation != nil && m.Consolidation.Enabled {
+			// consolidation window. Gated on the background-work lock
+			// so the rank entry doesn't churn between concurrent
+			// processes overwriting each other.
+			if gotLock && manifestErr == nil && m.Consolidation != nil && m.Consolidation.Enabled {
 				eligibility = startEligibility(cx, m.Consolidation, m.Federation)
 			}
 
 			// Election watchdog: closes out consolidation_claim events
-			// that never received a matching success/fail (winner crashed,
-			// network-partitioned, hung on the LLM endpoint, etc.) by
-			// emitting a fail with reason=watchdog_expired so the next
-			// election cycle can pick a new leader. Only runs when
-			// federation peers are configured — single-node cortexes
-			// can't have silent winners.
-			if manifestErr == nil && m.Consolidation != nil && m.Consolidation.Enabled &&
+			// that never received a matching success/fail. Gated on the
+			// background-work lock + federation peers; single-node
+			// cortexes can't have silent winners and lock losers don't
+			// need a parallel sweeper.
+			if gotLock && manifestErr == nil && m.Consolidation != nil && m.Consolidation.Enabled &&
 				m.Federation != nil && len(m.Federation.Peers) > 0 {
 				watchdog = startWatchdog(cx)
 			}
@@ -317,6 +337,14 @@ func serveCmd() *cobra.Command {
 			}
 			if watchdog != nil {
 				watchdog.Stop()
+			}
+			// Release the background-work lock last so background
+			// goroutines have already drained — the kernel would
+			// release it on exit anyway, but explicit release lets
+			// a sibling process pick up the lock before this binary
+			// finishes its own teardown.
+			if releaseErr := bgLock.Release(); releaseErr != nil {
+				fmt.Fprintf(os.Stderr, "[serve] releasing background lock: %v\n", releaseErr)
 			}
 			return err
 		},

--- a/internal/cli/cmd_serve.go
+++ b/internal/cli/cmd_serve.go
@@ -135,12 +135,15 @@ func serveCmd() *cobra.Command {
 			// processes polluting the consolidation_claim history when
 			// their schedulers fired briefly before the parent killed them.
 			//
-			// flock here picks one process per cortex dir to own the
-			// background work. Losers fall through to "MCP-only" mode —
-			// they still serve their transport's request handlers, just
-			// without redundant background loops. Lock auto-releases on
-			// process exit (any path), so a crash or kill -9 of the
-			// holder lets the next process pick up cleanly.
+			// An OS-level advisory lock here picks one process per
+			// cortex dir to own the background work (flock on Unix,
+			// LockFileEx on Windows — both with non-blocking
+			// exclusive semantics). Losers fall through to "MCP-only"
+			// mode — they still serve their transport's request
+			// handlers, just without redundant background loops. The
+			// kernel auto-releases the lock on process exit (any
+			// path: clean, SIGTERM, SIGKILL, panic), so a crashed
+			// holder hands off cleanly to the next process.
 			lockPath := filepath.Join(cx.Dir, "db", "background.lock")
 			bgLock, gotLock, lockErr := lock.TryAcquire(lockPath)
 			if lockErr != nil {

--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -1,0 +1,114 @@
+// Package lock provides a thin wrapper around POSIX flock(2) for
+// coordinating which noema process on a given cortex directory runs
+// background work (consolidator agent, eligibility loop, watchdog,
+// filesystem watcher).
+//
+// The whole-process problem this solves: noema serve can be invoked
+// concurrently against the same cortex via different transports — a
+// long-lived `--transport http` systemd service plus any number of
+// short-lived `--transport stdio` subprocesses spawned by MCP clients
+// (Claude Code, Hermes plugins, etc.). All of them open the same
+// SQLite DB in WAL mode, all of them load the same cortex_id, and all
+// of them currently start their own consolidator agent + eligibility
+// loop + watchdog + watcher. The result is duplicate event emissions,
+// rank churn in federation_state, and consolidation_claim/fail noise
+// from short-lived sessions whose schedulers fire briefly then get
+// killed.
+//
+// flock(2) is the right primitive: locks are associated with the open
+// file description, the kernel releases them automatically on process
+// exit (any path — clean, SIGTERM, SIGKILL, panic), and there's no
+// stale-lock-file problem to clean up. We use LOCK_EX|LOCK_NB so the
+// loser observes contention immediately and falls back to MCP-only
+// mode rather than blocking startup.
+//
+// Unix-only by design — syscall.Flock isn't defined on Windows. The
+// project's deployment targets are Linux (federated peers) and macOS
+// (developer laptops); a Windows port would need a parallel
+// LockFileEx implementation alongside this one.
+package lock
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"syscall"
+)
+
+// Lock represents an acquired exclusive flock on a sentinel file. The
+// kernel releases the underlying lock when the file descriptor is
+// closed (or when the process exits), so a process that crashes
+// without calling Release does not strand the lock for future
+// invocations — that property is load-bearing and is the whole reason
+// flock was chosen over a PID-file or sentinel-presence scheme.
+type Lock struct {
+	mu       sync.Mutex
+	f        *os.File
+	released bool
+}
+
+// TryAcquire attempts to acquire an exclusive non-blocking flock on
+// path. The file is created if it doesn't exist. Three return shapes:
+//
+//   - (lock, true, nil): we hold the lock; caller is responsible for
+//     calling Release at shutdown (the kernel also releases on exit).
+//   - (nil, false, nil): another process holds the lock; caller should
+//     proceed without acquiring resources gated on lock ownership.
+//   - (nil, false, err): something went wrong before we could ask the
+//     kernel for a lock (e.g., parent directory missing, permission
+//     denied). Treat as a hard error — don't silently fall through to
+//     "no lock" because that masks misconfiguration.
+//
+// path should be inside the cortex dir's `db/` subdirectory so it
+// doesn't show up in user-managed trace listings or get accidentally
+// synced by tools like Obsidian or iCloud.
+func TryAcquire(path string) (*Lock, bool, error) {
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0o644)
+	if err != nil {
+		return nil, false, fmt.Errorf("open lock file %q: %w", path, err)
+	}
+
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		// EWOULDBLOCK / EAGAIN means the lock is held by someone
+		// else — a normal, expected outcome and not a hard error.
+		// Anything else (EBADF, ENOLCK, etc.) is unexpected.
+		_ = f.Close()
+		if err == syscall.EWOULDBLOCK {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("flock %q: %w", path, err)
+	}
+
+	return &Lock{f: f}, true, nil
+}
+
+// Release explicitly drops the flock and closes the file descriptor.
+// Safe to call multiple times; the second and subsequent calls are
+// no-ops. Always pair every successful TryAcquire with a deferred
+// Release for clarity, even though the kernel would auto-release on
+// process exit.
+func (l *Lock) Release() error {
+	if l == nil {
+		return nil
+	}
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.released {
+		return nil
+	}
+	l.released = true
+
+	// Drop the kernel-side lock first, then close the fd. Closing
+	// alone would also release the lock, but explicit LOCK_UN keeps
+	// the intent obvious to readers and gives us a place to surface
+	// flock-specific errors.
+	flockErr := syscall.Flock(int(l.f.Fd()), syscall.LOCK_UN)
+	closeErr := l.f.Close()
+	if flockErr != nil {
+		return fmt.Errorf("flock unlock: %w", flockErr)
+	}
+	if closeErr != nil {
+		return fmt.Errorf("close lock file: %w", closeErr)
+	}
+	return nil
+}

--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -1,7 +1,7 @@
-// Package lock provides a thin wrapper around POSIX flock(2) for
-// coordinating which noema process on a given cortex directory runs
-// background work (consolidator agent, eligibility loop, watchdog,
-// filesystem watcher).
+// Package lock provides a thin wrapper around OS-level advisory file
+// locking for coordinating which noema process on a given cortex
+// directory runs background work (consolidator agent, eligibility
+// loop, watchdog, filesystem watcher).
 //
 // The whole-process problem this solves: noema serve can be invoked
 // concurrently against the same cortex via different transports — a
@@ -9,45 +9,44 @@
 // short-lived `--transport stdio` subprocesses spawned by MCP clients
 // (Claude Code, Hermes plugins, etc.). All of them open the same
 // SQLite DB in WAL mode, all of them load the same cortex_id, and all
-// of them currently start their own consolidator agent + eligibility
-// loop + watchdog + watcher. The result is duplicate event emissions,
-// rank churn in federation_state, and consolidation_claim/fail noise
-// from short-lived sessions whose schedulers fire briefly then get
-// killed.
+// of them previously started their own consolidator agent +
+// eligibility loop + watchdog + watcher. The result was duplicate
+// event emissions, rank churn in federation_state, and
+// consolidation_claim/fail noise from short-lived sessions whose
+// schedulers fired briefly then got killed.
 //
-// flock(2) is the right primitive: locks are associated with the open
-// file description, the kernel releases them automatically on process
-// exit (any path — clean, SIGTERM, SIGKILL, panic), and there's no
-// stale-lock-file problem to clean up. We use LOCK_EX|LOCK_NB so the
-// loser observes contention immediately and falls back to MCP-only
-// mode rather than blocking startup.
+// OS-level advisory locks are the right primitive: locks are bound to
+// the open file (descriptor on Unix, handle on Windows), the kernel
+// releases them automatically on process exit (any path — clean,
+// SIGTERM, SIGKILL, panic), and there's no stale-lock-file problem to
+// clean up. We use exclusive non-blocking semantics so the loser
+// observes contention immediately and falls back to MCP-only mode
+// rather than blocking startup.
 //
-// Unix-only by design — syscall.Flock isn't defined on Windows. The
-// project's deployment targets are Linux (federated peers) and macOS
-// (developer laptops); a Windows port would need a parallel
-// LockFileEx implementation alongside this one.
+// Cross-platform implementation lives in lock_unix.go (flock(2)) and
+// lock_windows.go (LockFileEx). The public API in this file is the
+// same on both.
 package lock
 
 import (
 	"fmt"
 	"os"
 	"sync"
-	"syscall"
 )
 
-// Lock represents an acquired exclusive flock on a sentinel file. The
-// kernel releases the underlying lock when the file descriptor is
-// closed (or when the process exits), so a process that crashes
-// without calling Release does not strand the lock for future
-// invocations — that property is load-bearing and is the whole reason
-// flock was chosen over a PID-file or sentinel-presence scheme.
+// Lock represents an acquired exclusive file lock. The kernel releases
+// the underlying lock when the file descriptor / handle is closed (or
+// when the process exits), so a process that crashes without calling
+// Release does not strand the lock for future invocations — that
+// property is load-bearing and is the whole reason an OS-level lock
+// was chosen over a PID-file or sentinel-presence scheme.
 type Lock struct {
 	mu       sync.Mutex
 	f        *os.File
 	released bool
 }
 
-// TryAcquire attempts to acquire an exclusive non-blocking flock on
+// TryAcquire attempts to acquire an exclusive non-blocking lock on
 // path. The file is created if it doesn't exist. Three return shapes:
 //
 //   - (lock, true, nil): we hold the lock; caller is responsible for
@@ -68,25 +67,24 @@ func TryAcquire(path string) (*Lock, bool, error) {
 		return nil, false, fmt.Errorf("open lock file %q: %w", path, err)
 	}
 
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
-		// EWOULDBLOCK / EAGAIN means the lock is held by someone
-		// else — a normal, expected outcome and not a hard error.
-		// Anything else (EBADF, ENOLCK, etc.) is unexpected.
+	got, err := tryLock(f)
+	if err != nil {
 		_ = f.Close()
-		if err == syscall.EWOULDBLOCK {
-			return nil, false, nil
-		}
-		return nil, false, fmt.Errorf("flock %q: %w", path, err)
+		return nil, false, fmt.Errorf("lock %q: %w", path, err)
 	}
-
+	if !got {
+		_ = f.Close()
+		return nil, false, nil
+	}
 	return &Lock{f: f}, true, nil
 }
 
-// Release explicitly drops the flock and closes the file descriptor.
-// Safe to call multiple times; the second and subsequent calls are
-// no-ops. Always pair every successful TryAcquire with a deferred
-// Release for clarity, even though the kernel would auto-release on
-// process exit.
+// Release explicitly drops the lock and closes the file descriptor /
+// handle. Safe to call multiple times; the second and subsequent
+// calls are no-ops. Always pair every successful TryAcquire with a
+// deferred Release for clarity, even though the kernel would
+// auto-release on process exit. Safe to call on a nil receiver, so
+// callers can `defer l.Release()` without an `if l != nil` guard.
 func (l *Lock) Release() error {
 	if l == nil {
 		return nil
@@ -99,16 +97,26 @@ func (l *Lock) Release() error {
 	l.released = true
 
 	// Drop the kernel-side lock first, then close the fd. Closing
-	// alone would also release the lock, but explicit LOCK_UN keeps
+	// alone would also release the lock, but explicit unlock keeps
 	// the intent obvious to readers and gives us a place to surface
-	// flock-specific errors.
-	flockErr := syscall.Flock(int(l.f.Fd()), syscall.LOCK_UN)
+	// platform-specific errors.
+	unlockErr := unlock(l.f)
 	closeErr := l.f.Close()
-	if flockErr != nil {
-		return fmt.Errorf("flock unlock: %w", flockErr)
+	if unlockErr != nil {
+		return fmt.Errorf("unlock: %w", unlockErr)
 	}
 	if closeErr != nil {
 		return fmt.Errorf("close lock file: %w", closeErr)
 	}
 	return nil
 }
+
+// tryLock and unlock are platform-specific. See lock_unix.go and
+// lock_windows.go for implementations. Both return:
+//
+//   - tryLock(f) (got bool, err error):
+//       got=true:  acquired the lock; caller owns it
+//       got=false, err=nil: contention (held by another process)
+//       got=false, err!=nil: hard error (unrelated to contention)
+//
+//   - unlock(f) error: drops the lock; nil on success

--- a/internal/lock/lock_test.go
+++ b/internal/lock/lock_test.go
@@ -1,0 +1,137 @@
+package lock_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/Fail-Safe/Noema/internal/lock"
+)
+
+func TestTryAcquire_FreshPath_Succeeds(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "background.lock")
+
+	l, got, err := lock.TryAcquire(path)
+	if err != nil {
+		t.Fatalf("TryAcquire: %v", err)
+	}
+	if !got {
+		t.Errorf("got = false, want true (fresh path should acquire)")
+	}
+	if l == nil {
+		t.Fatalf("lock = nil, want non-nil on success")
+	}
+	if err := l.Release(); err != nil {
+		t.Errorf("Release: %v", err)
+	}
+}
+
+func TestTryAcquire_HeldByAnother_ReturnsFalse(t *testing.T) {
+	// Two TryAcquire calls in the same process from different fds
+	// (different os.OpenFile invocations) create independent OFDs;
+	// flock semantics make the second one EWOULDBLOCK while the
+	// first holds the lock. This is the same behaviour we get when
+	// the second caller is a different process — verifying it here
+	// without spawning a subprocess.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "background.lock")
+
+	l1, got1, err := lock.TryAcquire(path)
+	if err != nil {
+		t.Fatalf("first TryAcquire: %v", err)
+	}
+	if !got1 {
+		t.Fatalf("first acquire = false, want true")
+	}
+	defer l1.Release()
+
+	l2, got2, err := lock.TryAcquire(path)
+	if err != nil {
+		t.Errorf("second TryAcquire returned error %v, want nil (contention is not an error)", err)
+	}
+	if got2 {
+		t.Errorf("second acquire = true, want false (lock already held)")
+	}
+	if l2 != nil {
+		t.Errorf("second lock = %v, want nil on contention", l2)
+		l2.Release()
+	}
+}
+
+func TestTryAcquire_AfterRelease_Reacquirable(t *testing.T) {
+	// Releasing the first lock must allow a fresh acquire to
+	// succeed. This is the "first process exits, next process
+	// picks up the background work" handoff path.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "background.lock")
+
+	l1, got1, err := lock.TryAcquire(path)
+	if err != nil || !got1 {
+		t.Fatalf("first acquire failed: got=%v err=%v", got1, err)
+	}
+	if err := l1.Release(); err != nil {
+		t.Fatalf("Release: %v", err)
+	}
+
+	l2, got2, err := lock.TryAcquire(path)
+	if err != nil {
+		t.Fatalf("second TryAcquire: %v", err)
+	}
+	if !got2 {
+		t.Errorf("re-acquire after release = false, want true")
+	}
+	if l2 != nil {
+		l2.Release()
+	}
+}
+
+func TestRelease_Idempotent(t *testing.T) {
+	// Calling Release twice on the same lock must be a no-op the
+	// second time, not an error and not a double-close. cmd_serve's
+	// shutdown path may legitimately call Release during a deferred
+	// cleanup even after some explicit earlier Release elsewhere.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "background.lock")
+
+	l, _, err := lock.TryAcquire(path)
+	if err != nil {
+		t.Fatalf("TryAcquire: %v", err)
+	}
+	if err := l.Release(); err != nil {
+		t.Fatalf("first Release: %v", err)
+	}
+	if err := l.Release(); err != nil {
+		t.Errorf("second Release returned %v, want nil (idempotent)", err)
+	}
+}
+
+func TestRelease_NilLockSafe(t *testing.T) {
+	// Defensive: deferred Release on a nil lock (the contention case
+	// where TryAcquire returned nil) must not panic. Lets callers
+	// write `defer l.Release()` without an `if l != nil` guard.
+	var l *lock.Lock
+	if err := l.Release(); err != nil {
+		t.Errorf("nil-receiver Release returned %v, want nil", err)
+	}
+}
+
+func TestTryAcquire_MissingDirectory_Errors(t *testing.T) {
+	// Hard error when the lock path's parent doesn't exist — we want
+	// callers to surface this as a startup failure rather than
+	// silently fall through to MCP-only mode (which would mask a
+	// misconfigured or corrupted cortex layout).
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nonexistent-subdir", "background.lock")
+
+	l, got, err := lock.TryAcquire(path)
+	if err == nil {
+		t.Errorf("error = nil, want non-nil for missing parent directory")
+	}
+	if got {
+		t.Errorf("got = true, want false on error path")
+	}
+	if l != nil {
+		t.Errorf("lock = %v, want nil on error path", l)
+		l.Release()
+	}
+}

--- a/internal/lock/lock_unix.go
+++ b/internal/lock/lock_unix.go
@@ -1,0 +1,29 @@
+//go:build unix
+
+package lock
+
+import (
+	"os"
+	"syscall"
+)
+
+// tryLock asks the kernel for an exclusive non-blocking flock on f.
+// EWOULDBLOCK / EAGAIN means another process holds the lock — a
+// normal, expected outcome and not a hard error. Anything else
+// (EBADF, ENOLCK, etc.) is unexpected and bubbles up.
+func tryLock(f *os.File) (bool, error) {
+	err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	if err == nil {
+		return true, nil
+	}
+	if err == syscall.EWOULDBLOCK {
+		return false, nil
+	}
+	return false, err
+}
+
+// unlock drops the flock. Closing the file would also release it,
+// but explicit LOCK_UN keeps the lifecycle obvious.
+func unlock(f *os.File) error {
+	return syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+}

--- a/internal/lock/lock_windows.go
+++ b/internal/lock/lock_windows.go
@@ -1,0 +1,60 @@
+//go:build windows
+
+package lock
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// allBytes is the maximum lock-region size LockFileEx accepts: a
+// 64-bit length split across two 32-bit fields. Combined with an
+// offset of zero (in the Overlapped struct), this locks the entire
+// file plus everything beyond EOF — Windows allows locking past the
+// end, and using the full range is the standard idiom for whole-file
+// advisory locks.
+const allBytes = ^uint32(0)
+
+// tryLock asks Windows for an exclusive immediate-fail lock on f.
+// LOCKFILE_EXCLUSIVE_LOCK is the equivalent of flock's LOCK_EX;
+// LOCKFILE_FAIL_IMMEDIATELY is the equivalent of LOCK_NB — without
+// it the call would block until the lock is granted. Contention is
+// surfaced as ERROR_LOCK_VIOLATION (the Win32 analogue of
+// EWOULDBLOCK) and converted to (false, nil) so callers can
+// distinguish "another process holds it" from real errors.
+func tryLock(f *os.File) (bool, error) {
+	overlapped := new(windows.Overlapped)
+	err := windows.LockFileEx(
+		windows.Handle(f.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0,        // reserved, must be zero
+		allBytes, // bytes-low
+		allBytes, // bytes-high
+		overlapped,
+	)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+		return false, nil
+	}
+	return false, err
+}
+
+// unlock drops the LockFileEx lock. The same Overlapped struct shape
+// (zeroed offsets) and byte range must match the lock call so
+// Windows can identify which region to release. UnlockFileEx with a
+// zero region offset and full-range length matches the lock we
+// took above.
+func unlock(f *os.File) error {
+	overlapped := new(windows.Overlapped)
+	return windows.UnlockFileEx(
+		windows.Handle(f.Fd()),
+		0,
+		allBytes,
+		allBytes,
+		overlapped,
+	)
+}


### PR DESCRIPTION
## Summary

Concurrent `noema serve` processes on the same cortex (long-lived `--transport http` systemd service plus transient `--transport stdio` subprocesses spawned by Claude Code, Hermes plugins, etc.) all open the same DB and previously each ran their own filesystem watcher, consolidator agent, eligibility loop, and watchdog. This commit gates those four background components on holding an exclusive OS-level advisory lock on `<cortex>/db/background.lock`. First process per cortex wins the lock and runs the background work; later processes (any transport) fall through to "MCP-only" mode and just serve request handlers.

The lock implementation is cross-platform: `flock(2)` on Unix and `LockFileEx` on Windows, both with non-blocking exclusive semantics and identical kernel-side auto-release on process exit.

## Background

Discovered while triaging an unexpected `consolidation_fail` (`reason=context_canceled`) on a multi-host federated ring. The fail event was tagged with a peer's `cortex_id`, but the peer's systemd-managed `noema-agentbrain.service` journal showed no consolidation activity at that moment — same PID throughout, no restart. Investigating the host turned up multiple concurrent `noema serve` processes against the same cortex:

```
PID 4169456  16h29m  noema serve --transport http   (systemd)
PID 128408    3h27m  noema serve
PID 128661    3h26m  noema serve --transport stdio
PID 129896    3h22m  noema serve
PID 194625      1s   noema serve
PID 194664      0s   noema serve --transport stdio
```

These are short-lived MCP-stdio subprocesses spawned by Hermes/Claude agent sessions. Each one opens the same SQLite DB (WAL mode allows concurrent access), loads the same `cortex_id` from `cortex.md`, and spins up the full serve stack — including its own consolidator agent, eligibility loop, watchdog, and watcher. When the parent agent finishes and kills the stdio subprocess mid-quiet-wait, the gate emits `consolidation_fail (context_canceled)` and the watcher emits trash events on its way out — which the long-lived service then sees via SQLite WAL and replays into its own log, but with no clue that those events came from a phantom subprocess.

Symptoms in production:
- Duplicate `trash` events for the same trace within the same second, with sequential vclock entries on the cortex's own ID — proving two processes both wrote.
- `consolidation_claim` / `consolidation_fail` noise that has no operational meaning (the short-lived process was never going to run a real pass before the parent killed it).
- Rank-advertisement churn in `federation_state` from multiple eligibility loops overwriting each other's local rank, making the long-lived service's advertised rank flicker based on which transient process last refreshed.

## Approach

A new `internal/lock` package wrapping the OS advisory-lock primitive. `lock.TryAcquire(path)` opens the path, attempts an exclusive non-blocking lock, and returns one of:

- `(lock, true, nil)` — acquired, caller is responsible for `Release` at shutdown
- `(nil, false, nil)` — another process holds it; no error, just contention
- `(nil, false, err)` — hard error (missing parent dir, permission denied, etc.)

`cmd_serve` calls `TryAcquire` on `<cortex>/db/background.lock` early in startup. The four `start*` calls (watcher, consolidator, eligibility, watchdog) are gated on `gotLock`. Lock losers print one log line and continue serving their transport's request handlers without background loops.

## Cross-platform implementation

The package is split into:

- `lock.go` — public API and the shared `Lock` struct. Calls into platform-specific `tryLock` / `unlock` helpers.
- `lock_unix.go` (`//go:build unix`) — wraps `syscall.Flock` with `LOCK_EX | LOCK_NB`. Contention surfaces as `EWOULDBLOCK`.
- `lock_windows.go` (`//go:build windows`) — wraps `windows.LockFileEx` from `golang.org/x/sys/windows` with `LOCKFILE_EXCLUSIVE_LOCK | LOCKFILE_FAIL_IMMEDIATELY`. Contention surfaces as `ERROR_LOCK_VIOLATION`.

Both convert their platform's contention error to `(got=false, err=nil)` so the public API behaves identically. `golang.org/x/sys` was already an indirect dep at v0.42.0 and gets promoted to direct here.

## Why kernel-managed locks (not PID files)

- No stale-lock-file problem to clean up — locks release automatically on process exit, regardless of exit path (clean, SIGTERM, SIGKILL, panic). The whole class of "noema didn't start because a stale lockfile from yesterday's crash blocks it" bugs simply doesn't exist.
- Per-OFD on Unix / per-handle on Windows: each `os.OpenFile` produces an independent open file description, so two processes on the same path each get their own resource and contend correctly.
- No new direct dependency on Unix; on Windows we use `golang.org/x/sys/windows` which was already transitively imported.

## What we keep

- Stdio-only single-node deployments still get full functionality, since their stdio process IS the first to start and wins the lock.
- Multi-process setups (long-lived http + transient stdio) get clean separation: http holds the lock, stdio sessions stay focused on serving MCP calls.
- No transport-conditional logic in `cmd_serve` — works the same regardless of transport mix.

## Test plan

- [x] `go build ./...` (Unix host)
- [x] `GOOS=windows go build ./...` (Windows cross-compile)
- [x] `go vet ./...`
- [x] `GOOS=windows go vet ./...`
- [x] `go test ./...` — all packages green, including 6 lock tests on the Unix path:
  - `TestTryAcquire_FreshPath_Succeeds`
  - `TestTryAcquire_HeldByAnother_ReturnsFalse`
  - `TestTryAcquire_AfterRelease_Reacquirable`
  - `TestRelease_Idempotent`
  - `TestRelease_NilLockSafe`
  - `TestTryAcquire_MissingDirectory_Errors`
- [ ] Deploy to a multi-host ring with active stdio MCP sessions; verify the long-lived http service's journal is the only one logging `[consolidation]` lines and event-log noise drops.
- [ ] Verify a stdio-only single-node setup still gets autoconsolidation (the stdio process holds the lock).
- [ ] Optional: runtime smoke test on Windows once a Windows runner is available. The cross-compile + vet is the current smoke-test ceiling, consistent with the rest of the codebase's testing posture.

## Notes

- The duplicate-watcher problem (two processes each emitting trash events for the same fsnotify trigger) was the smoking gun for needing this fix; the consolidation noise was the more visible symptom but the watcher race was structurally the most worrying because it could lead to genuine state divergence over time.
- This change retroactively addresses a class of issues we'd otherwise have kept seeing: rank churn making election fail rates artificially high, transient processes' watchdogs racing each other, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)