### PR TITLE
feat(consolidation): make watchdog timeout configurable

### DIFF
--- a/internal/cli/cmd_serve.go
+++ b/internal/cli/cmd_serve.go
@@ -237,7 +237,7 @@ func serveCmd() *cobra.Command {
 			// need a parallel sweeper.
 			if gotLock && manifestErr == nil && m.Consolidation != nil && m.Consolidation.Enabled &&
 				m.Federation != nil && len(m.Federation.Peers) > 0 {
-				watchdog = startWatchdog(cx)
+				watchdog = startWatchdog(cx, m.Consolidation)
 			}
 
 			switch transport {
@@ -583,22 +583,27 @@ func startEligibility(cx *cortex.Cortex, cfg *cortex.ConsolidationConfig, fed *c
 // startWatchdog launches the election watchdog. The caller has already
 // verified that consolidation is enabled AND federation peers are
 // configured — single-node cortexes never have silent winners and skip
-// the watchdog entirely. Defaults are baked into the watchdog package
-// (10-minute claim staleness ceiling, 1-minute sweep cadence); they
-// can be promoted to manifest config in a future change if real
-// deployments need to tune them.
-func startWatchdog(cx *cortex.Cortex) *consolidation.Watchdog {
+// the watchdog entirely. The claim-staleness ceiling is configurable via
+// consolidation.watchdog_timeout in cortex.md (defaults to 10 minutes
+// per consolidation.EffectiveWatchdogTimeout); operators with slow LLM
+// endpoints can raise it to avoid noise where a legitimate long-running
+// pass trips the watchdog before the local consolidator emits success.
+// Sweep cadence is still an internal default (1 minute) — promoting
+// that to manifest config can wait until someone needs it.
+func startWatchdog(cx *cortex.Cortex, cfg *cortex.ConsolidationConfig) *consolidation.Watchdog {
 	logger := func(format string, args ...any) {
 		fmt.Fprintf(os.Stderr, format+"\n", args...)
 	}
+	timeout := cfg.EffectiveWatchdogTimeout()
 	w := consolidation.NewWatchdog(consolidation.WatchdogConfig{
 		DB:            cx.DB.DB,
 		Emitter:       cx,
 		LocalCortexID: cx.ID,
+		Timeout:       timeout,
 		Log:           logger,
 	})
 	w.Start()
-	fmt.Fprintf(os.Stderr, "[consolidation] watchdog started\n")
+	fmt.Fprintf(os.Stderr, "[consolidation] watchdog started (timeout=%s)\n", timeout)
 	return w
 }
 

--- a/internal/cortex/cortex.go
+++ b/internal/cortex/cortex.go
@@ -245,6 +245,26 @@ type ConsolidationConfig struct {
 	// terminal tier for automatic promotion — useful for operators who
 	// want to curate the long tier by hand via `noema memory promote`.
 	Graduation *GraduationConfig `yaml:"graduation,omitempty"`
+
+	// WatchdogTimeout overrides the election watchdog's claim-staleness
+	// ceiling — the duration after which observers treat a
+	// consolidation_claim with no matching success/fail as orphaned and
+	// emit a closing fail (reason=watchdog_expired).
+	//
+	// The default 10 minutes is generous for consolidator passes backed
+	// by GPU-class endpoints, but slow LLM endpoints (low-VRAM laptops,
+	// CPU inference, congested API providers) can take longer than that
+	// for legitimate distillation work. When the pass takes longer than
+	// the watchdog budget, peers correctly emit watchdog_expired — but
+	// the pass eventually succeeds anyway, leaving both events for the
+	// same window in the log. Cosmetically noisy, not a correctness bug;
+	// raise the timeout on cortexes whose LLM is slower than the
+	// federation typical to avoid the noise.
+	//
+	// Format: any duration go's time.ParseDuration accepts ("10m",
+	// "20m", "1h"). Empty preserves the 10-minute default. See
+	// internal/consolidation/watchdog.go for the consumer.
+	WatchdogTimeout string `yaml:"watchdog_timeout,omitempty"`
 }
 
 // GraduationConfig controls the mid→long promotion heuristic. A
@@ -347,6 +367,28 @@ func (cc *ConsolidationConfig) HasTrigger() bool {
 		return false
 	}
 	return cc.Cron != "" || cc.IdleMinutes != 0 || cc.ThresholdShort != 0
+}
+
+// EffectiveWatchdogTimeout returns the configured watchdog claim-
+// staleness duration, or the 10-minute default when unset / unparseable.
+// We tolerate parse failure with a fallback rather than refusing to
+// start the agent: a typo in this knob shouldn't take a peer offline,
+// and 10 minutes is a safe ceiling for any setup we've observed.
+//
+// Manifest validation (separate code path) catches the unparseable
+// case at config-load time and surfaces a clear error to the operator;
+// this method is the runtime-side belt-and-suspenders for any path
+// that bypasses validation.
+func (cc *ConsolidationConfig) EffectiveWatchdogTimeout() time.Duration {
+	const fallback = 10 * time.Minute
+	if cc == nil || cc.WatchdogTimeout == "" {
+		return fallback
+	}
+	d, err := time.ParseDuration(cc.WatchdogTimeout)
+	if err != nil || d <= 0 {
+		return fallback
+	}
+	return d
 }
 
 // ErrSourceLocked is returned when a mutation is attempted on a
@@ -507,6 +549,21 @@ func (m Manifest) ValidateConsolidation() error {
 	cc := m.Consolidation
 	if cc == nil || !cc.Enabled {
 		return nil
+	}
+	// watchdog_timeout is independent of auto_distillation — validate
+	// it whenever consolidation is enabled at all, since the watchdog
+	// runs whenever federation peers are configured. A typo here
+	// silently falls back to 10 min via EffectiveWatchdogTimeout, but
+	// we'd rather surface the typo to the operator than have them
+	// wonder why their override didn't take.
+	if cc.WatchdogTimeout != "" {
+		d, err := time.ParseDuration(cc.WatchdogTimeout)
+		if err != nil {
+			return fmt.Errorf("consolidation.watchdog_timeout %q is not a valid duration (use formats like \"10m\", \"30m\", \"1h\"): %w", cc.WatchdogTimeout, err)
+		}
+		if d <= 0 {
+			return fmt.Errorf("consolidation.watchdog_timeout must be positive, got %q", cc.WatchdogTimeout)
+		}
 	}
 	if !cc.AutoDistillationEnabled {
 		return nil

--- a/internal/cortex/cortex_test.go
+++ b/internal/cortex/cortex_test.go
@@ -79,8 +79,8 @@ func TestCreate_AgentsMDContent(t *testing.T) {
 		"origin",
 		"trace_history",
 		"trace_lineage",
-		"Titles",      // new naming-rules section
-		"under 80",    // title length guidance
+		"Titles",        // new naming-rules section
+		"under 80",      // title length guidance
 		"100 character", // slug cap guidance
 	} {
 		if !strings.Contains(content, want) {
@@ -377,11 +377,11 @@ func TestPeerLabelCollidesWithSelf(t *testing.T) {
 		label string
 		want  bool
 	}{
-		{"alpha", true},      // exact collision
-		{"beta", false},      // distinct
-		{"", false},          // empty is not a collision (other validation handles empty)
-		{"Alpha", false},     // case-sensitive: cortex names are exact strings
-		{"alpha-1", false},   // distinct
+		{"alpha", true},    // exact collision
+		{"beta", false},    // distinct
+		{"", false},        // empty is not a collision (other validation handles empty)
+		{"Alpha", false},   // case-sensitive: cortex names are exact strings
+		{"alpha-1", false}, // distinct
 	}
 	for _, tc := range cases {
 		if got := m.PeerLabelCollidesWithSelf(tc.label); got != tc.want {
@@ -2551,6 +2551,74 @@ func TestValidateConsolidation_AutoDistillationMissingFields(t *testing.T) {
 				t.Fatalf("expected error mentioning %q, got nil", tc.wantSub)
 			}
 			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("error should mention %q, got: %v", tc.wantSub, err)
+			}
+		})
+	}
+}
+
+func TestEffectiveWatchdogTimeout(t *testing.T) {
+	// Default applies on nil receiver, empty string, malformed
+	// duration, and non-positive duration. Configured value applies
+	// otherwise.
+	cases := []struct {
+		name string
+		cfg  *cortex.ConsolidationConfig
+		want time.Duration
+	}{
+		{"nil receiver", nil, 10 * time.Minute},
+		{"empty string", &cortex.ConsolidationConfig{}, 10 * time.Minute},
+		{"valid 20m", &cortex.ConsolidationConfig{WatchdogTimeout: "20m"}, 20 * time.Minute},
+		{"valid 1h", &cortex.ConsolidationConfig{WatchdogTimeout: "1h"}, time.Hour},
+		{"malformed falls back", &cortex.ConsolidationConfig{WatchdogTimeout: "not-a-duration"}, 10 * time.Minute},
+		{"zero falls back", &cortex.ConsolidationConfig{WatchdogTimeout: "0s"}, 10 * time.Minute},
+		{"negative falls back", &cortex.ConsolidationConfig{WatchdogTimeout: "-5m"}, 10 * time.Minute},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.cfg.EffectiveWatchdogTimeout()
+			if got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateConsolidation_WatchdogTimeout(t *testing.T) {
+	// A typo in watchdog_timeout should produce a clear error at
+	// manifest load time rather than silently falling back to the
+	// default — operators tweaking this knob would otherwise
+	// wonder why their override didn't take effect.
+	cases := []struct {
+		name    string
+		raw     string
+		wantErr bool
+		wantSub string
+	}{
+		{"empty is ok", "", false, ""},
+		{"valid duration", "20m", false, ""},
+		{"valid hour", "1h30m", false, ""},
+		{"unparseable", "twenty minutes", true, "watchdog_timeout"},
+		{"missing unit", "20", true, "watchdog_timeout"},
+		{"zero rejected", "0s", true, "must be positive"},
+		{"negative rejected", "-5m", true, "must be positive"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := cortex.Manifest{
+				Consolidation: &cortex.ConsolidationConfig{
+					Enabled:         true,
+					WatchdogTimeout: tc.raw,
+				},
+			}
+			err := m.ValidateConsolidation()
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error mentioning %q, got nil", tc.wantSub)
+			}
+			if !tc.wantErr && err != nil {
+				t.Errorf("expected no error, got %v", err)
+			}
+			if tc.wantErr && err != nil && !strings.Contains(err.Error(), tc.wantSub) {
 				t.Errorf("error should mention %q, got: %v", tc.wantSub, err)
 			}
 		})


### PR DESCRIPTION
## Summary

Today's `v0.10.0-beta.7` production check surfaced a cosmetic but operationally noisy issue: the laptop's local LLM took 16 minutes to complete a distillation pass, longer than the watchdog's 10-minute ceiling. Three watchdogs (the laptop's own + two federation peers) correctly emitted `watchdog_expired` for the in-flight claim before the pass finished and emitted `success`. **No data loss, no incorrect tier transitions** — just an event log with both events for the same window, looking like a bug to anyone reading it.

## Why

10 minutes was a reasonable default for GPU-class LLM endpoints (the federation peers' `corsair-gpu-md` instances), but slow endpoints — low-VRAM laptops, CPU inference, congested API providers — need a wider budget. Hard-coding the ceiling means the only way to fix the noise is to recompile or to upgrade the LLM hardware. Neither is the right answer for an operator who just wants to bump the timeout.

## What

New optional field on `ConsolidationConfig`:

```yaml
consolidation:
  watchdog_timeout: 20m       # default 10m, accepts any time.ParseDuration string
```

- `cortex.ConsolidationConfig.EffectiveWatchdogTimeout()` returns the parsed duration or 10 min on nil/empty/malformed/zero/negative.
- `Manifest.ValidateConsolidation()` rejects unparseable / non-positive values at config-load time so operators see a clear error rather than wonder why their override silently fell back.
- `cmd_serve.go startWatchdog()` accepts the consolidation config and plumbs the timeout into `consolidation.WatchdogConfig`.
- Startup banner now logs the active timeout: `[consolidation] watchdog started (timeout=20m0s)` so an operator can confirm the config landed.

## Tests

| Coverage | Tests |
|---|---|
| `EffectiveWatchdogTimeout` | nil receiver, empty, valid (20m, 1h30m), malformed, zero, negative |
| `ValidateConsolidation` | empty ok, valid duration, unparseable error, missing-unit error, zero error, negative error — assertions on specific error substrings so future refactors don't drift the wording |

## What this is *not*

- Not a fix for the underlying watchdog-vs-long-pass tension; it just gives operators a knob to widen the budget. A more surgical fix would be having the watchdog skip its own in-flight claims (since we know we're not orphaned if we emitted it) — that's a separate refactor for a future PR.
- Not a behavior change for any cortex that doesn't set the new field. Default is still 10 minutes.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/cortex/... ./internal/cli/... ./internal/consolidation/...` clean
- [ ] Deploy + verify the laptop with `watchdog_timeout: 20m` no longer trips false-positives during long LLM passes

## Related

- v0.10.0-beta.7 release that surfaced the issue
- `internal/consolidation/watchdog.go` — the watchdog implementation
- `internal/consolidation/pass_gate.go` — emits the claim/fail/success that the watchdog observes

🤖 Generated with [Claude Code](https://claude.com/claude-code)