### PR TITLE
feat(serve): warn when cortex directory is in iCloud Drive

### DIFF
--- a/internal/cli/cmd_serve.go
+++ b/internal/cli/cmd_serve.go
@@ -202,6 +202,20 @@ func serveCmd() *cobra.Command {
 					cx.Name)
 			}
 
+			// iCloud Drive replicates the cortex directory across
+			// hosts and can replace inodes during sync, which the
+			// watcher will see as trash/recreate event bursts. We
+			// don't refuse to start — some operators deliberately use
+			// iCloud as an Obsidian Sync alternative — but the warning
+			// surfaces the escape hatch (`watch.enabled: false`) at
+			// the moment it would matter, so a noisy event log doesn't
+			// look like a bug. Skipped when the watcher is already
+			// disabled or the manifest is unreadable.
+			if manifestErr == nil && m.Watch.WatchEnabled() && inICloudDrive(cx.Dir) {
+				fmt.Fprintf(os.Stderr,
+					"[serve] cortex is in iCloud Drive — watcher may emit sync-driven events; consider watch.enabled: false if noise shows up\n")
+			}
+
 			// Filesystem watcher: on by default so external edits
 			// (Obsidian, VS Code, Finder, iCloud sync, another agent on
 			// the same cortex) emit real mutation events. Gated on the
@@ -411,6 +425,19 @@ func serveCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&printSystemdUnit, "print-systemd-unit", false, "print a systemd service unit for this serve command and exit")
 	cmd.Flags().BoolVar(&printLaunchdPlist, "print-launchd-plist", false, "print a launchd LaunchAgent plist for this serve command and exit")
 	return cmd
+}
+
+// inICloudDrive reports whether the resolved cortex directory lives
+// under the macOS iCloud Drive sync root. Symlinks are resolved so a
+// custom-named link (e.g. ~/cortex -> ~/Library/Mobile Documents/...)
+// is detected too. Returns false on platforms where the path component
+// can't appear, so the caller doesn't need a GOOS guard.
+func inICloudDrive(dir string) bool {
+	resolved, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		resolved = dir
+	}
+	return strings.Contains(resolved, "/Library/Mobile Documents/")
 }
 
 // startWatcher constructs and starts a filesystem watcher for the bound

--- a/internal/cli/cmd_serve_test.go
+++ b/internal/cli/cmd_serve_test.go
@@ -956,3 +956,49 @@ func TestValidateHTTPServe_ImplicitCortexErrorMessage(t *testing.T) {
 		}
 	}
 }
+
+// TestInICloudDrive pins the path-substring contract used by the
+// startup warning. The check is a string match on the canonical
+// macOS iCloud Drive sync root — adding flexibility (case-insensitive,
+// regex, etc.) is a footgun because legitimate paths like
+// "/library/mobile/documents" don't match the real container.
+func TestInICloudDrive(t *testing.T) {
+	cases := []struct {
+		name string
+		dir  string
+		want bool
+	}{
+		{
+			name: "default iCloud Drive container",
+			dir:  "/Users/alice/Library/Mobile Documents/com~apple~CloudDocs/cortex",
+			want: true,
+		},
+		{
+			name: "Obsidian iCloud-managed vault",
+			dir:  "/Users/alice/Library/Mobile Documents/iCloud~md~obsidian/Documents/cortex",
+			want: true,
+		},
+		{
+			name: "regular home directory",
+			dir:  "/Users/alice/cortex",
+			want: false,
+		},
+		{
+			name: "lowercase library is not iCloud",
+			dir:  "/Users/alice/library/mobile documents/cortex",
+			want: false,
+		},
+		{
+			name: "Linux XDG path",
+			dir:  "/home/alice/.local/share/noema/cortex",
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := inICloudDrive(tc.dir); got != tc.want {
+				t.Errorf("inICloudDrive(%q) = %v, want %v", tc.dir, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Detect when the cortex directory lives under macOS iCloud Drive (`/Library/Mobile Documents/`) at `noema serve` startup, resolving symlinks so a custom-named link into iCloud is also caught.
- Emit a single warning line recommending `watch.enabled: false` if false-positive emits become noisy. We don't refuse to start — some operators deliberately use iCloud as an Obsidian Sync alternative.
- Closes the #1 item from #63 (the partly-addressed cluster of iCloud hazards from the original ring stall investigation).

## Why a warning, not a refusal

Discussed at length in #63: the lock file already moved out of the cortex dir (PR #64), so iCloud no longer breaks coordination. The remaining concern is watcher noise — and that's user-visible, fixable, and not always a problem (Obsidian Sync substitution is a legitimate use case). A startup warning surfaces the escape hatch at the right moment without overriding operator intent.

## Test plan

- [x] `go test ./internal/cli/` — full package green
- [x] Unit tests for `inICloudDrive` covering the canonical Apple container, the Obsidian iCloud-managed vault path, regular paths, lowercase-only matches, and Linux XDG paths
- [x] Smoke check on macOS: run `noema serve` against a cortex inside `~/Library/Mobile Documents/com~apple~CloudDocs/...` and verify the warning fires once at startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)