### PR TITLE
test(watch): tighten flaky timing in debounce + settle constants

### DIFF
--- a/internal/watch/watcher_test.go
+++ b/internal/watch/watcher_test.go
@@ -18,9 +18,14 @@ import (
 const testDebounce = 50 * time.Millisecond
 
 // settleTime is how long to wait after a filesystem change for the
-// watcher to observe, debounce, and reconcile. testDebounce * 4 leaves
-// slack for scheduler jitter on busy machines.
-const settleTime = 4 * testDebounce
+// watcher to observe, debounce, and reconcile. testDebounce * 8 leaves
+// slack for scheduler jitter on busy machines — earlier 4× setting was
+// flaking under race-detector + GitHub Actions CPU contention, where a
+// 200ms wait wasn't always enough for the reconcile pipeline to catch
+// up. Bumping to 400ms eliminates the flakes at a per-test cost of
+// ~200ms and adds ~4s to total watch-package runtime, which is a fair
+// trade for deterministic CI.
+const settleTime = 8 * testDebounce
 
 // setupWatcher builds a cortex in a temp dir, seeds it with a single
 // trace, and starts a watcher with a short debounce. Returns the cortex
@@ -396,7 +401,13 @@ func TestDebounceCollapsesBurst(t *testing.T) {
 		if err := os.WriteFile(path, []byte(body), 0o640); err != nil {
 			t.Fatalf("WriteFile %d: %v", i, err)
 		}
-		time.Sleep(testDebounce / 5)
+		// testDebounce/20 keeps the entire 5-write burst comfortably
+		// inside one debounce window even under CI scheduler jitter.
+		// Earlier setting (testDebounce/5) put total burst time at
+		// exactly the debounce window, so any single write slipping
+		// past the window boundary on a slow runner would split the
+		// burst and emit multiple events.
+		time.Sleep(testDebounce / 20)
 	}
 	time.Sleep(settleTime)
 


### PR DESCRIPTION
## Summary

Eliminate three flaky tests in the watch package that have caused CI failures three times in two days:

- TestDebounceCollapsesBurst
- TestExternalDeleteTrashesAndRestores
- TestAtomicSaveDoesNotTrash

All three are timing-sensitive and fail under GitHub Actions CPU contention + race-detector load. Local builds rarely flake; CI does.

## Changes

1. **Bump \`settleTime\` from 4× to 8× testDebounce** (200ms → 400ms). The post-mutation wait wasn't always enough for the reconcile pipeline to catch up under load. Costs ~200ms per test (~4s across the suite) — fair trade for deterministic CI.
2. **Tighten \`TestDebounceCollapsesBurst\` inter-write sleep** from \`testDebounce/5\` (10ms each, total burst = 50ms = exactly the debounce window) to \`testDebounce/20\` (2.5ms each, total burst = 12.5ms = comfortably inside the window). The original spacing meant any write slipping past the boundary on a slow runner would split the burst and emit multiple events.

## Test plan

- [x] \`go test -race ./internal/watch/\` — green
- [x] \`go test -race -count=1\` of the three flaking tests, three consecutive runs — all green
- [x] CI on this PR — pending merge

## Why now

Three flakes in two days isn't weather. The earlier diagnostic stance ("re-run if it flakes again") was correct once; with three failures it crossed into "fix the test, not the runner." Both fixes are small, surgical, and don't change what's being tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)