### PR TITLE
feat(obsidian): immutable / source-locked warning banner

### DIFF
--- a/plugins/obsidian/src/immutable-warning.ts
+++ b/plugins/obsidian/src/immutable-warning.ts
@@ -1,0 +1,144 @@
+import { App, MarkdownView, TFile } from "obsidian";
+import type NoemaPlugin from "./main";
+
+// ImmutableWarning manages a banner injected above the editor for any
+// trace whose state means the cortex will reject in-editor edits:
+//
+//   - tier=long: long-tier traces are immutable except via tier_votes.
+//     Editing the body and saving produces a content_hash mismatch
+//     that the cortex's content-locked guard refuses.
+//
+//   - source_locked=true AND origin != local cortex name: the trace
+//     came from a peer and is marked source-locked; the local cortex
+//     will refuse Update/Trash/Remove. Edits made in Obsidian get
+//     rolled back the next time the watcher reconciles.
+//
+// The banner is intentionally non-dismissable — these are persistent
+// invariants of the trace, not transient notifications. A dismiss
+// affordance would invite the user to forget and edit anyway, then
+// be confused when their changes silently revert.
+//
+// Lifecycle: on active-leaf-change and on metadata-cache changes we
+// re-evaluate the active file and either inject, update, or remove
+// the banner. On plugin unload, removeAll() cleans up any lingering
+// banner DOM so a reload doesn't leave orphan elements behind.
+export class ImmutableWarning {
+	private bannerEl: HTMLElement | null = null;
+	private currentFile: TFile | null = null;
+
+	constructor(private app: App, private plugin: NoemaPlugin) {}
+
+	// refresh re-evaluates the currently active file and updates the
+	// banner state. Safe to call as often as the host triggers UI
+	// events; we cheaply skip work when nothing changed.
+	refresh(): void {
+		const view = this.app.workspace.getActiveViewOfType(MarkdownView);
+		if (!view) {
+			this.removeBanner();
+			return;
+		}
+		const file = view.file;
+		if (!file) {
+			this.removeBanner();
+			return;
+		}
+		const reason = this.shouldWarn(file);
+		if (!reason) {
+			this.removeBanner();
+			return;
+		}
+		this.showBanner(view, file, reason);
+	}
+
+	removeAll(): void {
+		this.removeBanner();
+	}
+
+	private shouldWarn(file: TFile): WarningReason | null {
+		const cache = this.app.metadataCache.getFileCache(file);
+		const fm = cache?.frontmatter;
+		if (!fm) return null;
+
+		// tier=long check first because it doesn't depend on knowing
+		// our own cortex identity — the warning is correct regardless
+		// of MCP connection state.
+		const tier = typeof fm.tier === "string" ? fm.tier.toLowerCase() : "";
+		if (tier === "long") {
+			return { kind: "long-tier" };
+		}
+
+		// source_locked check requires knowing the local cortex name
+		// to determine "is this origin foreign?". When disconnected,
+		// plugin.cortexName is empty and we conservatively skip rather
+		// than risk a misleading "from peer" label that points at our
+		// own cortex.
+		const sourceLocked = fm.source_locked === true || fm.source_locked === "true";
+		const origin = typeof fm.origin === "string" ? fm.origin : "";
+		const localCortex = this.plugin.cortexName;
+		if (sourceLocked && origin && localCortex && origin !== localCortex) {
+			return { kind: "source-locked", origin };
+		}
+		return null;
+	}
+
+	private showBanner(view: MarkdownView, file: TFile, reason: WarningReason): void {
+		// If we already have a banner for this file with the same
+		// reason, leave it alone — re-rendering on every event would
+		// produce visible flicker. Cheap by-reference equality plus
+		// reason kind covers the common case.
+		if (
+			this.bannerEl &&
+			this.currentFile === file &&
+			this.bannerEl.dataset.kind === reason.kind
+		) {
+			return;
+		}
+		this.removeBanner();
+
+		const target = view.containerEl.querySelector(".view-content");
+		if (!(target instanceof HTMLElement)) {
+			// Layout shape changed in some Obsidian version we don't
+			// recognize. Better to skip silently than throw — the
+			// banner is a nice-to-have, not load-bearing.
+			return;
+		}
+
+		const banner = document.createElement("div");
+		banner.className = "noema-immutable-warning";
+		banner.dataset.kind = reason.kind;
+
+		const glyph = banner.createSpan({ cls: "noema-immutable-warning-glyph" });
+		glyph.setText(reason.kind === "long-tier" ? "[L]" : "[locked]");
+
+		const text = banner.createSpan({ cls: "noema-immutable-warning-text" });
+		if (reason.kind === "long-tier") {
+			text.setText(
+				"Long-tier trace — immutable except via tier_votes. Edits will not be accepted by the cortex."
+			);
+		} else {
+			text.setText(
+				`Source-locked trace from peer "${reason.origin}" — local edits will not be accepted by the cortex.`
+			);
+		}
+
+		target.prepend(banner);
+		this.bannerEl = banner;
+		this.currentFile = file;
+	}
+
+	private removeBanner(): void {
+		if (this.bannerEl) {
+			this.bannerEl.remove();
+			this.bannerEl = null;
+		}
+		this.currentFile = null;
+	}
+}
+
+// WarningReason is an intentional sum-type so showBanner can render
+// reason-specific copy without a chain of optional fields. New reason
+// kinds (e.g. archived, divergence, content_hash mismatch) plug in
+// here without changing the call site.
+type WarningReason =
+	| { kind: "long-tier" }
+	| { kind: "source-locked"; origin: string };

--- a/plugins/obsidian/src/main.ts
+++ b/plugins/obsidian/src/main.ts
@@ -3,6 +3,7 @@ import { DEFAULT_SETTINGS, NoemaSettings, NoemaSettingTab } from "./settings";
 import { LineageView, LINEAGE_VIEW_TYPE } from "./lineage-view";
 import { McpClient } from "./mcp-client";
 import { readTraceMetadata, tierGlyph, tierLabel } from "./tier-status";
+import { ImmutableWarning } from "./immutable-warning";
 
 const STATUS_PING_INTERVAL_MS = 30_000;
 
@@ -22,9 +23,13 @@ const STATUS_PING_INTERVAL_MS = 30_000;
 export default class NoemaPlugin extends Plugin {
 	settings: NoemaSettings = DEFAULT_SETTINGS;
 	client: McpClient | null = null;
+	// cortexName is exposed (not private) because immutable-warning
+	// needs it to decide whether a source_locked trace's origin is
+	// "foreign" (warn) or local (don't warn).
+	cortexName = "";
 	private statusBarEl: HTMLElement | null = null;
-	private cortexName = "";
 	private connected = false;
+	private immutableWarning: ImmutableWarning | null = null;
 
 	async onload(): Promise<void> {
 		await this.loadSettings();
@@ -58,14 +63,27 @@ export default class NoemaPlugin extends Plugin {
 			},
 		});
 
-		// Re-render the status bar when the active file changes so the
-		// tier glyph follows the user across files.
+		this.immutableWarning = new ImmutableWarning(this.app, this);
+
+		// Re-render the status bar AND immutable-warning banner when
+		// the active file changes (tier glyph follows the user) or
+		// when frontmatter changes (a tier promotion to long would
+		// flip the warning state without an active-leaf-change).
 		this.registerEvent(
-			this.app.workspace.on("active-leaf-change", () => this.renderStatus())
+			this.app.workspace.on("active-leaf-change", () => {
+				this.renderStatus();
+				this.immutableWarning?.refresh();
+			})
 		);
 		this.registerEvent(
-			this.app.metadataCache.on("changed", () => this.renderStatus())
+			this.app.metadataCache.on("changed", () => {
+				this.renderStatus();
+				this.immutableWarning?.refresh();
+			})
 		);
+		// Initial render in case a trace file is already open at
+		// plugin start.
+		this.immutableWarning.refresh();
 
 		// Initial connection probe + periodic ping. We don't block
 		// onload on this — a missing or unreachable endpoint at
@@ -82,6 +100,10 @@ export default class NoemaPlugin extends Plugin {
 		// preserves view state across plugin reloads when the plugin
 		// re-registers the same view type, which is a better UX than
 		// closing the panel on every plugin restart during dev.
+
+		// Clean up any lingering banner DOM so a plugin reload during
+		// active development doesn't leave orphan elements behind.
+		this.immutableWarning?.removeAll();
 	}
 
 	async loadSettings(): Promise<void> {

--- a/plugins/obsidian/styles.css
+++ b/plugins/obsidian/styles.css
@@ -144,3 +144,28 @@
 	font-style: italic;
 	padding: 8px 0;
 }
+
+/* ---- Immutable / source-locked warning ---- */
+
+.noema-immutable-warning {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+	padding: 8px 12px;
+	margin: 8px 12px;
+	border-radius: 6px;
+	background: var(--background-modifier-border-hover);
+	border-left: 3px solid var(--text-warning, var(--text-accent));
+	font-size: var(--font-ui-smaller);
+}
+
+.noema-immutable-warning-glyph {
+	font-family: var(--font-monospace);
+	font-weight: 600;
+	color: var(--text-warning, var(--text-accent));
+	flex-shrink: 0;
+}
+
+.noema-immutable-warning-text {
+	color: var(--text-normal);
+}


### PR DESCRIPTION
## Summary

Adds a non-dismissable banner above the editor for any trace where the cortex will reject in-editor edits — long-tier traces (immutable except via tier_votes) and source-locked traces from a foreign origin. Eliminates a class of "I edited it, why didn't it stick?" confusion.

## Tier 1 of the post-#62 roadmap

This is the second of three Tier-1 features. Pair-PR with #65 (trace-creation modal).

## Trigger conditions

Banner shows when:

1. **`tier == "long"`** — body edits will produce a `content_hash` mismatch the cortex's content-locked guard refuses.
2. **`source_locked == true` AND `origin != local cortex name`** — the trace came from a peer and the consumer-side guard refuses `Update` / `Trash` / `Remove`.

Both conditions render different copy:

- Long: `[L] Long-tier trace — immutable except via tier_votes. Edits will not be accepted by the cortex.`
- Source-locked: `[locked] Source-locked trace from peer "<origin>" — local edits will not be accepted by the cortex.`

## Why non-dismissable

These are persistent invariants of the trace, not transient notifications. A dismiss affordance would invite the user to forget and edit anyway, then be confused when changes silently revert. The banner is small (one row, theme-tinted) and stays out of the way.

## Disconnected handling

The source-locked check requires knowing the local cortex name to classify origin as foreign vs. local. When disconnected from MCP, `plugin.cortexName` is empty; in that case we skip the source-locked warning rather than risk a misleading "from peer" label that points at our own cortex. The tier=long check has no such dependency and works offline.

## Lifecycle

`refresh()` runs on:
- `active-leaf-change` — when the user opens a different file
- `metadataCache.on("changed")` — when frontmatter changes (so a tier promotion to long flips the banner state without requiring a leaf change)
- Plugin start (initial render)

On unload, `removeAll()` cleans up any lingering banner DOM so a plugin reload during dev doesn't leave orphan elements behind.

## Files

- New: `plugins/obsidian/src/immutable-warning.ts` (~140 lines incl. comments)
- Modified: `main.ts` (instance + lifecycle wiring; expose `cortexName` for the warning to read)
- Modified: `styles.css` (banner appearance — theme variables only, plays nicely with dark/light themes)

## Test plan

- [x] `npm run build` clean (~14KB main.js)
- [x] `npx tsc --noEmit` clean
- [x] `go build ./...` and `go vet ./...` clean (no Go changes; sanity)
- [ ] Manual: open a long-tier trace, see `[L]` banner.
- [ ] Manual: open a source-locked trace from a peer, see `[locked]` banner with the peer's origin name.
- [ ] Manual: open a regular short-tier trace, no banner.
- [ ] Manual: disconnect MCP, open a source-locked trace — no banner (correct, we don't know which is local).
- [ ] Manual: promote a trace to long via TUI/CLI while file is open in Obsidian, banner appears without leaf change (`metadataCache.on("changed")` path).

## Out of scope (separate PRs)

- Edit blocking: the banner is informational, doesn't actually prevent typing. Could be future work to make the editor read-only when the warning is shown — but Obsidian's read-only flag is at the file level which isn't quite right semantically (it's the *cortex* that's enforcing immutability, not the file). Banner is the right level for now.
- Other warning conditions: `archived_at != null`, `divergence` type, content_hash mismatch detection. Each is a clean follow-up if the pattern earns its keep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)