### PR TITLE
feat(stats): extend memory stats with engagement + lineage diagnostics

### DIFF
--- a/internal/cli/cmd_memory.go
+++ b/internal/cli/cmd_memory.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"text/tabwriter"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -204,14 +205,41 @@ thinking it's short-term.`,
 	return cmd
 }
 
+// statsReport bundles every metric the stats command can surface.
+// Flat structure so JSON output stays predictable and scriptable —
+// downstream tooling can grep for specific fields without descending
+// into nested objects.
+type statsReport struct {
+	Tiers      cortex.TierStats             `json:"tiers"`
+	Engagement *cortex.EngagementStats      `json:"engagement,omitempty"`
+	Lineage    *cortex.MidLineageBreakdown  `json:"mid_lineage,omitempty"`
+	MidHealth  *cortex.MidEngagementSnapshot `json:"mid_engagement,omitempty"`
+}
+
 func memoryStatsCmd() *cobra.Command {
 	var outputFlag string
+	var detailedFlag bool
+	var zeroEngagementAgeDays int
 	cmd := &cobra.Command{
 		Use:   "stats",
-		Short: "Show tier counts for the active cortex",
+		Short: "Show tier counts and (with --detailed) engagement signal for the active cortex",
 		Long: `Reports how many traces currently live in each memory tier, plus the
 count of purged tombstones. Archived and trashed traces are excluded
 so the numbers reflect memory actively in use.
+
+Pass --detailed to add the engagement dashboard:
+
+  - total reads / search hits / modifies across active traces (the
+    federation-wide signal the consolidation heuristic and graduation
+    gate evaluate against)
+  - mid-tier lineage breakdown: 0 sources / 1 source / >=2 sources.
+    Real consolidations live in the >=2 bucket; a growing 1-source
+    bucket usually indicates a writeback pattern emitting "summary"
+    traces that aren't really summarising.
+  - mid-tier zero-engagement count: traces with no reads, no search
+    hits, no modifies. The older-than-14d subset is a candidate pool
+    for archival — the graduation min-age is the same threshold so
+    these traces had a fair chance to accumulate signal.
 
 Later phases will expand this dashboard with consolidation quality
 metrics (validation pass rate, cohesion confidence, model-tier
@@ -223,23 +251,69 @@ profile performance) as the event log accumulates that data.`,
 			}
 			defer cx.Close()
 
-			stats, err := cx.TierStats()
+			tiers, err := cx.TierStats()
 			if err != nil {
 				return err
+			}
+			report := statsReport{Tiers: tiers}
+
+			if detailedFlag {
+				eng, err := cx.EngagementStats()
+				if err != nil {
+					return fmt.Errorf("engagement stats: %w", err)
+				}
+				lineage, err := cx.MidLineageBreakdown()
+				if err != nil {
+					return fmt.Errorf("lineage breakdown: %w", err)
+				}
+				olderThan := time.Duration(zeroEngagementAgeDays) * 24 * time.Hour
+				health, err := cx.MidEngagementSnapshot(olderThan)
+				if err != nil {
+					return fmt.Errorf("mid engagement snapshot: %w", err)
+				}
+				report.Engagement = &eng
+				report.Lineage = &lineage
+				report.MidHealth = &health
 			}
 
 			switch outputFlag {
 			case "json":
-				out, _ := json.MarshalIndent(stats, "", "  ")
+				out, _ := json.MarshalIndent(report, "", "  ")
 				fmt.Println(string(out))
 			case "text", "":
 				w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
 				fmt.Fprintf(w, "Tier\tCount\n")
-				fmt.Fprintf(w, "short\t%d\n", stats.Short)
-				fmt.Fprintf(w, "mid\t%d\n", stats.Mid)
-				fmt.Fprintf(w, "long\t%d\n", stats.Long)
-				fmt.Fprintf(w, "purged\t%d\n", stats.Purged)
+				fmt.Fprintf(w, "short\t%d\n", report.Tiers.Short)
+				fmt.Fprintf(w, "mid\t%d\n", report.Tiers.Mid)
+				fmt.Fprintf(w, "long\t%d\n", report.Tiers.Long)
+				fmt.Fprintf(w, "purged\t%d\n", report.Tiers.Purged)
 				w.Flush()
+
+				if detailedFlag {
+					fmt.Fprintln(cmd.OutOrStdout())
+					ew := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+					fmt.Fprintf(ew, "Signal\tTotal\n")
+					fmt.Fprintf(ew, "reads\t%d\n", report.Engagement.TotalReads)
+					fmt.Fprintf(ew, "search hits\t%d\n", report.Engagement.TotalSearchHits)
+					fmt.Fprintf(ew, "modifies\t%d\n", report.Engagement.TotalModifies)
+					ew.Flush()
+
+					fmt.Fprintln(cmd.OutOrStdout())
+					lw := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
+					fmt.Fprintf(lw, "Mid lineage\tCount\n")
+					fmt.Fprintf(lw, "no derived_from\t%d\n", report.Lineage.NoSources)
+					fmt.Fprintf(lw, "1 source\t%d\n", report.Lineage.SingleSource)
+					fmt.Fprintf(lw, ">=2 sources\t%d\n", report.Lineage.MultiSource)
+					lw.Flush()
+
+					fmt.Fprintln(cmd.OutOrStdout())
+					fmt.Fprintf(cmd.OutOrStdout(),
+						"Mid traces with zero engagement: %d (%d older than %dd)\n",
+						report.MidHealth.ZeroEngagement,
+						report.MidHealth.ZeroEngagementOlder,
+						zeroEngagementAgeDays,
+					)
+				}
 			default:
 				return fmt.Errorf("unsupported --output %q (try: text, json)", outputFlag)
 			}
@@ -247,5 +321,7 @@ profile performance) as the event log accumulates that data.`,
 		},
 	}
 	cmd.Flags().StringVar(&outputFlag, "output", "text", "output format: text, json")
+	cmd.Flags().BoolVar(&detailedFlag, "detailed", false, "include engagement signal, lineage breakdown, and zero-engagement counts")
+	cmd.Flags().IntVar(&zeroEngagementAgeDays, "zero-engagement-age-days", 14, "age threshold (days) for the zero-engagement-older count under --detailed")
 	return cmd
 }

--- a/internal/cortex/stats.go
+++ b/internal/cortex/stats.go
@@ -17,6 +17,52 @@ type TierStats struct {
 	Purged int
 }
 
+// EngagementStats summarises usage signal across all active traces in
+// the cortex. Aggregates across every peer's trace_usage rows so the
+// numbers reflect federation-wide consumption, not the local slice.
+// Used by `noema memory stats --detailed` to answer "is anyone
+// actually reading these traces" at a glance — the question that
+// motivated migration 015's search_hit_count, since auto-injection
+// providers were generating only the search_hit_count signal.
+type EngagementStats struct {
+	TotalReads      int // sum of read_count across active traces
+	TotalSearchHits int // sum of search_hit_count
+	TotalModifies   int // sum of modify_count
+}
+
+// MidLineageBreakdown reports how mid-tier traces decompose by their
+// derived_from count. The buckets answer the diagnostic question that
+// surfaced during the Hermes session-summary audit: how much of the
+// mid tier is real consolidation vs. provenance-only forwarding?
+//
+//   - NoSources:   stand-alone mids (heuristic-promoted, manually
+//     curated, etc.) — neither bad nor good, just not synthesis.
+//   - SingleSource: one derived_from. After
+//     MinLineageSourcesForCredit landed in the heuristic, no NEW
+//     traces in this bucket should be promoting via the lineage
+//     bonus alone. A growing count here is still a smell because it
+//     usually points at a writeback pattern emitting "summary"
+//     traces that aren't really summarising.
+//   - MultiSource: ≥2 derived_from — real distillations.
+type MidLineageBreakdown struct {
+	NoSources    int
+	SingleSource int
+	MultiSource  int
+}
+
+// MidEngagementSnapshot reports how many mid-tier traces have
+// accumulated any usage signal at all. ZeroEngagement is the count of
+// active mid traces with no reads, no search hits, and no modifies —
+// the cohort that's accumulating in the cortex without earning its
+// keep, and the natural input to a future archival pass. Older
+// expresses the same cohort filtered to traces older than the
+// graduation min-age (default 14 days) so transient new traces don't
+// inflate the number.
+type MidEngagementSnapshot struct {
+	ZeroEngagement      int
+	ZeroEngagementOlder int // ZeroEngagement filtered to age >= 14 days
+}
+
 // TierStats counts active traces by tier and purged tombstones.
 // Archived and trashed traces are excluded so the numbers reflect
 // "memory currently in use" — the signal users reason about when
@@ -59,6 +105,96 @@ func (c *Cortex) TierStats() (TierStats, error) {
 	).Scan(&s.Purged); err != nil {
 		return s, err
 	}
+	return s, nil
+}
+
+// EngagementStats sums read/search-hit/modify counters across every
+// peer's row for every active trace. Active = not archived, trashed,
+// or purged. The federation MAX-merges these counters per trace at
+// sync time, so summing all rows here gives the federation-wide
+// signal even on a single peer.
+func (c *Cortex) EngagementStats() (EngagementStats, error) {
+	var s EngagementStats
+	err := c.DB.QueryRow(`
+		SELECT
+			COALESCE(SUM(u.read_count), 0),
+			COALESCE(SUM(u.search_hit_count), 0),
+			COALESCE(SUM(u.modify_count), 0)
+		FROM trace_usage u
+		JOIN traces t ON t.id = u.trace_id
+		WHERE t.archived_at IS NULL
+		  AND t.trashed_at IS NULL
+		  AND t.purged_at IS NULL`,
+	).Scan(&s.TotalReads, &s.TotalSearchHits, &s.TotalModifies)
+	return s, err
+}
+
+// MidLineageBreakdown bucketizes active mid-tier traces by their
+// outbound derived_from count (how many sources THIS trace has, not
+// how many others reference it). v_derived_from_count is the inbound
+// view used by the heuristic; here we group trace_lineage by trace_id
+// directly to get the outbound count.
+func (c *Cortex) MidLineageBreakdown() (MidLineageBreakdown, error) {
+	var b MidLineageBreakdown
+	q := `
+		SELECT
+			SUM(CASE WHEN COALESCE(l.n, 0) = 0 THEN 1 ELSE 0 END),
+			SUM(CASE WHEN COALESCE(l.n, 0) = 1 THEN 1 ELSE 0 END),
+			SUM(CASE WHEN COALESCE(l.n, 0) >= 2 THEN 1 ELSE 0 END)
+		FROM traces t
+		LEFT JOIN (
+			SELECT trace_id, COUNT(*) AS n
+			FROM trace_lineage
+			GROUP BY trace_id
+		) l ON l.trace_id = t.id
+		WHERE t.tier = 'mid'
+		  AND t.archived_at IS NULL
+		  AND t.trashed_at IS NULL
+		  AND t.purged_at IS NULL`
+	row := c.DB.QueryRow(q)
+	var none, single, multi sql.NullInt64
+	if err := row.Scan(&none, &single, &multi); err != nil {
+		return b, err
+	}
+	b.NoSources = int(none.Int64)
+	b.SingleSource = int(single.Int64)
+	b.MultiSource = int(multi.Int64)
+	return b, nil
+}
+
+// MidEngagementSnapshot reports zero-engagement counts for the mid
+// tier — total and the older subset (age >= the supplied threshold,
+// typically the graduation min-age so transient new mids don't
+// inflate the number).
+func (c *Cortex) MidEngagementSnapshot(olderThan time.Duration) (MidEngagementSnapshot, error) {
+	var s MidEngagementSnapshot
+	cutoff := time.Now().UTC().Add(-olderThan).Format(time.RFC3339)
+	q := `
+		SELECT
+			COUNT(*),
+			SUM(CASE WHEN t.created_at <= ? THEN 1 ELSE 0 END)
+		FROM traces t
+		LEFT JOIN (
+			SELECT trace_id,
+			       SUM(read_count)       AS reads,
+			       SUM(search_hit_count) AS hits,
+			       SUM(modify_count)     AS mods
+			FROM trace_usage
+			GROUP BY trace_id
+		) u ON u.trace_id = t.id
+		WHERE t.tier = 'mid'
+		  AND t.archived_at IS NULL
+		  AND t.trashed_at IS NULL
+		  AND t.purged_at IS NULL
+		  AND COALESCE(u.reads, 0) = 0
+		  AND COALESCE(u.hits, 0) = 0
+		  AND COALESCE(u.mods, 0) = 0`
+	var total, older sql.NullInt64
+	if err := c.DB.QueryRow(q, cutoff).Scan(&total, &older); err != nil {
+		return s, err
+	}
+	s.ZeroEngagement = int(total.Int64)
+	s.ZeroEngagementOlder = int(older.Int64)
 	return s, nil
 }
 

--- a/internal/cortex/stats_engagement_test.go
+++ b/internal/cortex/stats_engagement_test.go
@@ -1,0 +1,195 @@
+package cortex_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Fail-Safe/Noema/internal/cortex"
+	"github.com/Fail-Safe/Noema/internal/trace"
+)
+
+// TestEngagementStats_AggregatesAcrossActiveTraces pins that the
+// summary sums every counter from every peer's row, restricted to
+// active (not archived/trashed/purged) traces. Archived rows are the
+// most likely regression — adding a trace, archiving it, and then
+// asserting the read counter still surfaces is exactly what we don't
+// want for an "actively in use" dashboard.
+func TestEngagementStats_AggregatesAcrossActiveTraces(t *testing.T) {
+	cx := setup(t)
+
+	active := trace.New("active", "note", "", nil, "body")
+	if err := cx.Add(active); err != nil {
+		t.Fatalf("Add active: %v", err)
+	}
+	// Two reads + one search hit on the active trace.
+	for range 2 {
+		if _, err := cx.GetAs(active.ID, cortex.ActorAgent); err != nil {
+			t.Fatalf("GetAs: %v", err)
+		}
+	}
+	if _, err := cx.SearchAs("active", cortex.ListOptions{}, cortex.ActorAgent, cortex.DefaultSearchHitTopN); err != nil {
+		t.Fatalf("SearchAs: %v", err)
+	}
+
+	// Archived trace whose counters must be excluded.
+	archived := trace.New("archived", "note", "", nil, "body")
+	if err := cx.Add(archived); err != nil {
+		t.Fatalf("Add archived: %v", err)
+	}
+	if _, err := cx.GetAs(archived.ID, cortex.ActorAgent); err != nil {
+		t.Fatalf("GetAs archived: %v", err)
+	}
+	if err := cx.Archive(archived.ID); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+
+	got, err := cx.EngagementStats()
+	if err != nil {
+		t.Fatalf("EngagementStats: %v", err)
+	}
+	if got.TotalReads != 2 {
+		t.Errorf("TotalReads = %d, want 2 (archived trace's read should be excluded)", got.TotalReads)
+	}
+	if got.TotalSearchHits != 1 {
+		t.Errorf("TotalSearchHits = %d, want 1", got.TotalSearchHits)
+	}
+}
+
+func TestEngagementStats_EmptyCortex(t *testing.T) {
+	cx := setup(t)
+	got, err := cx.EngagementStats()
+	if err != nil {
+		t.Fatalf("EngagementStats: %v", err)
+	}
+	if got.TotalReads != 0 || got.TotalSearchHits != 0 || got.TotalModifies != 0 {
+		t.Errorf("expected all zero, got %+v", got)
+	}
+}
+
+// TestMidLineageBreakdown_BucketsBySourceCount pins that mids are
+// classified by their derived_from count. The 1-source bucket is the
+// signal we care about — a growing count there is a smell, since
+// MinLineageSourcesForCredit means new traces shouldn't promote on
+// lineage alone anymore.
+func TestMidLineageBreakdown_BucketsBySourceCount(t *testing.T) {
+	cx := setup(t)
+
+	// Stand-alone mid (no derived_from).
+	a := trace.New("solo", "note", "", nil, "body")
+	a.Tier = trace.TierMid
+	if err := cx.Add(a); err != nil {
+		t.Fatalf("Add a: %v", err)
+	}
+
+	// Source for the linked mids.
+	src1 := trace.New("source-1", "note", "", nil, "body")
+	if err := cx.Add(src1); err != nil {
+		t.Fatalf("Add src1: %v", err)
+	}
+	src2 := trace.New("source-2", "note", "", nil, "body")
+	if err := cx.Add(src2); err != nil {
+		t.Fatalf("Add src2: %v", err)
+	}
+
+	// 1-source mid (the Hermes session-summary shape).
+	single := trace.New("session-summary-shaped", "observation", "", nil, "body")
+	single.Tier = trace.TierMid
+	single.DerivedFrom = []string{src1.ID}
+	if err := cx.Add(single); err != nil {
+		t.Fatalf("Add single: %v", err)
+	}
+
+	// 2-source mid (a real distillation shape).
+	multi := trace.New("real-distillation", "observation", "", nil, "body")
+	multi.Tier = trace.TierMid
+	multi.DerivedFrom = []string{src1.ID, src2.ID}
+	if err := cx.Add(multi); err != nil {
+		t.Fatalf("Add multi: %v", err)
+	}
+
+	// Short trace — must not show up in the mid breakdown.
+	noise := trace.New("short noise", "note", "", nil, "body")
+	if err := cx.Add(noise); err != nil {
+		t.Fatalf("Add noise: %v", err)
+	}
+
+	got, err := cx.MidLineageBreakdown()
+	if err != nil {
+		t.Fatalf("MidLineageBreakdown: %v", err)
+	}
+	if got.NoSources != 1 {
+		t.Errorf("NoSources = %d, want 1", got.NoSources)
+	}
+	if got.SingleSource != 1 {
+		t.Errorf("SingleSource = %d, want 1", got.SingleSource)
+	}
+	if got.MultiSource != 1 {
+		t.Errorf("MultiSource = %d, want 1", got.MultiSource)
+	}
+}
+
+// TestMidEngagementSnapshot_ZeroEngagementCount pins the count of
+// mids with no usage signal at all. The "older" subset is filtered to
+// traces whose created_at predates the cutoff — used to exclude
+// transient new mids from the archival-candidate count.
+func TestMidEngagementSnapshot_ZeroEngagementCount(t *testing.T) {
+	cx := setup(t)
+
+	// Two cold mids — neither read, hit, nor modified.
+	for i := range 2 {
+		tr := trace.New("cold-"+itoa(i), "note", "", nil, "body")
+		tr.Tier = trace.TierMid
+		if err := cx.Add(tr); err != nil {
+			t.Fatalf("Add cold-%d: %v", i, err)
+		}
+	}
+
+	// One engaged mid (a single read makes it ineligible for the
+	// zero-engagement bucket).
+	hot := trace.New("hot", "note", "", nil, "body")
+	hot.Tier = trace.TierMid
+	if err := cx.Add(hot); err != nil {
+		t.Fatalf("Add hot: %v", err)
+	}
+	if _, err := cx.GetAs(hot.ID, cortex.ActorAgent); err != nil {
+		t.Fatalf("GetAs hot: %v", err)
+	}
+
+	// olderThan=0 collapses the older subset to "everything", which
+	// matches the expectation that all current cold mids count.
+	got, err := cx.MidEngagementSnapshot(0)
+	if err != nil {
+		t.Fatalf("MidEngagementSnapshot: %v", err)
+	}
+	if got.ZeroEngagement != 2 {
+		t.Errorf("ZeroEngagement = %d, want 2", got.ZeroEngagement)
+	}
+	if got.ZeroEngagementOlder != 2 {
+		t.Errorf("ZeroEngagementOlder (cutoff=now) = %d, want 2", got.ZeroEngagementOlder)
+	}
+}
+
+// TestMidEngagementSnapshot_OlderCutoffExcludesTransients pins that
+// the "older than" filter actually narrows. Setting olderThan to a
+// year filters every freshly-seeded trace out of the older bucket
+// while leaving the total intact.
+func TestMidEngagementSnapshot_OlderCutoffExcludesTransients(t *testing.T) {
+	cx := setup(t)
+	for i := range 3 {
+		tr := trace.New("fresh-"+itoa(i), "note", "", nil, "body")
+		tr.Tier = trace.TierMid
+		if err := cx.Add(tr); err != nil {
+			t.Fatalf("Add: %v", err)
+		}
+	}
+	got, err := cx.MidEngagementSnapshot(365 * 24 * time.Hour)
+	if err != nil {
+		t.Fatalf("MidEngagementSnapshot: %v", err)
+	}
+	if got.ZeroEngagement != 3 {
+		t.Errorf("ZeroEngagement = %d, want 3", got.ZeroEngagement)
+	}
+	if got.ZeroEngagementOlder != 0 {
+		t.Errorf("ZeroEngagementOlder (cutoff=1y) = %d, want 0", got.ZeroEngagementOlder)
+	}
+}


### PR DESCRIPTION
## Summary

Extends \`noema memory stats\` with a \`--detailed\` flag that surfaces the diagnostics needed to validate that #84 (now merged) and #86 are working in production:

- **Engagement signal**: total reads, search hits, modifies across active traces (federation-wide via \`trace_usage\`)
- **Mid lineage breakdown**: 0 / 1 / ≥2 derived_from buckets. The 1-source bucket is the Hermes-session-summary smell that #86 gates against; this view shows whether it's stabilising.
- **Mid zero-engagement count**: total + the older-than-14-days subset. The natural candidate pool for source archival (the v2+ TODO in \`distill.go\`).

## Why

After #84 + #86 land, you want to be able to answer \"is this actually helping?\" without opening the SQLite. Sample output against agentbrain right now (with #84 not yet deployed to the live serve, so search hits = 0):

\`\`\`
Tier    Count
short   100
mid     244
long    0
purged  0

Signal       Total
reads        67
search hits  0      ← expected to climb after #84 deploys
modifies     21

Mid lineage      Count
no derived_from  122
1 source         63   ← expected to stabilise after #86
>=2 sources      59

Mid traces with zero engagement: 212 (109 older than 14d)
\`\`\`

Originally PR #87 (auto-closed when its base \`feature/search-hit-instrumentation\` was deleted on #84 merge); rebased onto \`next\` and refiled here.

## Test plan

- [x] \`go build ./...\`, \`go vet ./...\`, \`go test ./...\` all green
- [x] Smoke test against the agentbrain cortex confirmed the queries return sensible numbers
- [x] New tests pin: \`EngagementStats\` excludes archived/trashed/purged, empty cortex returns zeros, \`MidLineageBreakdown\` correctly buckets 0/1/≥2 sources and ignores non-mid tiers, \`MidEngagementSnapshot\` returns zero-engagement totals + older subset

🤖 Generated with [Claude Code](https://claude.com/claude-code)