### PR TITLE
feat(cli): add 'noema append' for pipe-friendly body appends

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ noema add [flags]                         Add a Trace (interactive if flags omit
 noema list [flags]                        List Traces
 noema get <id>                            Show a Trace
 noema edit <id>                           Edit a Trace in $EDITOR
+noema append <id> [--content <text>]      Append to a Trace body (pipe-friendly: `echo X | noema append <id>`)
 noema remove <id>                         Move a Trace to trash (--force to hard-delete)
 noema recover <id>                        Restore a Trace from trash
 noema purge [--days N]                    Permanently delete all trashed Traces older than N days

--- a/internal/cli/cmd_append.go
+++ b/internal/cli/cmd_append.go
@@ -1,0 +1,103 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Fail-Safe/Noema/internal/cortex"
+)
+
+// appendCmd wraps cortex.Append for the human-at-terminal and pipe-
+// from-script use cases. The MCP `append_trace` tool already exposes
+// the same operation to agents; this fills the matching CLI gap so a
+// shell user can run `echo "..." | noema append <id>` without
+// reaching for `edit` (which fires up $EDITOR and overshoots the use
+// case).
+//
+// Why not under `noema memory`: the memory subcommand group is for
+// tiering admin and observability (promote / demote / purge / stats).
+// Append is a body mutation on an existing trace, conceptually
+// peers with `add` (new trace) and `edit` (open in $EDITOR), so it
+// belongs at top level alongside them.
+func appendCmd() *cobra.Command {
+	var (
+		content string
+		force   bool
+	)
+
+	cmd := &cobra.Command{
+		Use:   "append <id>",
+		Short: "Append content to an existing Trace's body",
+		Long: `Append content to an existing Trace's body. Pipe-friendly:
+useful for running journals, fire-and-forget logging, and any case where
+another process needs to add a line or two to a Trace without reading
+the full current body first.
+
+Content sources, in priority order:
+  --content "text"                       one-liner via flag
+  echo "text" | noema append <id>        piped from stdin (no flag needed)
+  noema append <id>                      interactive: type, Ctrl+D to save
+
+A newline is inserted between the existing body and the appended
+content if the existing body doesn't end with one. The cortex emits an
+update event for the append, so the change replicates through
+federation like any other body edit.`,
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: completionsFor(cortex.ListOptions{}),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cx, err := resolveCortex()
+			if err != nil {
+				return err
+			}
+			defer cx.Close()
+
+			id := args[0]
+
+			// Resolve content from flag, pipe, or interactive prompt.
+			// Flag wins; otherwise we sniff stdin's mode so a piped
+			// invocation reads silently while a tty invocation prints
+			// a prompt and waits for Ctrl+D — same convention as
+			// `noema add` for body input.
+			if content == "" && !cmd.Flags().Changed("content") {
+				fi, _ := os.Stdin.Stat()
+				piped := (fi.Mode() & os.ModeCharDevice) == 0
+				if !piped {
+					fmt.Println("Content to append (Ctrl+D to save, Ctrl+C to cancel):")
+				}
+				data, err := readBodyFromStdin()
+				if err != nil {
+					return err
+				}
+				content = data
+			}
+			if content == "" {
+				return fmt.Errorf("no content provided to append")
+			}
+
+			// Source-lock bypass — mirrors the edit/archive convention
+			// so users have one consistent override across mutation
+			// commands. Only takes effect for THIS process's call to
+			// Append; it does not persist.
+			if force {
+				cx.SetForceSourceLock(true)
+			}
+
+			if err := cx.Append(id, content); err != nil {
+				if errors.Is(err, cortex.ErrSourceLocked) {
+					return fmt.Errorf("%w (use --force to override)", err)
+				}
+				return err
+			}
+			fmt.Printf("Appended to trace %s.\n", id)
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&content, "content", "",
+		"content to append (use stdin or interactive prompt if omitted)")
+	cmd.Flags().BoolVarP(&force, "force", "f", false,
+		"bypass source-lock protection")
+	return cmd
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -79,7 +79,7 @@ func init() {
 	)
 
 	addGrouped(groupTrace,
-		addCmd(), listCmd(), getCmd(), editCmd(), removeCmd(),
+		addCmd(), listCmd(), getCmd(), editCmd(), appendCmd(), removeCmd(),
 		searchCmd(), archiveCmd(), unarchiveCmd(), recoverCmd(), purgeCmd(), syncCmd(),
 		eventsCmd(), resolveCmd(), memoryCmd(), consolidateCmd(),
 	)


### PR DESCRIPTION
## Summary

Closes the CLI gap for body-append. The MCP server has exposed `append_trace` since v0.1 — agents already use it for fire-and-forget logging — but the CLI didn't have a matching command, leaving shell-driven workflows without a clean way to append to a Trace.

## Why this matters

For any project that drives Noema from a script (cron job, log processor, daemon writing to a running journal), the existing options were both bad:

- `noema edit <id>` fires up `$EDITOR` — overshoots for a one-line append and breaks any non-interactive pipeline.
- Editing the markdown file directly bypasses the cortex's mutation methods, so `content_hash` and the `update` event don't get emitted correctly. The watcher would catch the file change but route it as an external update, not an append.

`noema append` calls `cortex.Append(id, content)` — same code path the MCP `append_trace` tool uses — so federation events, content-hash recomputation, and source-lock enforcement all behave identically whether the caller is an agent or a shell pipeline.

## Three input modes

In priority order:

```
noema append <id> --content "one-liner"             # flag wins
echo "piped content" | noema append <id>             # stdin (no flag)
noema append <id>                                    # interactive: type, Ctrl+D to save
```

Stdin mode is the primary use case driving this change — `echo X | noema append <id>` is exactly what shell-driven integrations need.

## Why a top-level command (not under `noema memory`)

`noema memory ...` is the subcommand group for tiering admin and observability (promote, demote, purge, stats). Append is a body mutation on an existing trace — same conceptual category as `add` (new) and `edit` (open in editor). It belongs at top level alongside them.

## Files

- New: `internal/cli/cmd_append.go` (~95 lines incl. comments)
- Modified: `internal/cli/root.go` (add to `groupTrace`)
- Modified: `README.md` (CLI command listing)

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` clean (existing `cortex.Append` tests cover the underlying operation; CLI plumbing is small enough that the existing pattern doesn't add per-command tests)
- [x] Manual end-to-end against a temp cortex: all three input modes work, body assembled correctly with newline separation
- [x] Tab completion for trace IDs works (mirrors edit/archive via `completionsFor(cortex.ListOptions{})`)
- [ ] Source-locked + `--force` smoke test
- [ ] Federation replication smoke test (append on one peer, observe update event on another)

## What's not in this PR

- No Obsidian plugin command. That can land later as Tier-2 plugin work; this PR is focused on the CLI side specifically.
- No retry-on-conflict logic. `cortex.Append` is atomic at the SQL transaction level; if there's contention on the same trace, the loser sees an error and can retry — we don't add retry logic to the command itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)