### PR TITLE
fix(hermes): build session-summary body from all user turns + final response

### DIFF
--- a/plugins/hermes/__init__.py
+++ b/plugins/hermes/__init__.py
@@ -184,6 +184,17 @@ _TOOL_MAP = {
 # Max chars to keep from user/assistant content in the session log.
 _TURN_MAX_CHARS = 2000
 
+# Bookends for session-summary bodies. User questions frame the topical
+# scope of a session — usually short directives or "how do I X" prompts —
+# so we capture all of them at a generous-but-bounded length to give FTS5
+# good signal. The final assistant turn carries the resolution and gets a
+# longer slice. Total body stays under ~4 KB for a typical session, well
+# below Hermes's default memory_char_limit so injecting one summary still
+# leaves room for sibling traces.
+_SUMMARY_MAX_USER_TURNS = 12
+_SUMMARY_USER_CHARS = 240
+_SUMMARY_FINAL_ASSISTANT_CHARS = 1500
+
 
 def _tool_error(msg: str) -> str:
     return json.dumps({"error": msg})
@@ -191,6 +202,46 @@ def _tool_error(msg: str) -> str:
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _build_session_summary_body(messages: List[Dict[str, Any]], turn_count: int) -> str:
+    """Construct the body for a session-summary trace.
+
+    Earlier versions used only the final assistant message as the body,
+    which made the trace title ("session-summary: …") inconsistent with
+    its content (a single assistant turn). The result was poor FTS5
+    signal and search results that returned message fragments instead
+    of summaries. This builder bookends the session: every user turn
+    (the topical-scope signal — what was *asked*) followed by the final
+    assistant turn (how it ended). Each user message is truncated
+    individually so a verbose user turn can't crowd out the rest.
+    """
+    user_turns: List[str] = []
+    final_assistant = ""
+    for msg in messages:
+        role = msg.get("role")
+        content = msg.get("content", "")
+        if not isinstance(content, str) or not content.strip():
+            continue
+        if role == "user":
+            user_turns.append(content.strip()[:_SUMMARY_USER_CHARS])
+        elif role == "assistant":
+            final_assistant = content.strip()[:_SUMMARY_FINAL_ASSISTANT_CHARS]
+
+    # Cap user-turn count so a runaway session doesn't blow the body
+    # budget. We keep the most recent turns because they carry the
+    # current intent; opener context degrades fast in long sessions.
+    if len(user_turns) > _SUMMARY_MAX_USER_TURNS:
+        user_turns = user_turns[-_SUMMARY_MAX_USER_TURNS:]
+
+    parts = [f"Session with {turn_count} turns."]
+    if user_turns:
+        parts.append("## User turns")
+        parts.extend(f"- {t}" for t in user_turns)
+    if final_assistant:
+        parts.append("## Final assistant response")
+        parts.append(final_assistant)
+    return "\n\n".join(parts)
 
 
 # ---------------------------------------------------------------------------
@@ -467,14 +518,7 @@ class NoemaMemoryProvider(MemoryProvider):
         turn_count = self._turn_count
         title = self._session_title or self._session_id[:12]
 
-        # Extract last assistant message for the summary.
-        last_assistant = ""
-        for msg in reversed(messages or []):
-            if msg.get("role") == "assistant":
-                content = msg.get("content", "")
-                if isinstance(content, str) and content.strip():
-                    last_assistant = content[:3000]
-                    break
+        body = _build_session_summary_body(messages or [], turn_count)
 
         def _end():
             try:
@@ -482,7 +526,6 @@ class NoemaMemoryProvider(MemoryProvider):
                 if self._sync_thread and self._sync_thread.is_alive():
                     self._sync_thread.join(timeout=5.0)
 
-                body = f"Session with {turn_count} turns.\n\n{last_assistant}" if last_assistant else f"Session with {turn_count} turns."
                 self._transport.call_tool("create_trace", {
                     "title": f"session-summary: {title}",
                     "type": "observation",

--- a/plugins/hermes/tests/test_unit.py
+++ b/plugins/hermes/tests/test_unit.py
@@ -24,6 +24,10 @@ from plugins.hermes import (
     _tool_error,
     _now_iso,
     _load_config,
+    _build_session_summary_body,
+    _SUMMARY_MAX_USER_TURNS,
+    _SUMMARY_USER_CHARS,
+    _SUMMARY_FINAL_ASSISTANT_CHARS,
 )
 
 
@@ -592,3 +596,101 @@ class TestSessionTrace:
 
         call_args = p._transport.call_tool.call_args
         assert "abcdefghijkl" in call_args[0][1]["title"]
+
+
+# ---------------------------------------------------------------------------
+# Session-summary body builder
+# ---------------------------------------------------------------------------
+
+class TestBuildSessionSummaryBody:
+    """Pin the structure of the session-summary body so future edits don't
+    silently regress to the old "last assistant message only" shape that
+    polluted the cortex's mid-tier search corpus."""
+
+    def test_includes_all_user_turns_as_topical_signal(self):
+        messages = [
+            {"role": "user", "content": "How does the FTS5 tokenizer handle hyphens?"},
+            {"role": "assistant", "content": "Hyphens split tokens by default."},
+            {"role": "user", "content": "Can we override that?"},
+            {"role": "assistant", "content": "Yes — pass a custom tokenizer."},
+        ]
+        body = _build_session_summary_body(messages, turn_count=2)
+
+        # Both user questions present — these carry the topical scope
+        # FTS5 will rank against.
+        assert "FTS5 tokenizer" in body
+        assert "override" in body
+        # Final assistant turn present.
+        assert "custom tokenizer" in body
+        # Earlier assistant turn deliberately absent — only the final
+        # one is bookended.
+        assert "Hyphens split tokens" not in body
+        # Turn count surfaces.
+        assert "2 turns" in body
+
+    def test_no_messages_returns_turn_count_only(self):
+        body = _build_session_summary_body([], turn_count=0)
+        assert body == "Session with 0 turns."
+
+    def test_skips_blank_and_non_string_content(self):
+        messages = [
+            {"role": "user", "content": ""},
+            {"role": "user", "content": "   "},
+            {"role": "user", "content": None},
+            {"role": "user", "content": "real question"},
+            {"role": "assistant", "content": "real answer"},
+        ]
+        body = _build_session_summary_body(messages, turn_count=1)
+        assert "real question" in body
+        assert "real answer" in body
+        # The blanks must not produce empty bullet rows.
+        assert "- \n" not in body
+        assert "-  \n" not in body
+
+    def test_user_turns_truncated_individually(self):
+        long_q = "x" * (_SUMMARY_USER_CHARS * 3)
+        messages = [
+            {"role": "user", "content": long_q},
+            {"role": "assistant", "content": "ok"},
+        ]
+        body = _build_session_summary_body(messages, turn_count=1)
+        # The single user turn must be capped to _SUMMARY_USER_CHARS so a
+        # verbose user turn can't crowd the rest of the body.
+        assert body.count("x") == _SUMMARY_USER_CHARS
+
+    def test_user_turn_count_capped_to_max(self):
+        # Inject more than the cap; only the most-recent _SUMMARY_MAX_USER_TURNS
+        # should survive (we keep the tail because it carries current
+        # intent).
+        msgs = []
+        for i in range(_SUMMARY_MAX_USER_TURNS + 5):
+            msgs.append({"role": "user", "content": f"q{i}"})
+        body = _build_session_summary_body(msgs, turn_count=len(msgs))
+        # First 5 questions dropped; tail kept.
+        assert "q0" not in body
+        assert "q4" not in body
+        assert f"q{_SUMMARY_MAX_USER_TURNS + 4}" in body
+
+    def test_final_assistant_truncated_to_cap(self):
+        long_a = "y" * (_SUMMARY_FINAL_ASSISTANT_CHARS * 2)
+        messages = [
+            {"role": "user", "content": "go"},
+            {"role": "assistant", "content": long_a},
+        ]
+        body = _build_session_summary_body(messages, turn_count=1)
+        assert body.count("y") == _SUMMARY_FINAL_ASSISTANT_CHARS
+
+    def test_only_user_turns_no_final_assistant(self):
+        # Edge case: session aborted before the model responded.
+        messages = [{"role": "user", "content": "what about Go?"}]
+        body = _build_session_summary_body(messages, turn_count=0)
+        assert "what about Go?" in body
+        assert "Final assistant response" not in body
+
+    def test_only_assistant_no_user_section(self):
+        # Edge case: provider hook fired with assistant-only context
+        # (system prompt aside). Skip the user section entirely.
+        messages = [{"role": "assistant", "content": "I have no input."}]
+        body = _build_session_summary_body(messages, turn_count=0)
+        assert "I have no input." in body
+        assert "User turns" not in body


### PR DESCRIPTION
## Summary

The Hermes plugin's \`on_session_end\` used to set the session-summary body to just the **last assistant message** — making the trace's title (\"session-summary: …\") inconsistent with its content (a single message fragment) and giving FTS5 poor signal.

The new builder bookends the session: every user turn (the topical scope — what was *asked*) plus the final assistant turn (how it ended), each truncated individually so a verbose turn can't crowd the rest.

## Why

Audit of an active cortex showed many \"session-summary\" mid-tier traces whose bodies were a single fragment like \"I honestly don't have them — I've searched the entire filesystem...\" rather than an actual summary of the session. Those fragments dominate FTS5 results for any topic the session covered, so memory-injection providers see noise instead of signal. This is the upstream half of why auto-injection memory was degrading; the downstream half (Noema-side instrumentation so search hits drive graduation) is in #84.

## Test plan

- [x] All 84 unit tests pass (\`python -m pytest plugins/hermes/tests/test_unit.py\`)
- [x] Existing integration test contract preserved: title still prefixed \`session-summary:\`, type still \`observation\`, session trace still archived
- [x] 8 new tests pin: all user turns included, final assistant included, individual truncation, max-user-turn cap (keeps tail), blank-content skipping, edge cases (no user, no assistant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)