### PR TITLE
feat(obsidian): append-to-trace modal

### DIFF
--- a/plugins/obsidian/src/append-modal.ts
+++ b/plugins/obsidian/src/append-modal.ts
@@ -1,0 +1,178 @@
+import { App, Modal, Notice, TFile } from "obsidian";
+import type NoemaPlugin from "./main";
+import { readTraceMetadata, tierGlyph } from "./tier-status";
+
+// AppendModal lets the user add content to an existing trace's body
+// from inside Obsidian. It's the editor-side counterpart to the
+// `noema append` CLI command and the `append_trace` MCP tool, both
+// designed for the "running journal" / "fire-and-forget log" pattern
+// where you want to extend a trace without reading and replacing its
+// full current body.
+//
+// Body content IS in this modal (unlike CreateTraceModal, which
+// deliberately punts body to the editor). The reason is shape: append
+// content is bounded — usually a sentence or a paragraph — and the
+// whole point of the operation is to commit it in one shot without a
+// round-trip through the editor's read/write cycle. A textarea is
+// the right fit.
+//
+// The target trace is fixed at construction time from the active
+// editor; the modal does not include a trace picker. If the user
+// wants to append to a different trace they switch files first and
+// run the command again. This keeps the modal small and forecloses
+// the failure mode where someone has the right textarea content but
+// the wrong trace selected.
+export class AppendModal extends Modal {
+	private contentInput!: HTMLTextAreaElement;
+	private submitBtn!: HTMLButtonElement;
+	private errorEl!: HTMLElement;
+	private submitting = false;
+
+	constructor(
+		app: App,
+		private plugin: NoemaPlugin,
+		private targetFile: TFile,
+		private targetId: string,
+		private targetTitle: string,
+		private targetTier: string
+	) {
+		super(app);
+	}
+
+	onOpen(): void {
+		const { contentEl } = this;
+		contentEl.empty();
+		contentEl.addClass("noema-append-modal");
+
+		this.titleEl.setText("Append to trace");
+
+		// Header showing which trace we're appending to. Read-only
+		// summary, not a picker — the modal binds to the active
+		// trace at open time and stays bound for the duration.
+		const targetEl = contentEl.createEl("div", { cls: "noema-append-target" });
+		const tierEl = targetEl.createEl("span", { cls: "noema-append-target-glyph" });
+		tierEl.setText(`[${tierGlyph(this.targetTier as any)}]`);
+		const titleEl = targetEl.createEl("span", { cls: "noema-append-target-title" });
+		titleEl.setText(this.targetTitle);
+		const idEl = targetEl.createEl("div", { cls: "noema-append-target-id" });
+		idEl.setText(this.targetId);
+
+		// Textarea for the content to append. Sized for short-form
+		// content (a few lines) but resizable so longer appends are
+		// fine — that's the user's call.
+		const labelRow = contentEl.createEl("div", { cls: "noema-append-label" });
+		labelRow.setText("Content to append");
+
+		this.contentInput = contentEl.createEl("textarea", {
+			cls: "noema-append-content",
+			attr: { rows: "6", placeholder: "Type or paste content to append…" },
+		});
+
+		const hint = contentEl.createEl("div", { cls: "noema-append-hint" });
+		hint.setText(
+			"A newline is inserted automatically between the existing body and your content if needed. ⌘+Enter to submit."
+		);
+
+		this.errorEl = contentEl.createEl("div", { cls: "noema-append-error" });
+		this.errorEl.style.display = "none";
+
+		const buttonRow = contentEl.createEl("div", { cls: "noema-append-buttons" });
+		const cancelBtn = buttonRow.createEl("button", { text: "Cancel" });
+		cancelBtn.addEventListener("click", () => this.close());
+		this.submitBtn = buttonRow.createEl("button", {
+			text: "Append",
+			cls: "mod-cta",
+		});
+		this.submitBtn.addEventListener("click", () => this.submit());
+
+		// ⌘+Enter / Ctrl+Enter to submit — common power-user shortcut
+		// for "send" actions in textareas. Plain Enter inserts a
+		// newline as expected.
+		this.contentInput.addEventListener("keydown", (evt) => {
+			if (evt.key === "Enter" && (evt.metaKey || evt.ctrlKey)) {
+				evt.preventDefault();
+				this.submit();
+			}
+		});
+
+		setTimeout(() => this.contentInput.focus(), 0);
+	}
+
+	onClose(): void {
+		this.contentEl.empty();
+	}
+
+	private async submit(): Promise<void> {
+		if (this.submitting) return;
+		this.errorEl.style.display = "none";
+		this.errorEl.empty();
+
+		const content = this.contentInput.value;
+		// Trim only trailing whitespace — leading whitespace might
+		// be intentional (e.g. continuing a code block, or formatting
+		// a list item). The cortex's Append handles its own newline
+		// normalisation between the existing body and our content.
+		const trimmed = content.replace(/\s+$/, "");
+		if (!trimmed) {
+			this.showError("Content is required.");
+			this.contentInput.focus();
+			return;
+		}
+
+		const client = this.plugin.client;
+		if (!client) {
+			this.showError(
+				"No noema endpoint configured. Set one in Settings → Noema."
+			);
+			return;
+		}
+
+		this.submitting = true;
+		this.submitBtn.disabled = true;
+		this.submitBtn.setText("Appending…");
+
+		try {
+			await client.appendTrace(this.targetId, trimmed);
+			this.close();
+			new Notice(`Appended to ${this.targetId}`);
+			// Don't re-open the file — Obsidian's watcher will pick up
+			// the change once the cortex's filesystem watcher writes
+			// the new content_hash and updated_at, and the editor
+			// already shows the file. A manual focus shift would
+			// fight whatever the user does next.
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : String(err);
+			this.showError(`Couldn't append: ${msg}`);
+			this.submitBtn.disabled = false;
+			this.submitBtn.setText("Append");
+		} finally {
+			this.submitting = false;
+		}
+	}
+
+	private showError(text: string): void {
+		this.errorEl.setText(text);
+		this.errorEl.style.display = "";
+	}
+}
+
+// openAppendModalFromActive resolves the currently-active editor leaf
+// to a trace and opens the modal pointed at it. Returns false if the
+// active leaf isn't a trace — the caller (a command checkCallback)
+// uses that to grey out the command in the palette so the operator
+// sees "no trace open" by absence rather than by error message.
+export function openAppendModalFromActive(plugin: NoemaPlugin): boolean {
+	const file = plugin.app.workspace.getActiveFile();
+	if (!(file instanceof TFile)) return false;
+	const meta = readTraceMetadata(plugin.app, file);
+	if (!meta?.id) return false;
+	new AppendModal(
+		plugin.app,
+		plugin,
+		file,
+		meta.id,
+		meta.title ?? "(untitled)",
+		meta.tier
+	).open();
+	return true;
+}

--- a/plugins/obsidian/src/main.ts
+++ b/plugins/obsidian/src/main.ts
@@ -1,10 +1,11 @@
-import { Plugin, TFile, WorkspaceLeaf } from "obsidian";
+import { Notice, Plugin, TFile, WorkspaceLeaf } from "obsidian";
 import { DEFAULT_SETTINGS, NoemaSettings, NoemaSettingTab } from "./settings";
 import { LineageView, LINEAGE_VIEW_TYPE } from "./lineage-view";
 import { McpClient } from "./mcp-client";
 import { readTraceMetadata, tierGlyph, tierLabel } from "./tier-status";
 import { CreateTraceModal } from "./create-modal";
 import { ImmutableWarning } from "./immutable-warning";
+import { openAppendModalFromActive } from "./append-modal";
 
 const STATUS_PING_INTERVAL_MS = 30_000;
 
@@ -69,6 +70,31 @@ export default class NoemaPlugin extends Plugin {
 			name: "New trace",
 			callback: () => {
 				new CreateTraceModal(this.app, this).open();
+			},
+		});
+
+		// Append-to-trace uses checkCallback so the command is greyed
+		// out in the palette unless the active editor is a trace.
+		// That's the right UX hint: "no trace open" reads as an
+		// absent/disabled command rather than as an error message
+		// after the user pulls the trigger.
+		this.addCommand({
+			id: "append-to-trace",
+			name: "Append to current trace",
+			checkCallback: (checking: boolean) => {
+				const file = this.app.workspace.getActiveFile();
+				if (!file) return false;
+				// Defer the metadata read until we know we'll act on it.
+				if (checking) {
+					// Cheap approximation — let the modal helper do the
+					// authoritative metadata check. We only need to
+					// know "is the active file a candidate?" here.
+					return file.extension === "md";
+				}
+				if (!openAppendModalFromActive(this)) {
+					new Notice("Open a trace first to append to it.");
+				}
+				return true;
 			},
 		});
 

--- a/plugins/obsidian/src/mcp-client.ts
+++ b/plugins/obsidian/src/mcp-client.ts
@@ -137,6 +137,21 @@ export class McpClient {
 		return parseLineage(text, traceId);
 	}
 
+	// appendTrace invokes the append_trace MCP tool, which is the
+	// designed primitive for "add a line or two to an existing
+	// trace" — the cortex reads the current body server-side, appends,
+	// recomputes the content_hash, and emits an update event in a
+	// single transaction. Compared to a full update_trace round-trip
+	// this avoids the read-modify-write window where another process
+	// could race against us, and saves shipping the existing body
+	// over the wire just to re-send it back.
+	async appendTrace(traceId: string, content: string): Promise<void> {
+		await this.callToolText("append_trace", {
+			id: traceId,
+			content: content,
+		});
+	}
+
 	// createTrace invokes the create_trace MCP tool. The server
 	// generates the canonical YYYYMMDD-<slug>.md filename, computes
 	// the content_hash, sets origin to the local cortex name, and

--- a/plugins/obsidian/styles.css
+++ b/plugins/obsidian/styles.css
@@ -212,3 +212,72 @@
 .noema-immutable-warning-text {
 	color: var(--text-normal);
 }
+
+/* ---- Append modal ---- */
+
+.noema-append-modal .noema-append-target {
+	display: flex;
+	align-items: baseline;
+	gap: 8px;
+	padding: 8px 12px;
+	margin-bottom: 12px;
+	border-radius: 6px;
+	background: var(--background-secondary);
+}
+
+.noema-append-modal .noema-append-target-glyph {
+	font-family: var(--font-monospace);
+	font-weight: 600;
+	color: var(--text-accent);
+	flex-shrink: 0;
+}
+
+.noema-append-modal .noema-append-target-title {
+	font-weight: 600;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.noema-append-modal .noema-append-target-id {
+	color: var(--text-faint);
+	font-family: var(--font-monospace);
+	font-size: var(--font-ui-smaller);
+	margin-left: auto;
+	padding-left: 8px;
+}
+
+.noema-append-modal .noema-append-label {
+	color: var(--text-muted);
+	font-size: var(--font-ui-smaller);
+	margin-bottom: 4px;
+}
+
+.noema-append-modal .noema-append-content {
+	width: 100%;
+	font-family: var(--font-text);
+	resize: vertical;
+	min-height: 120px;
+}
+
+.noema-append-modal .noema-append-hint {
+	color: var(--text-faint);
+	font-size: var(--font-ui-smaller);
+	margin-top: 4px;
+}
+
+.noema-append-modal .noema-append-error {
+	color: var(--text-error);
+	font-size: var(--font-ui-smaller);
+	margin: 8px 0;
+	padding: 6px 8px;
+	background: var(--background-modifier-error);
+	border-radius: 4px;
+}
+
+.noema-append-modal .noema-append-buttons {
+	display: flex;
+	justify-content: flex-end;
+	gap: 8px;
+	margin-top: 12px;
+}


### PR DESCRIPTION
Pairs the editor side with the new `noema append` CLI command (#67) and the existing `append_trace` MCP tool. Three surfaces, one operation.

## UI

`⌘P → "Noema: Append to current trace"` opens a modal that targets the currently-active trace and offers a textarea for the content to append:

- Header shows the target trace's tier glyph + title + ID (read-only summary, not a picker).
- Resizable textarea, 6 rows by default. Shape fits "a sentence or paragraph" — bounded append content, not a full body rewrite.
- `⌘+Enter` / `Ctrl+Enter` submits. Plain Enter inserts a newline.
- Submit calls `client.appendTrace(id, content)`; the server reads existing body, appends, recomputes content_hash, emits an update event — one transaction.

## Why the modal binds at open-time (no trace picker)

Forecloses the failure mode where someone has the right textarea content but the wrong trace selected. If you want to append to a different trace, switch files first and run the command again. The `checkCallback` greys out the command in the palette when no markdown file is active, so the affordance is absent (cheapest possible "no trace open" feedback).

## Why body content IS in this modal

Unlike `CreateTraceModal`, which deliberately punts body to the editor, append content is **bounded by design** — the whole point of `append_trace` is to commit a small extension without round-tripping through the editor's read/write cycle. A 6-row resizable textarea is the right shape.

## Whitespace handling

- Trailing whitespace trimmed (avoids a "trailing space breaks the markdown render" footgun).
- Leading whitespace preserved (might be intentional formatting like a code block continuation or list-item indent).
- The cortex's `Append` handles its own newline normalisation between the existing body and our content, so we don't insert separators ourselves.

## Files

- New: `plugins/obsidian/src/append-modal.ts` (~150 lines incl. comments)
- Modified: `mcp-client.ts` (new `appendTrace` method)
- Modified: `main.ts` (command registration, Notice import)
- Modified: `styles.css` (modal layout — theme variables only)

## Test plan

- [x] `npm run build` clean (~21KB main.js, up from ~18KB)
- [x] `npx tsc --noEmit` clean
- [x] `go build ./...` and `go vet ./...` clean (no Go changes; sanity)
- [ ] Manual: open a trace, ⌘P → Append to current trace, type content, submit. Verify file updates with new content separated by newline.
- [ ] Manual: try with no file open — command shouldn't fire (or shows the "open a trace first" Notice).
- [ ] Manual: ⌘+Enter from inside the textarea submits.
- [ ] Manual: try on a long-tier trace — should error from the cortex's content-locked guard. (Source-locked traces would also error.)

## Out of scope

- Trace picker (fuzzy file suggester) so you can append to a non-active trace. Punted by design — less footgun risk this way.
- Append history / preview ("you've appended 3 times today, here's the diff"). Lives well below the cost/value bar for a v1.

## Related

- #67 CLI append (the matching shell-side command)
- `append_trace` MCP tool (the agent-side surface, already shipping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)