### PR TITLE
chore(scripts): add deploy-hermes-plugin.sh for fleet plugin sync

### DIFF
--- a/scripts/deploy-hermes-plugin.sh
+++ b/scripts/deploy-hermes-plugin.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Deploy the Hermes Noema memory provider plugin to one or more remote hosts.
+#
+# Usage:
+#   scripts/deploy-hermes-plugin.sh <host> [<host> ...]
+#
+# Each host must be SSH-reachable. The script rsyncs plugins/hermes/ to
+# <hermes-home>/plugins/memory/noema/ on each host (default hermes-home is
+# ~/.hermes/hermes-agent — override with HERMES_HOME on the remote env).
+# Then it restarts every hermes-gateway-*.service systemd --user unit so the
+# new code is picked up.
+#
+# Idempotent. Safe to re-run. No-ops on hosts that don't have Hermes installed.
+#
+# Until `noema hermes install` (Tier 2) lands, this is the pull-mechanism
+# replacement for the manual `cp -r` step in plugins/hermes/README.md.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "usage: $0 <host> [<host> ...]" >&2
+    exit 64
+fi
+
+repo_root=$(cd "$(dirname "$0")/.." && pwd)
+src="$repo_root/plugins/hermes/"
+
+if [[ ! -f "$src/__init__.py" ]]; then
+    echo "error: plugin source not found at $src" >&2
+    exit 1
+fi
+
+for host in "$@"; do
+    echo "==> $host"
+
+    remote_home=$(ssh "$host" 'echo "${HERMES_HOME:-$HOME/.hermes/hermes-agent}"')
+    remote_dest="$remote_home/plugins/memory/noema"
+
+    if ! ssh "$host" "test -d $remote_home"; then
+        echo "    Hermes not installed at $remote_home — skipping"
+        continue
+    fi
+
+    ssh "$host" "mkdir -p $remote_dest"
+
+    # --delete removes stale files (e.g. an old transport_legacy.py); excludes
+    # __pycache__ so we don't ship local bytecode.
+    rsync -az --delete \
+        --exclude='__pycache__' \
+        --exclude='.pytest_cache' \
+        --exclude='.ruff_cache' \
+        "$src" "$host:$remote_dest/"
+
+    echo "    plugin synced to $remote_dest"
+
+    # Restart every Hermes gateway profile so the new code loads. Prefer
+    # the host's `hermes-profiles` utility if present — it owns the
+    # canonical restart convention (sequencing, profile discovery, etc.)
+    # and we should not re-implement it. Fall back to a direct systemctl
+    # glob restart on hosts that don't have the utility installed.
+    if ssh -n "$host" 'command -v hermes-profiles >/dev/null 2>&1'; then
+        echo "    restarting via hermes-profiles gateways restart"
+        ssh -n "$host" 'hermes-profiles gateways restart'
+        continue
+    fi
+
+    units=$(ssh -n "$host" "systemctl --user list-unit-files 'hermes-gateway*.service' --no-legend 2>/dev/null | awk '{print \$1}'" || true)
+    if [[ -z "$units" ]]; then
+        echo "    no hermes-gateway-*.service units found — skipping restart"
+        continue
+    fi
+    while IFS= read -r unit; do
+        [[ -z "$unit" ]] && continue
+        echo "    restarting $unit"
+        ssh -n "$host" "systemctl --user restart $unit"
+    done <<<"$units"
+done
+
+echo
+echo "deploy complete."


### PR DESCRIPTION
## Summary

- Adds `scripts/deploy-hermes-plugin.sh` to rsync `plugins/hermes/` to `<hermes-home>/plugins/memory/noema/` on one or more remote hosts and restart their Hermes gateway services.
- Stopgap measure until `noema plugin hermes install` lands (full design in `Noema-design/docs/plans/plugin-install-plan.md`).
- Plugin drift is the issue this addresses: PR #85 merged 2026-05-05 but the deployed plugin file on a target host sat at the pre-#85 mtime for 22+ hours because there's no pull mechanism — only a manual `cp -r` step in `plugins/hermes/README.md`.

## Behavior

- Rsync excludes `__pycache__` / `.pytest_cache` / `.ruff_cache`.
- Skips hosts whose `<hermes-home>` doesn't exist (no-op for non-Hermes hosts).
- Restart preference: `hermes-profiles gateways restart` when present (canonical multi-profile control on the operator's hosts); falls back to `systemctl --user restart 'hermes-gateway*.service'` otherwise.
- Uses `ssh -n` in the systemctl-fallback loop so the heredoc stdin isn't consumed by ssh (caught during initial deploy — only the first unit was restarting).

## Test plan

- [x] Deployed to two hosts (5 gateway services on host A, 2 on host B) — all `active` post-restart
- [x] Plugin md5 matches local repo HEAD (`b95dec86…`) on both hosts
- [x] Direct `python -c 'from noema import _build_session_summary_body'` against the deployed venv confirms PR #85's new function is reachable
- [x] Live conversation with a Hermes agent produced 3 `noema_recall` reads + 3 `search_hit_count` bumps — confirming PR #84 instrumentation fires end-to-end against the freshly-deployed plugin
- [x] Idempotent re-run is a no-op for unchanged files; restart still cycles services

🤖 Generated with [Claude Code](https://claude.com/claude-code)
