### PR TITLE
fix(consolidation): require ≥2 sources for lineage credit in heuristic

### DIFF
--- a/internal/consolidation/heuristic.go
+++ b/internal/consolidation/heuristic.go
@@ -116,6 +116,16 @@ func HeuristicPass(cx HeuristicProvider, cfg PassConfig, log func(format string,
 	}
 }
 
+// MinLineageSourcesForCredit is the minimum derived_from count that
+// earns the lineage weight in the heuristic score. A single derived_from
+// is provenance metadata (this trace was extracted from / supersedes /
+// annotates one other trace), not consolidation, and shouldn't tilt the
+// promotion threshold on its own. Two-or-more is the same bar
+// CreateDistilledTrace enforces (cortex.ErrDistillSourcesInsufficient at
+// internal/cortex/distill.go:76), so the heuristic agrees with the
+// distillation entry point on what counts as a real synthesis.
+const MinLineageSourcesForCredit = 2
+
 // scoreCandidate computes the blended signal for a single trace.
 // Exported for tests; package-private callers don't need it because
 // HeuristicPass is the single consumer.
@@ -127,9 +137,21 @@ func HeuristicPass(cx HeuristicProvider, cfg PassConfig, log func(format string,
 // Hermes only ever generate search hits, and without this fold-in
 // short-tier traces in those cortexes would never accumulate enough
 // signal to promote.
+//
+// Lineage credit is gated by MinLineageSourcesForCredit: a trace with
+// only one derived_from gets zero lineage points, regardless of the
+// configured WeightLineage. This stops 1-source provenance links (e.g.
+// the Hermes session-summary pattern, which sets derived_from to the
+// single session trace it was extracted from) from gliding past the
+// promotion threshold purely on the lineage head start. Multi-source
+// traces still earn the full weight per source.
 func scoreCandidate(pc cortex.PromotionCandidate, cfg PassConfig) int {
+	lineageCredit := 0
+	if pc.DerivedFromCount >= MinLineageSourcesForCredit {
+		lineageCredit = pc.DerivedFromCount * cfg.WeightLineage
+	}
 	return (pc.ReadCount+pc.SearchHitCount)*cfg.WeightReads +
 		pc.ModifyCount*cfg.WeightModifies +
-		pc.DerivedFromCount*cfg.WeightLineage +
+		lineageCredit +
 		pc.TierVotes*cfg.WeightVotes
 }

--- a/internal/consolidation/heuristic_test.go
+++ b/internal/consolidation/heuristic_test.go
@@ -48,9 +48,17 @@ func TestScoreCandidate_BlendedFormula(t *testing.T) {
 		{"5 search hits", cortex.PromotionCandidate{SearchHitCount: 5}, 5},
 		{"3 reads + 2 search hits sums into reads bucket", cortex.PromotionCandidate{ReadCount: 3, SearchHitCount: 2}, 5},
 		{"1 modify", cortex.PromotionCandidate{ModifyCount: 1}, 2},
-		{"1 lineage ref", cortex.PromotionCandidate{DerivedFromCount: 1}, 3},
+		// Lineage credit is gated at >= 2 sources. A single derived_from
+		// is provenance, not consolidation — see MinLineageSourcesForCredit.
+		{"1 lineage ref earns no credit", cortex.PromotionCandidate{DerivedFromCount: 1}, 0},
+		{"2 lineage refs earn full credit", cortex.PromotionCandidate{DerivedFromCount: 2}, 6},
+		{"3 lineage refs scale linearly", cortex.PromotionCandidate{DerivedFromCount: 3}, 9},
 		{"1 vote", cortex.PromotionCandidate{TierVotes: 1}, 5},
 		{"mix: 2 reads + 1 modify + 1 vote", cortex.PromotionCandidate{ReadCount: 2, ModifyCount: 1, TierVotes: 1}, 2 + 2 + 5},
+		// 1-source lineage doesn't push a low-engagement trace over the
+		// threshold — exactly the regression we want this gate to prevent
+		// (Hermes session-summary mids glided past on lineage alone).
+		{"1 lineage + 1 read stays sub-threshold", cortex.PromotionCandidate{ReadCount: 1, DerivedFromCount: 1}, 1},
 		{"negative vote counts against", cortex.PromotionCandidate{TierVotes: -1}, -5},
 	}
 	for _, tc := range tests {
@@ -71,7 +79,14 @@ func TestHeuristicPass_PromotesAboveThreshold(t *testing.T) {
 			{ID: "meh", Tier: trace.TierShort, ReadCount: 2},             // score 2  - skip
 			{ID: "voted", Tier: trace.TierShort, TierVotes: 1},           // score 5  - promote (at threshold)
 			{ID: "cold", Tier: trace.TierShort},                           // score 0  - skip
-			{ID: "referenced", Tier: trace.TierShort, DerivedFromCount: 2}, // score 6  - promote
+			{ID: "referenced", Tier: trace.TierShort, DerivedFromCount: 2}, // score 6  - promote (real consolidation)
+			// Regression guard: a 1-source provenance link with low
+			// engagement must not glide past the threshold. This is the
+			// exact pattern (Hermes session-summary writes one
+			// derived_from pointing at the session trace) that was
+			// silently inflating mid-tier before MinLineageSourcesForCredit
+			// landed. Score: 1*1 (read) + 0 (lineage gated) = 1.
+			{ID: "session-summary-shaped", Tier: trace.TierShort, ReadCount: 1, DerivedFromCount: 1},
 		},
 	}
 	pass := HeuristicPass(cx, PassConfig{}, nil)
@@ -87,7 +102,7 @@ func TestHeuristicPass_PromotesAboveThreshold(t *testing.T) {
 			t.Errorf("expected %q to be promoted, promoted=%v", want, cx.promoted)
 		}
 	}
-	for _, shouldSkip := range []string{"meh", "cold"} {
+	for _, shouldSkip := range []string{"meh", "cold", "session-summary-shaped"} {
 		if got[shouldSkip] {
 			t.Errorf("unexpected promotion of %q", shouldSkip)
 		}


### PR DESCRIPTION
## Summary

Tightens the short→mid heuristic so a single \`derived_from\` link no longer earns the full lineage weight. A trace with two-or-more sources is consolidation; a trace with one is provenance metadata, and shouldn't tilt the promotion threshold by itself.

## Why

Audit showed the Hermes session-summary writeback pattern (one \`derived_from\` pointing at the session trace it was extracted from) was repeatedly clearing the heuristic threshold of 5: 1 source × WeightLineage 3 + 1 read × WeightReads 1 + … = enough to promote, even though the trace wasn't synthesizing anything. The result was dozens of low-engagement mid-tier traces polluting FTS5 search results.

\`CreateDistilledTrace\` already enforces this rule from the other direction — it returns \`ErrDistillSourcesInsufficient\` when fewer than 2 sources are passed (\`internal/cortex/distill.go:76\`). This change brings the heuristic into agreement on what counts as a real synthesis.

Single-source traces still keep their \`derived_from\` link in \`trace_lineage\` — \`trace_lineage\` queries (and the upcoming \`derived_by\` view) are unchanged. The gate is purely on the heuristic score, not on the relationship itself.

## Test plan

- [x] \`go build ./...\`
- [x] \`go vet ./...\`
- [x] \`go test ./...\` — all green
- [x] \`TestScoreCandidate_BlendedFormula\` extended with boundary cases (0/1/2/3 sources) and a regression case for the \"1 lineage + 1 read stays sub-threshold\" pattern
- [x] \`TestHeuristicPass_PromotesAboveThreshold\` extended with a \`session-summary-shaped\` candidate that asserts the gate now blocks the historical bad pattern

## Related

Pairs with #84 (search-hit instrumentation) and #85 (Hermes session-summary body fix). Together: stop minting bad mids, fix the body content of the ones that were minted, and start producing usage signal so the surviving mids can graduate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)