### PR TITLE
feat(serve): log binary build fingerprint at startup

### DIFF
--- a/internal/cli/cmd_serve.go
+++ b/internal/cli/cmd_serve.go
@@ -103,6 +103,17 @@ func serveCmd() *cobra.Command {
 				}
 			}
 
+			// Build-fingerprint line, ahead of everything else, so an
+			// operator triaging journals can immediately spot a process
+			// running a stale binary (e.g. systemd-managed long-lived
+			// service that wasn't restarted after a deploy, or a
+			// launchd-managed agent inheriting an older binary path).
+			// Falls back gracefully when only Version is set (Makefile
+			// builds) and stays compact when all three fields are
+			// available (GoReleaser builds).
+			fmt.Fprintf(os.Stderr, "[serve] noema %s%s starting\n",
+				version(), buildFingerprint())
+
 			// Surface the bound cortex identity on every serve, so an
 			// operator who started the wrong cortex sees it in the very
 			// first log line instead of finding out via peer drift hours

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -38,6 +38,41 @@ func version() string {
 	return "dev"
 }
 
+// buildFingerprint renders an operator-facing suffix for log lines
+// that want to surface commit + build-date alongside the version.
+// Returns the empty string when neither Commit nor Date is set —
+// Makefile builds inject only Version, so the fallback keeps
+// startup logs uncluttered for those builds. Format:
+//
+//	" (commit abc1234, built 2026-04-28T15:00:00Z)"
+//
+// Includes a leading space so callers can concatenate it directly
+// after the version string without conditional logic at the call site.
+func buildFingerprint() string {
+	if Commit == "" && Date == "" {
+		return ""
+	}
+	switch {
+	case Commit != "" && Date != "":
+		return fmt.Sprintf(" (commit %s, built %s)", shortCommit(Commit), Date)
+	case Commit != "":
+		return fmt.Sprintf(" (commit %s)", shortCommit(Commit))
+	default:
+		return fmt.Sprintf(" (built %s)", Date)
+	}
+}
+
+// shortCommit truncates a full SHA to its leading 7 hex chars (the
+// git default). GoReleaser injects full SHAs; 7 chars is enough to
+// disambiguate in any practical repo and saves horizontal space in
+// startup log lines.
+func shortCommit(c string) string {
+	if len(c) > 7 {
+		return c[:7]
+	}
+	return c
+}
+
 var cortexFlag string
 
 var rootCmd = &cobra.Command{


### PR DESCRIPTION
Closes an operational gap surfaced by today's multi-process diagnosis.

## Why

When triaging the 4-watchers-on-the-same-cortex bug today, version drift across noema processes was diagnosed via `ps -ef + manual inference`. The user's launchd-managed agent had been running 3 days on the pre-flock binary while we thought the new build was active — the only reason we caught it was the `etime` column. Nothing in the journal told us which binary version each process was actually running.

## What

Print the build fingerprint as the very first log line of every `noema serve`:

```
[serve] noema v0.10.0-beta.6 (commit abc1234, built 2026-04-28T15:00:00Z) starting
[serve] cortex "agentbrain" (id=01K...) at /Users/...
[serve] background lock at /var/folders/.../noema/01K.../background.lock
```

Operators tailing `journalctl` now see the active build without spelunking through process trees. The format degrades gracefully:

| Build mode | Output |
|---|---|
| GoReleaser (release pipeline) | full version + 7-char commit + RFC3339 date |
| Makefile (`make build`) | just the version (Commit/Date are empty in ldflags) |
| `go install` / `go run` (working-copy) | `dev` from the fallback in `version()` |

A `buildFingerprint()` helper handles the conditional rendering so the call site stays a single `fmt.Fprintf`. `shortCommit()` truncates the full SHA to 7 hex chars (git default) — enough to disambiguate in any practical repo, saves horizontal space.

## Verified locally

```
$ go build -ldflags "-X .../cli.Version=v0.10.0-test -X .../cli.Commit=abc12345678 -X .../cli.Date=2026-04-28T18:00:00Z" ...
$ noema serve --transport stdio --cortex test
[serve] noema v0.10.0-test (commit abc1234, built 2026-04-28T18:00:00Z) starting
[serve] cortex "test" (id=...) at ...
```

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/cli/...` passes
- [x] Manual: build with all three ldflags, observe full fingerprint
- [x] Manual: build via Makefile (Version only), observe just the version
- [ ] CI run on this PR exercises the change implicitly via the existing build/test steps

## Out of scope

- A `--quiet` mode that suppresses startup banner output. The use case for this is rare (and existing log files give operators what they need); add it if/when someone asks.
- A periodic re-log of the version (e.g. every hour) — long-running processes would still have version-drift visibility from the *startup* line, since systemd / launchd journal-rotation typically keeps weeks of history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)