### PR TITLE
Release v0.10.1: Obsidian tag-conventions warnings + docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -673,6 +673,14 @@ iteration. We can revisit Rust if the MCP server demands higher concurrency.
 
 **Trace IDs and titles.** The ID is `YYYYMMDD-<slug>` — today's date prepended to a slugified title. The slug portion is capped at 100 characters (longer titles are silently truncated); aim for titles under 80 characters for scannability. Don't include the date in the title — `noema` prepends today's date automatically, and leading `YYYYMMDD-` / `YYYY-MM-DD-` prefixes in the title are stripped to prevent doubled-date IDs. Mid-title date fragments aren't stripped, so put date context in a tag (`tags: [event-2026-04-02]`) or the body instead of the title.
 
+**Tag conventions.** The cortex accepts any string as a tag — the constraints here are about what *renders correctly in Obsidian's tag panel* if a user is authoring through Obsidian (a common but optional surface). Non-Obsidian authoring (CLI, MCP, TUI, agent integrations) is unaffected.
+
+- **Tags must contain at least one letter.** A pure-numeric tag like `2026` or `42` is stored, indexed, and searchable via `search_traces` / FTS5, but Obsidian silently drops it from the tag panel. Use `y2026`, `2026q1`, or `event-2026-04-02` instead.
+- **Avoid dots inside a tag.** Obsidian interprets `release.candidate` as a nested tag tree (`release` / `candidate`), which is rarely the intent for a flat tag. Use hyphens: `release-candidate`.
+- **No spaces.** Use hyphens or underscores: `network-troubleshooting`, not `network troubleshooting`.
+
+The Obsidian plugin's "New trace" command surfaces these as inline warnings as you type — non-blocking hints, not validation errors. The cortex still accepts the tag.
+
 **Cortex layout on disk:**
 
 ```

--- a/internal/cortex/cortex.go
+++ b/internal/cortex/cortex.go
@@ -811,6 +811,24 @@ Choose the type that best reflects the **intent** of the memory:
   survive and produce awkward IDs. If a trace is *about* a specific date,
   put it in a tag (` + "`tags: [event-2026-04-02]`" + `) or in the body.
 
+## Tags
+
+The cortex accepts any string as a tag — the constraints below are about
+what *renders correctly in Obsidian's tag panel* if a user is authoring
+traces through Obsidian (a common but optional surface). Non-Obsidian
+authoring (CLI, MCP, TUI, agent integrations) is unaffected.
+
+- **Tags must contain at least one letter.** A pure-numeric tag like
+  ` + "`2026`" + ` or ` + "`42`" + ` is stored, indexed, and searchable, but Obsidian
+  silently drops it from the tag panel. Use ` + "`y2026`" + `, ` + "`2026q1`" + `, or
+  ` + "`event-2026-04-02`" + ` instead.
+- **Avoid dots inside a tag.** Obsidian interprets ` + "`release.candidate`" + `
+  as a nested tag tree (` + "`release/candidate`" + `), which is rarely the
+  intent for a flat tag. Use hyphens: ` + "`release-candidate`" + `.
+- **No spaces.** Tag tokens are split on whitespace by most tooling;
+  use hyphens or underscores to keep multi-word tags as one token:
+  ` + "`network-troubleshooting`" + `, not ` + "`network troubleshooting`" + `.
+
 ## Creating a Trace (filesystem)
 
 1. Pick a type and write your content.

--- a/plugins/obsidian/README.md
+++ b/plugins/obsidian/README.md
@@ -23,6 +23,16 @@ That's intentionally the whole feature set for v0.1. File-explorer decorations, 
 
 The status bar will show `noema: <cortex-name>` once the connection succeeds.
 
+## Tag conventions
+
+The cortex accepts any string as a tag — these constraints are about what Obsidian's tag panel surfaces:
+
+- **Tags must contain at least one letter.** Pure-numeric tags like `2026` or `42` are stored on the trace and remain searchable through Noema's MCP / FTS5 surfaces, but Obsidian silently drops them from its tag panel. Use `y2026`, `2026q1`, or `event-2026-04-02`.
+- **Avoid dots in a tag.** Obsidian interprets `release.candidate` as a nested tag tree (`release` / `candidate`). Use hyphens: `release-candidate`.
+- **No spaces.** Use hyphens or underscores: `network-troubleshooting`, not `network troubleshooting`.
+
+The "New trace" command shows inline warnings as you type a non-conformant tag. Submission proceeds normally — these are hints, not errors. Authoring through CLI / MCP / TUI is unaffected.
+
 ## Building
 
 ```sh

--- a/plugins/obsidian/src/create-modal.ts
+++ b/plugins/obsidian/src/create-modal.ts
@@ -18,6 +18,7 @@ export class CreateTraceModal extends Modal {
 	private titleInput!: HTMLInputElement;
 	private typeSelect!: HTMLSelectElement;
 	private tagsInput!: HTMLInputElement;
+	private tagWarningsEl!: HTMLElement;
 	private derivedFromInput!: HTMLInputElement;
 	private submitBtn!: HTMLButtonElement;
 	private errorEl!: HTMLElement;
@@ -55,6 +56,17 @@ export class CreateTraceModal extends Modal {
 			placeholder: "go, language, architecture",
 		}) as HTMLInputElement;
 		this.descriptor("Comma- or semicolon-separated. Optional.");
+		// Tag-validation hints for Obsidian-incompatible tag formats.
+		// We don't BLOCK submission — the cortex accepts any string,
+		// the limitation is purely what Obsidian's tag panel renders.
+		// Inline hints surface the gotcha at the moment of entry, so
+		// users authoring through Obsidian can adjust without
+		// re-reading the docs.
+		this.tagWarningsEl = contentEl.createEl("div", {
+			cls: "noema-create-tag-warnings",
+		});
+		this.tagWarningsEl.style.display = "none";
+		this.tagsInput.addEventListener("input", () => this.refreshTagWarnings());
 
 		this.derivedFromInput = this.row("Derived from", "input", {
 			type: "text",
@@ -117,6 +129,41 @@ export class CreateTraceModal extends Modal {
 			cls: "noema-create-hint",
 			text,
 		});
+	}
+
+	// refreshTagWarnings re-validates the tag input on every keystroke
+	// and updates the inline hint area below the field. Hidden when no
+	// warnings; revealed with a list of `<tag> — <reason>` lines when
+	// any tag would be invisible in Obsidian's tag panel. The cortex
+	// itself accepts every input — this is purely UX guidance for the
+	// Obsidian-authored workflow.
+	private refreshTagWarnings(): void {
+		const tags = splitDelimited(this.tagsInput.value);
+		const warnings = validateObsidianTags(tags);
+		this.tagWarningsEl.empty();
+		if (warnings.length === 0) {
+			this.tagWarningsEl.style.display = "none";
+			return;
+		}
+		this.tagWarningsEl.style.display = "";
+		for (const w of warnings) {
+			const row = this.tagWarningsEl.createEl("div", {
+				cls: "noema-create-tag-warning",
+			});
+			row.createEl("span", {
+				cls: "noema-create-tag-warning-glyph",
+				text: "⚠",
+			});
+			row.createEl("code", {
+				cls: "noema-create-tag-warning-tag",
+				text: w.tag,
+			});
+			row.appendChild(document.createTextNode(" — "));
+			row.createEl("span", {
+				cls: "noema-create-tag-warning-reason",
+				text: w.reason,
+			});
+		}
 	}
 
 	private async submit(): Promise<void> {
@@ -208,6 +255,53 @@ function splitDelimited(raw: string): string[] {
 		.split(/[,;]/)
 		.map((s) => s.trim())
 		.filter(Boolean);
+}
+
+// TagWarning is a hint that a tag will be invisible or misinterpreted
+// in Obsidian's tag panel. The cortex itself accepts every input;
+// these warnings are purely for the Obsidian-authored workflow.
+export interface TagWarning {
+	tag: string;
+	reason: string;
+}
+
+// validateObsidianTags returns a list of warnings for tags that won't
+// render correctly in Obsidian's tag panel. Per Obsidian's tag spec
+// (https://obsidian.md/help/tags#Tag+format):
+//
+//   - Tags must contain at least one non-numeric character. A tag
+//     like "2026" is silently dropped from the tag panel.
+//   - Dots inside a tag are interpreted as nested-tag separators
+//     ("release.candidate" → tag tree "release" / "candidate"),
+//     which is rarely what an author of a flat tag intends.
+//
+// Both forms are valid in the cortex — they're stored, indexed by
+// FTS5, and searchable via MCP tools. The Obsidian-side limitation is
+// purely about what Obsidian's UI surfaces. Exported so a future
+// command-palette tag editor (or other plugin surface) can reuse the
+// rule without duplicating the regex.
+export function validateObsidianTags(tags: string[]): TagWarning[] {
+	const warnings: TagWarning[] = [];
+	for (const t of tags) {
+		// Numeric-only check: any tag whose chars are all in the set
+		// [0-9 - _] (i.e. no letter at all) is dropped by Obsidian.
+		// Trailing-letter "v1" passes, "2026" doesn't, "2026q1" passes.
+		if (/^[0-9_-]+$/.test(t)) {
+			warnings.push({
+				tag: t,
+				reason:
+					"Obsidian requires at least one letter. Pure-numeric tags are not surfaced in its tag panel.",
+			});
+		}
+		if (t.includes(".")) {
+			warnings.push({
+				tag: t,
+				reason:
+					"Obsidian interprets dots as nested-tag separators (so \"a.b\" becomes tag tree a/b).",
+			});
+		}
+	}
+	return warnings;
 }
 
 function sleep(ms: number): Promise<void> {

--- a/plugins/obsidian/styles.css
+++ b/plugins/obsidian/styles.css
@@ -281,3 +281,34 @@
 	gap: 8px;
 	margin-top: 12px;
 }
+
+/* ---- Tag-validation hints in create modal ---- */
+
+.noema-create-tag-warnings {
+	margin: -4px 0 8px 128px;
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+}
+
+.noema-create-tag-warning {
+	font-size: var(--font-ui-smaller);
+	color: var(--text-muted);
+}
+
+.noema-create-tag-warning-glyph {
+	color: var(--text-warning, var(--text-accent));
+	margin-right: 6px;
+}
+
+.noema-create-tag-warning-tag {
+	font-family: var(--font-monospace);
+	color: var(--text-normal);
+	background: var(--background-modifier-border-hover);
+	padding: 0 4px;
+	border-radius: 3px;
+}
+
+.noema-create-tag-warning-reason {
+	color: var(--text-muted);
+}


### PR DESCRIPTION
## Summary

Patch release: surfaces Obsidian's tag-format limitations to authors at the moment of entry, with parallel documentation across all three relevant surfaces.

Single squash commit on a release branch (same pattern as v0.10.0) to satisfy main's no-merge-commits / linear-history rules.

## Two paired PRs landed in this release

- **#75 — Inline tag warnings in the create-trace modal.** Numeric-only tags (`2026`) and tags containing a dot (`release.candidate`) are silently dropped or reinterpreted by Obsidian's tag panel. The plugin now flags these as inline ⚠ hints under the Tags input. Non-blocking — the cortex accepts every input.
- **#76 — Documentation pass.** Three doc surfaces updated with parallel tag-convention guidance: `README.md` (Data Model section), `plugins/obsidian/README.md` (Tag conventions section), and the embedded `AGENTS.md` template that `noema init` writes into every new cortex. The AGENTS.md update is high-leverage — every agent that ever joins a cortex reads it as their primary reference.

## Verification

- [x] `go build ./...` clean (post-squash tree)
- [x] `go vet ./...` clean
- [x] `go test ./...` clean — full suite green
- [ ] CI run on this PR
- [ ] After merge, tag `v0.10.1` and observe GoReleaser publishing to the stable `noema` homebrew formula

## Issues

None opened or closed by this release; pure UX/docs polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)