### PR TITLE
fix(lock): move background.lock to runtime dir keyed by cortex ID

### DIFF
--- a/internal/cli/cmd_serve.go
+++ b/internal/cli/cmd_serve.go
@@ -136,7 +136,7 @@ func serveCmd() *cobra.Command {
 			// their schedulers fired briefly before the parent killed them.
 			//
 			// An OS-level advisory lock here picks one process per
-			// cortex dir to own the background work (flock on Unix,
+			// cortex to own the background work (flock on Unix,
 			// LockFileEx on Windows — both with non-blocking
 			// exclusive semantics). Losers fall through to "MCP-only"
 			// mode — they still serve their transport's request
@@ -144,12 +144,48 @@ func serveCmd() *cobra.Command {
 			// kernel auto-releases the lock on process exit (any
 			// path: clean, SIGTERM, SIGKILL, panic), so a crashed
 			// holder hands off cleanly to the next process.
-			lockPath := filepath.Join(cx.Dir, "db", "background.lock")
+			//
+			// The lock file lives in a platform-appropriate runtime
+			// directory keyed by cortex ID, NOT inside the cortex dir
+			// itself. That insulates the lock from sync layers (iCloud
+			// Drive, Dropbox, Syncthing, OneDrive) which would otherwise
+			// replicate the file to other hosts (where it has no
+			// semantic meaning) and could replace the inode underneath
+			// our flock during a sync, leaving us holding a flock on
+			// an orphaned inode. See lock.RuntimePath for details.
+			lockPath, lockPathErr := lock.RuntimePath(cx.ID)
+			if lockPathErr != nil {
+				return fmt.Errorf("resolving lock path: %w", lockPathErr)
+			}
 			bgLock, gotLock, lockErr := lock.TryAcquire(lockPath)
 			if lockErr != nil {
 				return fmt.Errorf("acquiring background lock: %w", lockErr)
 			}
-			if !gotLock {
+			if gotLock {
+				fmt.Fprintf(os.Stderr, "[serve] background lock at %s\n", lockPath)
+				// Best-effort cleanup of the previous-release lock
+				// location. Earlier versions placed background.lock
+				// inside the cortex dir at <cortex>/db/background.lock,
+				// which had the iCloud-replication problem described
+				// above. Now that we hold the new lock, deleting the
+				// old-location file is safe — no other process should
+				// be relying on it (older binaries would have lost the
+				// race for the new location). If removal fails for any
+				// reason, log and move on; an orphaned 0-byte file is
+				// harmless.
+				oldLockPath := filepath.Join(cx.Dir, "db", "background.lock")
+				if _, statErr := os.Stat(oldLockPath); statErr == nil {
+					if rmErr := os.Remove(oldLockPath); rmErr != nil {
+						fmt.Fprintf(os.Stderr,
+							"[serve] could not remove stale lock at %s: %v (harmless, ignore)\n",
+							oldLockPath, rmErr)
+					} else {
+						fmt.Fprintf(os.Stderr,
+							"[serve] removed stale lock from previous location %s\n",
+							oldLockPath)
+					}
+				}
+			} else {
 				fmt.Fprintf(os.Stderr,
 					"[serve] another noema process owns background work for cortex %q; running as MCP-only\n",
 					cx.Name)

--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -29,8 +29,10 @@
 package lock
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sync"
 )
 
@@ -120,3 +122,57 @@ func (l *Lock) Release() error {
 //       got=false, err!=nil: hard error (unrelated to contention)
 //
 //   - unlock(f) error: drops the lock; nil on success
+
+// RuntimePath returns the per-cortex background-work lock path in a
+// runtime/temp location that user-data sync layers (iCloud Drive,
+// Dropbox, Syncthing, OneDrive) won't replicate. Keyed on the cortex's
+// stable ULID so two cortexes with different IDs but the same display
+// name don't collide on shared hosts.
+//
+// Why not <cortex>/db/background.lock (the previous location): when
+// the cortex directory is inside a sync layer, the lock file gets
+// replicated to other devices where it has no semantic meaning, and
+// the sync layer's "replace on sync" can unlink the inode our flock
+// is bound to and create a fresh inode at the same path — leaving us
+// holding a flock on an orphaned inode while a new noema process
+// successfully acquires its own flock on the new file. Putting the
+// lock outside the cortex dir removes both problems uniformly,
+// regardless of which sync layer the user has configured.
+//
+// Cross-host coordination is intentionally given up: kernel flocks
+// are per-host and never propagated across machines anyway, so two
+// hosts mounting the same cortex via a sync layer were always going
+// to each acquire their own local flock. Federation HTTP is the
+// designed cross-host coordination mechanism, not flock.
+//
+// Path resolution prefers $XDG_RUNTIME_DIR (Linux convention,
+// tmpfs-backed when set), else os.TempDir() (which resolves
+// correctly on macOS and Windows: per-user temp under
+// /var/folders on macOS, %TEMP% on Windows).
+//
+// Creates the parent directory with 0700 permissions if missing.
+func RuntimePath(cortexID string) (string, error) {
+	if cortexID == "" {
+		return "", errors.New("cortex ID required for runtime lock path")
+	}
+	base := filepath.Join(runtimeBase(), "noema", cortexID)
+	if err := os.MkdirAll(base, 0o700); err != nil {
+		return "", fmt.Errorf("creating runtime dir %q: %w", base, err)
+	}
+	return filepath.Join(base, "background.lock"), nil
+}
+
+// runtimeBase resolves the platform-appropriate runtime root. On
+// Linux distributions that set $XDG_RUNTIME_DIR (typical on systemd
+// systems — points at a tmpfs under /run/user/$UID), we use that.
+// Otherwise os.TempDir() picks the right per-user temp on every
+// supported platform: confstr(_CS_DARWIN_USER_TEMP_DIR) on macOS,
+// $TMPDIR or /tmp on Linux without XDG_RUNTIME_DIR, %TEMP% on
+// Windows. None of these locations are inside iCloud Drive or
+// equivalent sync roots by default.
+func runtimeBase() string {
+	if xdg := os.Getenv("XDG_RUNTIME_DIR"); xdg != "" {
+		return xdg
+	}
+	return os.TempDir()
+}

--- a/internal/lock/lock_test.go
+++ b/internal/lock/lock_test.go
@@ -1,7 +1,9 @@
 package lock_test
 
 import (
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/Fail-Safe/Noema/internal/lock"
@@ -133,5 +135,146 @@ func TestTryAcquire_MissingDirectory_Errors(t *testing.T) {
 	if l != nil {
 		t.Errorf("lock = %v, want nil on error path", l)
 		l.Release()
+	}
+}
+
+// ---- RuntimePath ----
+
+func TestRuntimePath_ReturnsValidPath(t *testing.T) {
+	// Point the runtime base at a controlled temp dir for the test —
+	// XDG_RUNTIME_DIR takes precedence over os.TempDir() so this is
+	// a portable way to redirect the resolution. We restore the
+	// environment afterward.
+	dir := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", dir)
+
+	const cid = "01TESTCORTEXIDXXXXXXXXXXXX"
+	path, err := lock.RuntimePath(cid)
+	if err != nil {
+		t.Fatalf("RuntimePath: %v", err)
+	}
+	if !strings.HasPrefix(path, dir) {
+		t.Errorf("path %q does not start with runtime root %q", path, dir)
+	}
+	if !strings.Contains(path, cid) {
+		t.Errorf("path %q does not contain cortex ID %q", path, cid)
+	}
+	if filepath.Base(path) != "background.lock" {
+		t.Errorf("path %q does not end in background.lock", path)
+	}
+
+	// Parent directory must exist after the call — TryAcquire opens
+	// the file with O_CREATE but does not mkdir its parents, so
+	// RuntimePath must create them first.
+	if _, statErr := os.Stat(filepath.Dir(path)); statErr != nil {
+		t.Errorf("parent dir not created: %v", statErr)
+	}
+}
+
+func TestRuntimePath_EmptyCortexIDErrors(t *testing.T) {
+	// Empty cortex ID is a programmer error — we'd rather fail
+	// loudly than create a "noema/" directory at the runtime root
+	// shared across all cortexes (which would be a real footgun on
+	// multi-cortex hosts).
+	_, err := lock.RuntimePath("")
+	if err == nil {
+		t.Errorf("error = nil, want non-nil for empty cortex ID")
+	}
+}
+
+func TestRuntimePath_StableAcrossCalls(t *testing.T) {
+	// Two calls with the same cortex ID must produce the same path,
+	// otherwise the lock-acquire / lock-release lifecycle wouldn't
+	// reuse the same file across restarts.
+	dir := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", dir)
+
+	a, err := lock.RuntimePath("01STABLECORTEXIDXXXXXXXXX1")
+	if err != nil {
+		t.Fatalf("first RuntimePath: %v", err)
+	}
+	b, err := lock.RuntimePath("01STABLECORTEXIDXXXXXXXXX1")
+	if err != nil {
+		t.Fatalf("second RuntimePath: %v", err)
+	}
+	if a != b {
+		t.Errorf("paths differ across calls: %q vs %q", a, b)
+	}
+}
+
+func TestRuntimePath_DistinctIDsCollide(t *testing.T) {
+	// Different cortex IDs must produce different paths so two
+	// cortexes on the same host can each hold their own lock
+	// without any cross-cortex interference.
+	dir := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", dir)
+
+	a, err := lock.RuntimePath("01CORTEXAAAAAAAAAAAAAAAAAA")
+	if err != nil {
+		t.Fatalf("first RuntimePath: %v", err)
+	}
+	b, err := lock.RuntimePath("01CORTEXBBBBBBBBBBBBBBBBBB")
+	if err != nil {
+		t.Fatalf("second RuntimePath: %v", err)
+	}
+	if a == b {
+		t.Errorf("distinct IDs collided to the same path: %q", a)
+	}
+}
+
+func TestRuntimePath_HonoursXDGRuntimeDir(t *testing.T) {
+	// XDG_RUNTIME_DIR is the Linux convention for tmpfs-backed
+	// per-user runtime state. When set, we prefer it over
+	// os.TempDir() so on systemd hosts the lock lives under
+	// /run/user/$UID/noema/<cortex-id>/ rather than /tmp.
+	dir := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", dir)
+
+	path, err := lock.RuntimePath("01XDGCORTEXIDXXXXXXXXXXXX1")
+	if err != nil {
+		t.Fatalf("RuntimePath: %v", err)
+	}
+	if !strings.HasPrefix(path, dir) {
+		t.Errorf("XDG_RUNTIME_DIR not honoured: path %q is not under %q", path, dir)
+	}
+}
+
+func TestRuntimePath_FallsBackToTempDir(t *testing.T) {
+	// With XDG_RUNTIME_DIR explicitly cleared, the fallback path
+	// must come from os.TempDir(). On the test host this is
+	// /var/folders/.../T (macOS), /tmp (Linux), or %TEMP% (Windows)
+	// — anywhere except an iCloud/Dropbox/etc. sync root.
+	t.Setenv("XDG_RUNTIME_DIR", "")
+	tmp := os.TempDir()
+
+	path, err := lock.RuntimePath("01FALLBACKCORTEXIDXXXXXXXX")
+	if err != nil {
+		t.Fatalf("RuntimePath: %v", err)
+	}
+	if !strings.HasPrefix(path, tmp) {
+		t.Errorf("fallback to os.TempDir() not honoured: path %q is not under %q", path, tmp)
+	}
+}
+
+func TestRuntimePath_AcquirableViaTryAcquire(t *testing.T) {
+	// End-to-end: RuntimePath returns a path that TryAcquire can
+	// actually open and flock. This catches mode / permission /
+	// parent-dir bugs that the unit tests above would miss.
+	dir := t.TempDir()
+	t.Setenv("XDG_RUNTIME_DIR", dir)
+
+	path, err := lock.RuntimePath("01ACQUIRECORTEXIDXXXXXXXXX")
+	if err != nil {
+		t.Fatalf("RuntimePath: %v", err)
+	}
+	l, got, err := lock.TryAcquire(path)
+	if err != nil {
+		t.Fatalf("TryAcquire: %v", err)
+	}
+	if !got || l == nil {
+		t.Fatalf("expected to acquire fresh runtime lock, got got=%v lock=%v", got, l)
+	}
+	if err := l.Release(); err != nil {
+		t.Errorf("Release: %v", err)
 	}
 }


### PR DESCRIPTION
Closes part of #63 (specifically: structural fix for sync-layer + lock-file interactions).

## Summary

Move the per-cortex background-work lock file out of `<cortex>/db/background.lock` and into a platform-appropriate runtime/temp directory keyed by the cortex's stable ULID. This insulates the flock from user-data sync layers (iCloud Drive, Dropbox, Syncthing, OneDrive) that would otherwise replicate the file across hosts and could replace the inode underneath our open file descriptor during a sync.

## Background

Discovered while diagnosing a "deleted traces resurrect with ` 2` suffix" production incident on an iCloud-synced cortex. Multiple noema processes that predated PR #61 (the original flock work) were each running their own watcher because the flock file lived inside iCloud and the sync layer's behaviour broke single-host coordination. Even with all processes restarted onto the new build, **kernel flocks don't replicate across machines**, so two Macs signed into the same iCloud account would each successfully acquire their own local flock on their own copy of the lock file — the appearance of cross-host coordination without any actual coordination.

Full diagnosis in #63.

## Approach

`internal/lock/lock.go` gains a `RuntimePath(cortexID)` helper that resolves to a per-cortex path under a platform-appropriate runtime root:

- **Linux:** `$XDG_RUNTIME_DIR/noema/<cortex-id>/background.lock` when XDG_RUNTIME_DIR is set (typical on systemd hosts — tmpfs-backed, per-user, designed for runtime state). Else `/tmp/noema/<cortex-id>/background.lock`.
- **macOS:** `$TMPDIR/noema/<cortex-id>/background.lock` — `os.TempDir()` resolves to a per-user dir under `/var/folders/...` on macOS, which is never inside iCloud Drive.
- **Windows:** `%TEMP%\noema\<cortex-id>\background.lock` — `os.TempDir()` resolves to the per-user temp, not inside OneDrive by default.

`os.TempDir()` picks the right base on all three platforms without conditional logic; only `XDG_RUNTIME_DIR` is special-cased on Linux as a preference over `/tmp`.

`cmd_serve.go` calls `RuntimePath(cx.ID)` instead of hardcoding the cortex-relative path, logs the resolved path on startup so operators can see where the lock lives, and best-effort-cleans up any stale lock file at the previous location after successfully acquiring the new lock.

## Why give up cross-host coordination

Kernel flocks have always been per-host — `flock(2)` and `LockFileEx` don't replicate across machines, regardless of any sync layer. The previous lock location *appeared* to coordinate across hosts because the file was in a shared sync root, but two hosts' kernels would each independently grant the lock on their local copies. The "coordination" was theatre.

Federation HTTP is the designed cross-host coordination mechanism. Hosts that want to share a cortex should run noema HTTP endpoints and federate, not mount the same directory via a sync layer.

## Migration

After successfully acquiring the new-location lock, the agent best-effort-deletes any stale lock file at `<cortex>/db/background.lock`. Failure to remove is logged and ignored — an orphaned 0-byte file is harmless. Users with synced cortexes will see the stale file stop being replicated as soon as the upgraded binary runs.

If a user downgrades, the older binary will look at the original path, not find a file, create one, acquire its lock there. The upgraded binary uses the runtime path. The two won't see each other's locks → MCP duplication returns. This is a documented edge case of any path-changing migration; the fix is to not downgrade.

## What we lose

- **Slightly less discoverable.** Operators troubleshooting "where's the lock file?" need to look in `$TMPDIR/noema/<cortex-id>/`. Mitigation: a startup log line prints the resolved path.
- **Stale runtime dirs accumulate** if a cortex is deleted. They're 0-byte sentinel files in temp paths; cleaned at reboot on macOS and tmpfs Linux, persistent on Windows %TEMP% and persistent /tmp. Worst case is a few hundred bytes per orphaned cortex; not worth cleanup logic.

## Test plan

- [x] `go build ./...`
- [x] `GOOS=windows go build ./...`
- [x] `go vet ./...` and `GOOS=windows go vet ./...`
- [x] `go test ./...` — full suite green, including 7 new `RuntimePath` tests:
  - `TestRuntimePath_ReturnsValidPath`
  - `TestRuntimePath_EmptyCortexIDErrors`
  - `TestRuntimePath_StableAcrossCalls`
  - `TestRuntimePath_DistinctIDsCollide`
  - `TestRuntimePath_HonoursXDGRuntimeDir`
  - `TestRuntimePath_FallsBackToTempDir`
  - `TestRuntimePath_AcquirableViaTryAcquire` (end-to-end via TryAcquire)
- [ ] Deploy to a host with an iCloud-synced cortex, restart, verify: lock file appears at the new runtime path, old-location file gets cleaned up, no resurrection on Obsidian deletes.

## Related

Refs #63 (full hazard documentation). Builds on #61 (original flock work) and complements the rest of #63's recommended mitigations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)