### PR TITLE
fix(watch): stop file rewrite on external-edit ingest (Obsidian toast loop)

### DIFF
--- a/internal/cortex/cortex.go
+++ b/internal/cortex/cortex.go
@@ -1791,9 +1791,39 @@ func (c *Cortex) restoreBodyToTrash(id string, r *Row) (bool, error) {
 	return true, nil
 }
 
-// Update rewrites an existing trace's DB row and FTS entry from its (potentially
-// edited) markdown file on disk.
+// Update rewrites an existing trace's DB row, FTS entry, AND the on-disk
+// markdown file from the (potentially edited) frontmatter+body on disk.
+// Use this for explicit Noema-driven mutations (CLI, MCP, TUI) where Noema
+// is the writer and the canonical frontmatter format should be re-stamped.
+//
+// Do NOT use this on the watcher's external-edit ingest path: rewriting
+// the file while an editor (Obsidian, VSCode, etc.) has it open kicks
+// off a "modified externally" feedback loop where each Noema rewrite
+// triggers an editor re-save which triggers a watcher event which
+// triggers another Update. Use UpdateFromFile for that path.
 func (c *Cortex) Update(id string) error {
+	return c.updateFromFile(id, true)
+}
+
+// UpdateFromFile syncs the DB and FTS index from the on-disk file
+// without rewriting the file. Used by the filesystem watcher when an
+// external editor has saved a change — the user's editor is the
+// authoritative writer in that flow, and Noema's job is to mirror the
+// new state into the DB, not to canonicalize the editor's frontmatter
+// format back at it. Skipping the rewrite here breaks the
+// "modified externally" toast loop that would otherwise fight with any
+// editor that has the file open.
+//
+// Side effect of skipping the rewrite: the file's frontmatter
+// `updated:` and `content_hash:` fields will go stale relative to the
+// DB. The DB is authoritative anyway (every Noema read goes through
+// it), and explicit mutations through Update will re-canonicalize the
+// frontmatter the next time the user edits via CLI/MCP/TUI.
+func (c *Cortex) UpdateFromFile(id string) error {
+	return c.updateFromFile(id, false)
+}
+
+func (c *Cortex) updateFromFile(id string, rewriteFile bool) error {
 	if err := c.CheckSourceLock(id); err != nil {
 		return err
 	}
@@ -1808,15 +1838,16 @@ func (c *Cortex) Update(id string) error {
 	}
 
 	// Stamp the update time authoritatively rather than trusting whatever the
-	// editor left in the frontmatter — and write it back to the file so disk,
-	// DB, and emitted event all agree. Tier is DB-managed after creation: if
+	// editor left in the frontmatter. Tier is DB-managed after creation: if
 	// the on-disk frontmatter drifted (manual edit), authoritative value lives
-	// in the DB row and gets stamped back to the file here.
+	// in the DB row and gets stamped back into the parsed trace here.
 	t.Updated = time.Now().UTC().Format(time.RFC3339)
 	t.Tier = r.Tier
 	t.ContentHash = trace.ContentHash(t.Body)
-	if err := t.Write(path); err != nil {
-		return fmt.Errorf("rewriting trace file with updated timestamp: %w", err)
+	if rewriteFile {
+		if err := t.Write(path); err != nil {
+			return fmt.Errorf("rewriting trace file with updated timestamp: %w", err)
+		}
 	}
 
 	tx, err := c.DB.Begin()

--- a/internal/watch/reconcile.go
+++ b/internal/watch/reconcile.go
@@ -231,7 +231,7 @@ func (w *Watcher) reconcileExisting(path, id string, dir traceDir, row *cortex.R
 			row, _ = w.cx.Get(id)
 		}
 		if bodyHash != row.ContentHash {
-			if err := w.cx.Update(id); err != nil {
+			if err := w.cx.UpdateFromFile(id); err != nil {
 				return fmt.Errorf("update: %w", err)
 			}
 			log.Printf("[watch] ingested external edit: %s", id)
@@ -255,7 +255,7 @@ func (w *Watcher) reconcileExisting(path, id string, dir traceDir, row *cortex.R
 			row, _ = w.cx.Get(id)
 		}
 		if bodyHash != row.ContentHash {
-			if err := w.cx.Update(id); err != nil {
+			if err := w.cx.UpdateFromFile(id); err != nil {
 				return fmt.Errorf("update: %w", err)
 			}
 			log.Printf("[watch] ingested external edit (archived): %s", id)

--- a/internal/watch/watcher_test.go
+++ b/internal/watch/watcher_test.go
@@ -1,6 +1,7 @@
 package watch_test
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"testing"
@@ -113,6 +114,52 @@ func TestExternalEditEmitsUpdate(t *testing.T) {
 	}
 	if r.ContentHash == "" {
 		t.Error("content_hash should be refreshed after external edit")
+	}
+}
+
+// TestExternalEditDoesNotRewriteFile pins the regression for the
+// "modified externally" toast loop: when an editor saves a file and
+// the watcher ingests the change, Noema must NOT rewrite the file.
+// Rewriting kicks off a feedback loop where the editor sees a fresh
+// external modification, re-saves, the watcher fires again, and so on.
+//
+// Concretely: capture the file's bytes after the external write,
+// trigger watcher reconcile, and assert the bytes are byte-identical
+// afterwards. The DB-side update must still happen (covered by
+// TestExternalEditEmitsUpdate); only the file must stay untouched.
+func TestExternalEditDoesNotRewriteFile(t *testing.T) {
+	cx, _, id := setupWatcher(t)
+
+	path := cx.TraceFile(id, false)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	modified := []byte(string(data) + "\nedit by an external editor\n")
+	if err := os.WriteFile(path, modified, 0o640); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	time.Sleep(settleTime)
+
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile after settle: %v", err)
+	}
+	if !bytes.Equal(modified, after) {
+		t.Errorf("watcher rewrote the file after an external edit\n--- expected (caller's bytes) ---\n%s\n--- got (file on disk) ---\n%s",
+			string(modified), string(after))
+	}
+
+	// Sanity: the DB still picked up the change. Without this, a
+	// regression that disabled the watcher entirely would also pass
+	// the byte-equality check.
+	r, err := cx.Get(id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if r.ContentHash == "" {
+		t.Error("DB content_hash should be set after external edit")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fix a self-driving feedback loop where editing a trace in Obsidian (or any editor with the file open) produced a "modified externally, merging changes automatically" toast every few seconds during active writing.

## Diagnosis

Reproduced live: every Obsidian save triggered \`Cortex.Update\`, which unconditionally rewrote the file with a fresh \`updated:\` timestamp and recomputed \`content_hash\`. Obsidian saw the rewrite as an external modification, displayed the toast, merged + re-saved, the watcher ingested the re-save, called \`Update\` again — loop. The bug isn't Obsidian-specific; it'd hit any editor with the file open (VSCode, vim with autoreload, etc.).

## Fix

Split \`Update\` into two paths:

- **\`Update(id)\`** — unchanged behavior. Used by CLI / MCP / TUI explicit mutations where Noema is the writer and canonicalizing frontmatter is the right thing.
- **\`UpdateFromFile(id)\`** — new entry point. Reads file, syncs DB + FTS, emits Update event. **Does NOT rewrite the file.** Used by the watcher's external-edit ingest paths.

Watcher's reconcile dispatches both external-edit branches (active and archive) through \`UpdateFromFile\`, breaking the loop.

## Tradeoff

The file's frontmatter \`updated:\` and \`content_hash:\` fields will go stale relative to the DB. Mitigations considered:

- **Lazy self-heal**: explicit mutations through CLI / MCP / TUI re-canonicalize frontmatter naturally. Covers the common case.
- **Boot-time canonicalize**: walk active traces at serve startup, rewrite stale frontmatter. Deferred — small follow-up if staleness becomes a visible issue.
- **lsof-gated rewrite**: only canonicalize when no editor has files open in the cortex. Cleverer but adds platform-specific code; deferred until evidence it's worth the complexity.

The DB is authoritative for trace metadata anyway (every \`get_trace\` and \`noema get\` read goes through it), so frontmatter staleness is mostly invisible to Noema's primary surfaces.

## Test plan

- [x] \`go test -race ./internal/watch/\` green
- [x] New regression test \`TestExternalEditDoesNotRewriteFile\` asserts file is byte-identical before/after watcher reconcile, with sanity check that DB still updates
- [x] Full \`go test ./...\` green
- [ ] CI on this PR
- [ ] Live verification: edit a trace in Obsidian, confirm no "modified externally" toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)