### PR TITLE
feat(obsidian): trace-creation modal

### DIFF
--- a/plugins/obsidian/src/create-modal.ts
+++ b/plugins/obsidian/src/create-modal.ts
@@ -1,0 +1,215 @@
+import { App, Modal, Notice, TFile } from "obsidian";
+import type NoemaPlugin from "./main";
+import { CreateTraceParams, TRACE_TYPES, TraceType } from "./mcp-client";
+
+// CreateTraceModal collects the structured frontmatter fields that
+// every trace needs and hands them to McpClient.createTrace, which
+// generates the canonical filename and writes the file via the
+// cortex's mutation method (so origin, content_hash, and the
+// create event all land correctly).
+//
+// The body is intentionally NOT in this modal: a multi-line text
+// area in a modal scales badly past a few sentences and competes
+// with Obsidian's own editor for the same UX role. Instead we
+// create the file with a single-character placeholder body, then
+// open it in the editor so the user can write the real content
+// using the tool they already have open.
+export class CreateTraceModal extends Modal {
+	private titleInput!: HTMLInputElement;
+	private typeSelect!: HTMLSelectElement;
+	private tagsInput!: HTMLInputElement;
+	private derivedFromInput!: HTMLInputElement;
+	private submitBtn!: HTMLButtonElement;
+	private errorEl!: HTMLElement;
+	private submitting = false;
+
+	constructor(app: App, private plugin: NoemaPlugin) {
+		super(app);
+	}
+
+	onOpen(): void {
+		const { contentEl } = this;
+		contentEl.empty();
+		contentEl.addClass("noema-create-modal");
+
+		this.titleEl.setText("New trace");
+
+		this.titleInput = this.row("Title", "input", {
+			type: "text",
+			placeholder: "Why we chose Go",
+		}) as HTMLInputElement;
+
+		this.typeSelect = this.row("Type", "select") as HTMLSelectElement;
+		for (const t of TRACE_TYPES) {
+			const opt = this.typeSelect.createEl("option", { text: t });
+			opt.value = t;
+		}
+		// Default to "note" — the most generic type and the right
+		// fallback when the author hasn't decided yet. Specific types
+		// (decision, fact, etc.) are deliberate choices a user makes
+		// when they know what they're capturing.
+		this.typeSelect.value = "note";
+
+		this.tagsInput = this.row("Tags", "input", {
+			type: "text",
+			placeholder: "go, language, architecture",
+		}) as HTMLInputElement;
+		this.descriptor("Comma- or semicolon-separated. Optional.");
+
+		this.derivedFromInput = this.row("Derived from", "input", {
+			type: "text",
+			placeholder: "20260328-language-candidates, 20260329-runtime-survey",
+		}) as HTMLInputElement;
+		this.descriptor("Comma-separated trace IDs this one is derived from. Optional.");
+
+		this.errorEl = contentEl.createEl("div", { cls: "noema-create-error" });
+		this.errorEl.style.display = "none";
+
+		const buttonRow = contentEl.createEl("div", { cls: "noema-create-buttons" });
+		const cancelBtn = buttonRow.createEl("button", { text: "Cancel" });
+		cancelBtn.addEventListener("click", () => this.close());
+		this.submitBtn = buttonRow.createEl("button", {
+			text: "Create",
+			cls: "mod-cta",
+		});
+		this.submitBtn.addEventListener("click", () => this.submit());
+
+		// Submit on Enter from the title field — most common path.
+		this.titleInput.addEventListener("keydown", (evt) => {
+			if (evt.key === "Enter") {
+				evt.preventDefault();
+				this.submit();
+			}
+		});
+
+		// Focus the title field on open so the user can start typing
+		// immediately. Obsidian focuses the modal's first focusable
+		// element by default but only after a render tick; doing it
+		// explicitly here removes the perceptible lag.
+		setTimeout(() => this.titleInput.focus(), 0);
+	}
+
+	onClose(): void {
+		this.contentEl.empty();
+	}
+
+	private row(
+		label: string,
+		tag: "input" | "select",
+		attrs?: Record<string, string>
+	): HTMLElement {
+		const row = this.contentEl.createEl("div", { cls: "noema-create-row" });
+		row.createEl("label", { text: label });
+		const el = row.createEl(tag);
+		if (attrs) {
+			for (const [k, v] of Object.entries(attrs)) {
+				el.setAttribute(k, v);
+			}
+		}
+		return el;
+	}
+
+	// descriptor adds a small helper line under the most recent
+	// row — used for one-liner field hints that are too long for
+	// the placeholder.
+	private descriptor(text: string): void {
+		this.contentEl.createEl("div", {
+			cls: "noema-create-hint",
+			text,
+		});
+	}
+
+	private async submit(): Promise<void> {
+		if (this.submitting) return;
+		this.errorEl.style.display = "none";
+		this.errorEl.empty();
+
+		const title = this.titleInput.value.trim();
+		if (!title) {
+			this.showError("Title is required.");
+			this.titleInput.focus();
+			return;
+		}
+		const type = this.typeSelect.value as TraceType;
+		const tags = splitDelimited(this.tagsInput.value);
+		const derivedFrom = splitDelimited(this.derivedFromInput.value);
+
+		const client = this.plugin.client;
+		if (!client) {
+			this.showError(
+				"No noema endpoint configured. Set one in Settings → Noema."
+			);
+			return;
+		}
+
+		const params: CreateTraceParams = {
+			title,
+			type,
+			// One-character placeholder body to satisfy the server's
+			// required-body validation. The user fills the real
+			// content in the editor afterwards. We use a NUL-equivalent
+			// glyph that survives YAML/markdown parsing cleanly:
+			// a single space.
+			body: " ",
+			author: this.plugin.settings.defaultAuthor || undefined,
+			tags: tags.length > 0 ? tags : undefined,
+			derivedFrom: derivedFrom.length > 0 ? derivedFrom : undefined,
+		};
+
+		this.submitting = true;
+		this.submitBtn.disabled = true;
+		this.submitBtn.setText("Creating…");
+
+		try {
+			const traceId = await client.createTrace(params);
+			this.close();
+			new Notice(`Created ${traceId}`);
+			await this.openTraceFile(traceId);
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			this.showError(`Couldn't create trace: ${msg}`);
+			this.submitBtn.disabled = false;
+			this.submitBtn.setText("Create");
+		} finally {
+			this.submitting = false;
+		}
+	}
+
+	// openTraceFile waits for Obsidian to notice the new file (fsnotify
+	// lag from the server-side write) and opens it in the active leaf.
+	// Retry budget is short — if the file genuinely never appears the
+	// caller saw the success notice anyway, so silently giving up is
+	// preferable to a stuck loading state.
+	private async openTraceFile(traceId: string): Promise<void> {
+		const folder = this.plugin.settings.tracesFolder.replace(/\/+$/, "");
+		const path = `${folder}/${traceId}.md`;
+		for (let i = 0; i < 20; i++) {
+			const file = this.app.vault.getFileByPath(path);
+			if (file instanceof TFile) {
+				await this.app.workspace.getLeaf(false).openFile(file);
+				return;
+			}
+			await sleep(100);
+		}
+	}
+
+	private showError(text: string): void {
+		this.errorEl.setText(text);
+		this.errorEl.style.display = "";
+	}
+}
+
+// splitDelimited turns "go, language; architecture" into
+// ["go", "language", "architecture"]. Tolerates either separator
+// because users invariably mix them.
+function splitDelimited(raw: string): string[] {
+	if (!raw) return [];
+	return raw
+		.split(/[,;]/)
+		.map((s) => s.trim())
+		.filter(Boolean);
+}
+
+function sleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/plugins/obsidian/src/main.ts
+++ b/plugins/obsidian/src/main.ts
@@ -3,6 +3,7 @@ import { DEFAULT_SETTINGS, NoemaSettings, NoemaSettingTab } from "./settings";
 import { LineageView, LINEAGE_VIEW_TYPE } from "./lineage-view";
 import { McpClient } from "./mcp-client";
 import { readTraceMetadata, tierGlyph, tierLabel } from "./tier-status";
+import { CreateTraceModal } from "./create-modal";
 
 const STATUS_PING_INTERVAL_MS = 30_000;
 
@@ -55,6 +56,14 @@ export default class NoemaPlugin extends Plugin {
 						await view.refreshFromActive();
 					}
 				}
+			},
+		});
+
+		this.addCommand({
+			id: "create-trace",
+			name: "New trace",
+			callback: () => {
+				new CreateTraceModal(this.app, this).open();
 			},
 		});
 

--- a/plugins/obsidian/src/mcp-client.ts
+++ b/plugins/obsidian/src/mcp-client.ts
@@ -54,6 +54,35 @@ export interface Lineage {
 	derivedBy: string[];
 }
 
+// TraceType matches the cortex's trace-type enum. Surfaced as a
+// shared constant so the create-trace modal and any future tier-aware
+// UI can populate dropdowns from one source of truth that tracks the
+// server's accepted values.
+export const TRACE_TYPES = [
+	"fact",
+	"decision",
+	"preference",
+	"context",
+	"skill",
+	"intent",
+	"observation",
+	"note",
+] as const;
+export type TraceType = (typeof TRACE_TYPES)[number];
+
+// CreateTraceParams is the input shape for McpClient.createTrace.
+// tags and derivedFrom are arrays at this layer for caller ergonomics;
+// they get joined to the comma-separated wire format the server
+// expects inside createTrace.
+export interface CreateTraceParams {
+	title: string;
+	type: TraceType;
+	body: string;
+	author?: string;
+	tags?: string[];
+	derivedFrom?: string[];
+}
+
 // Streamable-HTTP MCP servers (per the 2025-03-26 spec) bind every
 // JSON-RPC request to a server-allocated session id. The lifecycle is:
 //
@@ -106,6 +135,37 @@ export class McpClient {
 	async traceLineage(traceId: string): Promise<Lineage> {
 		const text = await this.callToolText("trace_lineage", { id: traceId });
 		return parseLineage(text, traceId);
+	}
+
+	// createTrace invokes the create_trace MCP tool. The server
+	// generates the canonical YYYYMMDD-<slug>.md filename, computes
+	// the content_hash, sets origin to the local cortex name, and
+	// emits the create event in the same transaction. Returns the
+	// freshly-allocated trace ID parsed out of the server's
+	// "Trace created: <id>" response.
+	//
+	// body is required by the server schema; pass at least a single
+	// placeholder character if the caller wants to fill content in
+	// the editor afterwards. tags and derivedFrom come in as arrays
+	// for caller ergonomics and get joined into comma-separated
+	// strings (the wire shape the server expects).
+	async createTrace(params: CreateTraceParams): Promise<string> {
+		const args: Record<string, unknown> = {
+			title: params.title,
+			type: params.type,
+			body: params.body,
+		};
+		if (params.author) args.author = params.author;
+		if (params.tags && params.tags.length > 0) args.tags = params.tags.join(",");
+		if (params.derivedFrom && params.derivedFrom.length > 0) {
+			args.derived_from = params.derivedFrom.join(",");
+		}
+		const text = await this.callToolText("create_trace", args);
+		const match = text.match(/Trace created:\s*(\S+)/);
+		if (!match) {
+			throw new Error(`create_trace: unexpected response shape: ${text}`);
+		}
+		return match[1];
 	}
 
 	// callToolText invokes a tool and returns the concatenated text

--- a/plugins/obsidian/src/settings.ts
+++ b/plugins/obsidian/src/settings.ts
@@ -5,17 +5,22 @@ export interface NoemaSettings {
 	endpoint: string;
 	bearerKey: string;
 	tracesFolder: string;
+	defaultAuthor: string;
 }
 
 // DEFAULT_SETTINGS deliberately leave endpoint and bearerKey empty so
 // the plugin starts in "disconnected" state on a fresh install rather
 // than blindly trying to reach a localhost URL. tracesFolder defaults
 // to "traces" because that's the cortex layout convention; users with
-// a non-standard layout (rare) can override.
+// a non-standard layout (rare) can override. defaultAuthor is empty
+// by default — the create-trace flow omits the author field entirely
+// when the setting is empty, letting the cortex's own author logic
+// decide what to record.
 export const DEFAULT_SETTINGS: NoemaSettings = {
 	endpoint: "",
 	bearerKey: "",
 	tracesFolder: "traces",
+	defaultAuthor: "",
 };
 
 export class NoemaSettingTab extends PluginSettingTab {
@@ -72,6 +77,21 @@ export class NoemaSettingTab extends PluginSettingTab {
 					.setValue(this.plugin.settings.tracesFolder)
 					.onChange(async (value) => {
 						this.plugin.settings.tracesFolder = value.trim() || "traces";
+						await this.plugin.saveSettings();
+					})
+			);
+
+		new Setting(containerEl)
+			.setName("Default author")
+			.setDesc(
+				"Stamped on traces created via the 'New trace' command. Leave empty to let the cortex's default apply. Free-form — typical values are a username, agent name, or 'agent/handle'."
+			)
+			.addText((text) =>
+				text
+					.setPlaceholder("e.g. alice or agent/researcher-1")
+					.setValue(this.plugin.settings.defaultAuthor)
+					.onChange(async (value) => {
+						this.plugin.settings.defaultAuthor = value.trim();
 						await this.plugin.saveSettings();
 					})
 			);

--- a/plugins/obsidian/styles.css
+++ b/plugins/obsidian/styles.css
@@ -144,3 +144,46 @@
 	font-style: italic;
 	padding: 8px 0;
 }
+
+/* ---- Create-trace modal ---- */
+
+.noema-create-modal .noema-create-row {
+	display: grid;
+	grid-template-columns: 120px 1fr;
+	gap: 8px;
+	align-items: center;
+	margin-bottom: 8px;
+}
+
+.noema-create-modal .noema-create-row label {
+	color: var(--text-muted);
+	font-size: var(--font-ui-smaller);
+	text-align: right;
+}
+
+.noema-create-modal .noema-create-row input,
+.noema-create-modal .noema-create-row select {
+	width: 100%;
+}
+
+.noema-create-modal .noema-create-hint {
+	color: var(--text-faint);
+	font-size: var(--font-ui-smaller);
+	margin: -4px 0 8px 128px;
+}
+
+.noema-create-modal .noema-create-error {
+	color: var(--text-error);
+	font-size: var(--font-ui-smaller);
+	margin: 8px 0;
+	padding: 6px 8px;
+	background: var(--background-modifier-error);
+	border-radius: 4px;
+}
+
+.noema-create-modal .noema-create-buttons {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+	margin-top: 12px;
+}


### PR DESCRIPTION
## Summary

Adds a **Noema: New trace** command to the Obsidian plugin that opens a modal collecting the structured frontmatter every trace needs (title, type, tags, derived_from), then calls `create_trace` MCP and opens the new file in the editor for the body. Eliminates the YAML-by-hand workflow and the typo-prone frontmatter authoring it involves.

## Tier 1 of the post-#62 roadmap

This is the first of three Tier-1 features identified after the v0.1 plugin landed:
1. **Trace-creation modal** ← this PR
2. Source-locked / immutable warning bar — coming next
3. Tier transition commands — TBD

## What it does

- ⌘P → "Noema: New trace" opens a modal with:
  - **Title** (text, required) — submits on Enter for the common case.
  - **Type** (dropdown of 9 types: fact / decision / preference / context / skill / intent / observation / note). Defaults to `note`.
  - **Tags** (comma- or semicolon-delimited, optional).
  - **Derived from** (comma-delimited trace IDs, optional).
- On submit:
  - Calls `client.createTrace(...)`, which routes through the `create_trace` MCP tool. The server generates the canonical `YYYYMMDD-<slug>.md` filename, computes `content_hash`, stamps `origin` from the local cortex, and emits a `create` event in the same DB transaction.
  - Shows a Notice with the new trace ID.
  - Polls the vault metadata cache for up to ~2s to pick up the file Obsidian hasn't yet indexed via fsnotify, then opens it in the active leaf so the user can fill in body content.
- A new optional `Default author` setting stamps the configured author on each create. Empty preserves the previous behaviour.

## Body content is intentionally NOT in the modal

A multi-line text area in a modal scales badly past a few sentences and would duplicate the role Obsidian's editor already plays. We create the file with a single-character placeholder body (server requires non-empty), and the user writes the real content in the editor afterwards. That keeps the modal small and tightens the focus on the structured fields the editor doesn't help with.

## Files

- New: `plugins/obsidian/src/create-modal.ts` (~200 lines incl. comments).
- Modified: `mcp-client.ts` (new `TRACE_TYPES` const, `CreateTraceParams` interface, `createTrace` method).
- Modified: `main.ts` (new command registration).
- Modified: `settings.ts` (new optional `defaultAuthor` field).
- Modified: `styles.css` (modal layout — uses Obsidian theme variables for colours).

## Test plan

- [x] `npm install` + `npm run build` produces `main.js` (~16KB, up from ~12KB).
- [x] `npx tsc --noEmit` clean.
- [x] `go build ./...` and `go vet ./...` clean (no Go changes; sanity).
- [ ] Manual: enable plugin, ⌘P → "Noema: New trace", create a few test traces. Verify ID generation, frontmatter correctness, file opens for editing.
- [ ] Manual: create with `derived_from` referencing existing traces; verify lineage view of the new trace shows the parent.
- [ ] Manual: empty title → error message in modal; doesn't submit.
- [ ] Manual: disconnected endpoint → error message that says to configure the endpoint.

## Out of scope (for separate PRs)

- Trace-ID autocomplete in the Derived from field (requires a fuzzy-search picker over the metadata cache; more design surface than this PR).
- Tag autocomplete from existing traces.
- Body-templating (per-type templates that pre-populate common headings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)