### PR TITLE
feat(release): bundle noema-obsidian-plugin.tar.gz alongside hermes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,18 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          # Node is needed for the GoReleaser pre-hook that builds
+          # the Obsidian plugin (esbuild via npm). Pinning to 20 keeps
+          # the build reproducible across runner-image updates;
+          # ubuntu-latest already ships Node 20+ but explicit is
+          # better than implicit for release tooling.
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: plugins/obsidian/package-lock.json
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,6 +31,24 @@ before:
     - go mod tidy
     # Bundle the Hermes memory provider plugin as a release asset.
     - tar -czf noema-hermes-plugin.tar.gz -C plugins hermes
+    # Build and bundle the Obsidian plugin as a release asset. The
+    # tarball contains only the runtime artifacts the user drops into
+    # <vault>/.obsidian/plugins/noema/ — manifest.json, main.js,
+    # styles.css, README — wrapped in a "noema/" directory so end
+    # users can `tar -xzf … -C <vault>/.obsidian/plugins/` and have
+    # the right layout in one step (mirrors the hermes plugin's
+    # directory-rooted convention).
+    #
+    # Why staging dir instead of `tar --transform`: GNU tar supports
+    # --transform but BSD tar (macOS, FreeBSD) does not, and operators
+    # want to be able to `goreleaser release --snapshot` locally on
+    # any platform. The portable path is to copy into a temp dir.
+    #
+    # Node + npm are preinstalled on ubuntu-latest GitHub runners; we
+    # add a setup-node step in release.yml regardless to pin the
+    # version and keep CI immune to runner-image drift.
+    - bash -c "cd plugins/obsidian && npm ci --silent && npm run build"
+    - bash -c "rm -rf .release-obsidian && mkdir -p .release-obsidian/noema && cp plugins/obsidian/manifest.json plugins/obsidian/main.js plugins/obsidian/styles.css plugins/obsidian/README.md .release-obsidian/noema/ && tar -czf noema-obsidian-plugin.tar.gz -C .release-obsidian noema && rm -rf .release-obsidian"
 
 builds:
   - id: noema
@@ -123,6 +141,7 @@ release:
     require a manual step ship with an explicit `noema migrate` command.**
   extra_files:
     - glob: ./noema-hermes-plugin.tar.gz
+    - glob: ./noema-obsidian-plugin.tar.gz
   footer: |
     ---
     **Install:** see [README — Installation](https://github.com/Fail-Safe/Noema#installation).


### PR DESCRIPTION
## Summary

The Obsidian plugin landed in #62 / v0.10.0-beta.4 but had no parallel release artifact — users wanting the plugin had to clone and build it themselves. Add a `noema-obsidian-plugin.tar.gz` to the GoReleaser pipeline alongside the existing `noema-hermes-plugin.tar.gz`.

## How

Two GoReleaser `before:` hooks:

```yaml
- bash -c "cd plugins/obsidian && npm ci --silent && npm run build"
- bash -c "rm -rf .release-obsidian && mkdir -p .release-obsidian/noema && \
           cp plugins/obsidian/{manifest.json,main.js,styles.css,README.md} .release-obsidian/noema/ && \
           tar -czf noema-obsidian-plugin.tar.gz -C .release-obsidian noema && \
           rm -rf .release-obsidian"
```

Plus the tarball added to `extra_files`.

`release.yml` gets an explicit `actions/setup-node@v4` step pinned to Node 20.

## Why a staging dir

GNU tar supports `--transform` for renaming entries on the fly, but BSD tar (macOS, FreeBSD) does not. Operators need to be able to `goreleaser release --snapshot` locally on any platform, so the portable path is a temp directory. Costs ~2ms per build; trivially worth the cross-platform reproducibility.

## What end users see

```sh
# After downloading from the release page:
tar -xzf noema-obsidian-plugin.tar.gz -C <vault>/.obsidian/plugins/
```

Lands in `<vault>/.obsidian/plugins/noema/` with the four files Obsidian needs (`manifest.json`, `main.js`, `styles.css`, `README.md`). Same one-step extract pattern as the hermes plugin.

## Verified locally

```
$ goreleaser release --snapshot --clean --skip=publish
...
$ ls -la noema-obsidian-plugin.tar.gz
-rw-r--r--@ 7076 noema-obsidian-plugin.tar.gz
$ tar -tzf noema-obsidian-plugin.tar.gz
noema/
noema/styles.css
noema/README.md
noema/main.js
noema/manifest.json
```

## Test plan

- [x] `goreleaser release --snapshot --clean --skip=publish` succeeds
- [x] Resulting `noema-obsidian-plugin.tar.gz` is 7 KB (build output, not source) — sanity that we shipped the build artifact, not the TypeScript src
- [x] Tarball contains exactly four files wrapped in `noema/` dir
- [ ] Next tag push exercises the workflow end-to-end on CI; the Node 20 pin should make this reproducible
- [ ] User-facing install: download tarball, `tar -xzf … -C <vault>/.obsidian/plugins/`, enable in Obsidian — verify works

## Related

- Plugin baseline: #62
- Plugin features in flight: #65 (trace-creation modal), #66 (immutable warning banner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)