### PR TITLE
docs: tag conventions for Obsidian-compatible authoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -673,6 +673,14 @@ iteration. We can revisit Rust if the MCP server demands higher concurrency.
 
 **Trace IDs and titles.** The ID is `YYYYMMDD-<slug>` — today's date prepended to a slugified title. The slug portion is capped at 100 characters (longer titles are silently truncated); aim for titles under 80 characters for scannability. Don't include the date in the title — `noema` prepends today's date automatically, and leading `YYYYMMDD-` / `YYYY-MM-DD-` prefixes in the title are stripped to prevent doubled-date IDs. Mid-title date fragments aren't stripped, so put date context in a tag (`tags: [event-2026-04-02]`) or the body instead of the title.
 
+**Tag conventions.** The cortex accepts any string as a tag — the constraints here are about what *renders correctly in Obsidian's tag panel* if a user is authoring through Obsidian (a common but optional surface). Non-Obsidian authoring (CLI, MCP, TUI, agent integrations) is unaffected.
+
+- **Tags must contain at least one letter.** A pure-numeric tag like `2026` or `42` is stored, indexed, and searchable via `search_traces` / FTS5, but Obsidian silently drops it from the tag panel. Use `y2026`, `2026q1`, or `event-2026-04-02` instead.
+- **Avoid dots inside a tag.** Obsidian interprets `release.candidate` as a nested tag tree (`release` / `candidate`), which is rarely the intent for a flat tag. Use hyphens: `release-candidate`.
+- **No spaces.** Use hyphens or underscores: `network-troubleshooting`, not `network troubleshooting`.
+
+The Obsidian plugin's "New trace" command surfaces these as inline warnings as you type — non-blocking hints, not validation errors. The cortex still accepts the tag.
+
 **Cortex layout on disk:**
 
 ```

--- a/internal/cortex/cortex.go
+++ b/internal/cortex/cortex.go
@@ -811,6 +811,24 @@ Choose the type that best reflects the **intent** of the memory:
   survive and produce awkward IDs. If a trace is *about* a specific date,
   put it in a tag (` + "`tags: [event-2026-04-02]`" + `) or in the body.
 
+## Tags
+
+The cortex accepts any string as a tag — the constraints below are about
+what *renders correctly in Obsidian's tag panel* if a user is authoring
+traces through Obsidian (a common but optional surface). Non-Obsidian
+authoring (CLI, MCP, TUI, agent integrations) is unaffected.
+
+- **Tags must contain at least one letter.** A pure-numeric tag like
+  ` + "`2026`" + ` or ` + "`42`" + ` is stored, indexed, and searchable, but Obsidian
+  silently drops it from the tag panel. Use ` + "`y2026`" + `, ` + "`2026q1`" + `, or
+  ` + "`event-2026-04-02`" + ` instead.
+- **Avoid dots inside a tag.** Obsidian interprets ` + "`release.candidate`" + `
+  as a nested tag tree (` + "`release/candidate`" + `), which is rarely the
+  intent for a flat tag. Use hyphens: ` + "`release-candidate`" + `.
+- **No spaces.** Tag tokens are split on whitespace by most tooling;
+  use hyphens or underscores to keep multi-word tags as one token:
+  ` + "`network-troubleshooting`" + `, not ` + "`network troubleshooting`" + `.
+
 ## Creating a Trace (filesystem)
 
 1. Pick a type and write your content.

--- a/plugins/obsidian/README.md
+++ b/plugins/obsidian/README.md
@@ -23,6 +23,16 @@ That's intentionally the whole feature set for v0.1. File-explorer decorations, 
 
 The status bar will show `noema: <cortex-name>` once the connection succeeds.
 
+## Tag conventions
+
+The cortex accepts any string as a tag — these constraints are about what Obsidian's tag panel surfaces:
+
+- **Tags must contain at least one letter.** Pure-numeric tags like `2026` or `42` are stored on the trace and remain searchable through Noema's MCP / FTS5 surfaces, but Obsidian silently drops them from its tag panel. Use `y2026`, `2026q1`, or `event-2026-04-02`.
+- **Avoid dots in a tag.** Obsidian interprets `release.candidate` as a nested tag tree (`release` / `candidate`). Use hyphens: `release-candidate`.
+- **No spaces.** Use hyphens or underscores: `network-troubleshooting`, not `network troubleshooting`.
+
+The "New trace" command shows inline warnings as you type a non-conformant tag. Submission proceeds normally — these are hints, not errors. Authoring through CLI / MCP / TUI is unaffected.
+
 ## Building
 
 ```sh


### PR DESCRIPTION
## Summary

Documentation pass to complement the inline plugin warnings in #75. Three doc surfaces get parallel guidance about Obsidian's tag-panel limitations, written to fit each surface's audience.

## What changes

| Surface | Audience | Form |
|---|---|---|
| `README.md` (Data Model section) | Cortex operators, integrators | Compact "Tag conventions" note next to existing trace-IDs-and-titles guidance |
| `plugins/obsidian/README.md` | Plugin users | Standalone "Tag conventions" section above Building, so it's surfaced during install/setup |
| `AGENTS.md` template (embedded in `internal/cortex/cortex.go`, written into every new cortex by `noema init`) | Agents authoring traces (Hermes, Claude Code via MCP) | New "Tags" section after existing "Titles" — the most thorough writeup since it's the agent's primary reference |

The three rules captured everywhere:

- Tags must contain at least one letter (`2026` doesn't render in Obsidian; `2026q1` does)
- Avoid dots — Obsidian reads `release.candidate` as nested tag tree `release/candidate`
- No spaces — use hyphens / underscores

## Why three places, not one

- `README.md` is the project entry point — operators reading the data model expect to learn about tags here.
- The plugin README is what an Obsidian-only user sees; they won't read the main README first.
- `AGENTS.md` is what *agents* read inside the cortex — and agents are the most prolific tag authors. Without this update, an agent would have no in-band signal about the rule.

## Pairing with #75

#75 adds inline UI warnings in the create-trace modal as the user types non-conformant tags. This PR adds the docs that explain the rule in detail. They land cleanly in either order — the modal warnings work without the docs, and the docs are correct without the modal.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/cortex/...` clean (AGENTS.md template is rendered through the embedded string in cortex.go; the existing tests cover the renderer)
- [ ] Manual: `noema init --name doctest --path /tmp/doc-test`, inspect the generated `AGENTS.md` for the new Tags section
- [ ] Manual: render the plugin README on github.com to verify the new section reads cleanly

## Related

- #75 inline plugin warnings (paired feature)
- Obsidian's [tag spec](https://obsidian.md/help/tags#Tag+format) — the source of truth for the limitations being documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)