### PR TITLE
fix(consolidation): stop auto-promoting distillation sources to mid

### DIFF
--- a/internal/consolidation/pipeline.go
+++ b/internal/consolidation/pipeline.go
@@ -13,7 +13,7 @@ import (
 // pipeline needs. Separate from the narrower scheduler interface in
 // agent.go so tests of cadence don't have to stub promotion paths.
 type LLMCortex interface {
-	PromotionCandidates(tier string, window time.Duration) ([]cortex.PromotionCandidate, error)
+	LLMCandidates(window time.Duration) ([]cortex.PromotionCandidate, error)
 	Promote(id, newTier string) error
 	CreateDistilledTrace(spec cortex.DistilledTraceSpec) (string, error)
 	TraceFile(id string, archived bool) string
@@ -29,6 +29,14 @@ type PipelineConfig struct {
 	ModelName  string
 	MaxRetries int
 	DryRun     bool
+
+	// Heuristic tunes the fallback scorer that runs when the LLM
+	// rejects a cluster or the endpoint errors out. Zero-value uses
+	// the same defaults as the standalone HeuristicPass (threshold=5,
+	// reads=1, modifies=2, lineage=3, votes=5). Independent from the
+	// scheduled HeuristicPass so an operator can tune the fallback
+	// gate without touching the scheduled cadence.
+	Heuristic PassConfig
 }
 
 // PipelineResult summarises a single pass so the CLI can log what
@@ -89,7 +97,7 @@ func RunLLMPass(ctx context.Context, cx LLMCortex, llm LLMClient, cfg PipelineCo
 	}
 	var result PipelineResult
 
-	candidates, err := cx.PromotionCandidates(trace.TierShort, cfg.Window)
+	candidates, err := cx.LLMCandidates(cfg.Window)
 	if err != nil {
 		return result, fmt.Errorf("selecting candidates: %w", err)
 	}
@@ -161,7 +169,7 @@ func RunLLMPass(ctx context.Context, cx LLMCortex, llm LLMClient, cfg PipelineCo
 					cr.Reason = fmt.Sprintf("llm error (dry-run fallback suppressed): %v", runErr)
 				} else {
 					log("[consolidate] cluster failed after retries: %v; falling back to heuristic promotion", runErr)
-					n := heuristicFallback(cx, chunk, log)
+					n := heuristicFallback(cx, chunk, cfg.Heuristic, log)
 					result.FallbackPromotions += n
 					cr.Outcome = "fallback"
 					cr.Reason = fmt.Sprintf("llm error, heuristic-promoted %d: %v", n, runErr)
@@ -311,15 +319,22 @@ func runWithRetry(ctx context.Context, llm LLMClient, profile Profile, model str
 	return Distillation{}, lastErr
 }
 
-// heuristicFallback promotes every candidate in the chunk 1:1 so a
-// pass that couldn't produce a distillation still moves qualifying
-// short-term traces into mid-term. Individual Promote failures are
-// logged but don't abort the fallback loop — the caller already
-// degraded from LLM to heuristic; one further failure shouldn't
-// cascade.
-func heuristicFallback(cx LLMCortex, chunk []cortex.PromotionCandidate, log func(format string, args ...any)) int {
+// heuristicFallback promotes only the candidates in the chunk that
+// pass the heuristic score gate, so an LLM-failed pass still moves
+// qualifying short-term traces forward without dragging zero-signal
+// chunkmates along. Earlier versions promoted every candidate
+// unconditionally, which produced the same low-engagement mid-tier
+// pollution that the heuristic was deliberately gating against.
+// Individual Promote failures are logged but don't abort the loop —
+// the caller already degraded from LLM to heuristic; one further
+// failure shouldn't cascade.
+func heuristicFallback(cx LLMCortex, chunk []cortex.PromotionCandidate, cfg PassConfig, log func(format string, args ...any)) int {
+	cfg = cfg.resolved()
 	promoted := 0
 	for _, pc := range chunk {
+		if scoreCandidate(pc, cfg) < cfg.PromotionThreshold {
+			continue
+		}
 		if err := cx.Promote(pc.ID, trace.TierMid); err != nil {
 			log("[consolidate] fallback promote failed id=%s: %v", pc.ID, err)
 			continue

--- a/internal/consolidation/pipeline_test.go
+++ b/internal/consolidation/pipeline_test.go
@@ -112,27 +112,27 @@ func TestRunLLMPass_HappyPath_Frontier(t *testing.T) {
 		t.Errorf("CandidatesConsidered = %d, want 3", result.CandidatesConsidered)
 	}
 
-	// Verify a mid-tier trace now exists with derived_from linking
-	// to all three sources. Under the v1 "net-add with source
-	// promotion" policy, mid also contains the three promoted
-	// sources, so the expected count is 4 (1 distillation + 3
-	// sources). The distillation is the one with derived_from set.
+	// Verify a single mid-tier trace exists for the distilled summary;
+	// sources stay at short under the current policy. derived_from on
+	// the distilled row keeps the originals reachable, and LLMCandidates
+	// will skip them on the next pass via the ActionConsolidate event.
 	rows, err := cx.List(cortex.ListOptions{Tiers: []string{trace.TierMid}})
 	if err != nil {
 		t.Fatalf("List mid: %v", err)
 	}
-	if len(rows) != 4 {
-		t.Fatalf("mid tier rows = %d, want 4 (1 distilled + 3 promoted sources)", len(rows))
+	if len(rows) != 1 {
+		t.Fatalf("mid tier rows = %d, want 1 (distilled only; sources stay at short)", len(rows))
 	}
-	var distilledID string
-	for _, r := range rows {
-		if r.Title == "Auth strategy — distilled" {
-			distilledID = r.ID
-			break
-		}
+	distilledID := rows[0].ID
+	if rows[0].Title != "Auth strategy — distilled" {
+		t.Fatalf("mid-tier row title = %q, want %q", rows[0].Title, "Auth strategy — distilled")
 	}
-	if distilledID == "" {
-		t.Fatalf("no mid-tier row titled %q among %d mid rows", "Auth strategy — distilled", len(rows))
+	shortRows, err := cx.List(cortex.ListOptions{Tiers: []string{trace.TierShort}})
+	if err != nil {
+		t.Fatalf("List short: %v", err)
+	}
+	if len(shortRows) != 3 {
+		t.Errorf("short tier rows = %d, want 3 (sources untouched)", len(shortRows))
 	}
 	// List doesn't populate DerivedFrom (that's a separate lineage
 	// query); fetch via Get to verify the derived_from links.
@@ -209,14 +209,15 @@ func TestRunLLMPass_DryRun_SkipsWrite(t *testing.T) {
 }
 
 // TestRunLLMPass_LLMError_FallsBackToHeuristic pins the graceful-
-// degradation rail from Phase 8: when the LLM step repeatedly fails,
-// the pipeline drops to 1:1 heuristic promotion rather than leaving
-// the candidates in short-term forever.
-func TestRunLLMPass_LLMError_FallsBackToHeuristic(t *testing.T) {
+// degradation rail when the LLM step repeatedly fails. The fallback
+// runs the same heuristic score gate as the standalone HeuristicPass:
+// candidates without enough signal stay at short rather than getting
+// dragged forward unconditionally. Three zero-engagement seed traces
+// score 0 — well under the threshold of 5 — so none should promote.
+func TestRunLLMPass_LLMError_FallsBackToHeuristic_GatedByScore(t *testing.T) {
 	cx := setupCortex(t)
 	seedTraces(t, cx, 3)
 
-	// Empty response queue — every call errors with "exhausted".
 	llm := &scriptedLLM{}
 
 	result, err := consolidation.RunLLMPass(context.Background(), cx, llm, consolidation.PipelineConfig{
@@ -231,15 +232,52 @@ func TestRunLLMPass_LLMError_FallsBackToHeuristic(t *testing.T) {
 	if result.DistillationsCreated != 0 {
 		t.Errorf("DistillationsCreated = %d, want 0 (all failed)", result.DistillationsCreated)
 	}
-	if result.FallbackPromotions != 3 {
-		t.Errorf("FallbackPromotions = %d, want 3 (one per candidate)", result.FallbackPromotions)
+	if result.FallbackPromotions != 0 {
+		t.Errorf("FallbackPromotions = %d, want 0 (zero-engagement seeds shouldn't pass the gate)", result.FallbackPromotions)
 	}
 
-	// The three originals should now be mid-tier via heuristic
-	// fallback rather than frozen at short-tier forever.
+	rows, _ := cx.List(cortex.ListOptions{Tiers: []string{trace.TierMid}})
+	if len(rows) != 0 {
+		t.Errorf("mid tier rows after gated fallback = %d, want 0", len(rows))
+	}
+}
+
+// TestRunLLMPass_LLMError_FallbackPromotesQualifyingCandidates pairs
+// with the gated test above: when a candidate has accumulated enough
+// signal to clear the heuristic threshold, the fallback should still
+// promote it. Three reads on the seeded trace gives score=3 with the
+// default reads weight (1) and a derived_from of 2 adds the lineage
+// credit (≥2 sources × WeightLineage 3 = 6) for a total of 9, well
+// over the threshold of 5.
+func TestRunLLMPass_LLMError_FallbackPromotesQualifyingCandidates(t *testing.T) {
+	cx := setupCortex(t)
+	ids := seedTraces(t, cx, 3)
+
+	// Bump tier_votes on each seed so the heuristic score reaches the
+	// threshold without needing to fabricate read/modify history.
+	// One vote × WeightVotes (5) = 5, exactly at threshold.
+	for _, id := range ids {
+		if err := cx.Vote(id, +1, cortex.ActorAgent); err != nil {
+			t.Fatalf("Vote %s: %v", id, err)
+		}
+	}
+
+	llm := &scriptedLLM{}
+	result, err := consolidation.RunLLMPass(context.Background(), cx, llm, consolidation.PipelineConfig{
+		Window:     24 * time.Hour,
+		ModelTier:  "frontier",
+		ModelName:  "m",
+		MaxRetries: 1,
+	}, nil)
+	if err != nil {
+		t.Fatalf("RunLLMPass: %v", err)
+	}
+	if result.FallbackPromotions != 3 {
+		t.Errorf("FallbackPromotions = %d, want 3 (one vote each clears threshold)", result.FallbackPromotions)
+	}
 	rows, _ := cx.List(cortex.ListOptions{Tiers: []string{trace.TierMid}})
 	if len(rows) != 3 {
-		t.Errorf("mid tier rows after fallback = %d, want 3", len(rows))
+		t.Errorf("mid tier rows after qualifying fallback = %d, want 3", len(rows))
 	}
 }
 

--- a/internal/cortex/candidates.go
+++ b/internal/cortex/candidates.go
@@ -79,6 +79,76 @@ func (c *Cortex) GraduationCandidates(minAge time.Duration) ([]PromotionCandidat
 	return out, rows.Err()
 }
 
+// LLMCandidates returns the short-tier candidate pool for the LLM
+// distillation pass — same shape as PromotionCandidates, but with
+// already-consolidated sources filtered out. A trace is considered
+// "already consolidated" if its ID appears in the source_ids array of
+// any past ActionConsolidate event.
+//
+// CreateDistilledTrace used to keep these out of the pool by promoting
+// every source to mid as a side effect; that polluted mid with
+// zero-engagement traces. Filtering on the event log instead leaves
+// sources at their natural tier while still preventing the next pass
+// from re-clustering them into a duplicate distillation.
+//
+// json_each is part of SQLite's JSON1 extension, which is enabled by
+// modernc.org/sqlite at compile time; no driver flag is needed.
+func (c *Cortex) LLMCandidates(window time.Duration) ([]PromotionCandidate, error) {
+	cutoff := time.Now().UTC().Add(-window).Format(time.RFC3339)
+	q := `
+		SELECT
+			t.id,
+			t.tier,
+			t.type,
+			COALESCE(u.total_reads, 0)        AS read_count,
+			COALESCE(u.total_modifies, 0)     AS modify_count,
+			COALESCE(u.total_search_hits, 0)  AS search_hit_count,
+			t.tier_votes,
+			COALESCE(v.n, 0) AS derived_from_count,
+			t.created_at
+		FROM traces t
+		LEFT JOIN (
+			SELECT trace_id,
+			       SUM(read_count)       AS total_reads,
+			       SUM(modify_count)     AS total_modifies,
+			       SUM(search_hit_count) AS total_search_hits
+			FROM trace_usage
+			GROUP BY trace_id
+		) u ON u.trace_id = t.id
+		LEFT JOIN v_derived_from_count v ON v.trace_id = t.id
+		WHERE t.tier = 'short'
+		  AND t.archived_at IS NULL
+		  AND t.trashed_at IS NULL
+		  AND t.purged_at IS NULL
+		  AND t.created_at >= ?
+		  AND t.id != ''
+		  AND t.id NOT IN (
+		      SELECT je.value
+		      FROM events e, json_each(json_extract(e.data, '$.source_ids')) je
+		      WHERE e.action = 'consolidate'
+		  )
+		ORDER BY t.created_at DESC
+	`
+	rows, err := c.DB.Query(q, cutoff)
+	if err != nil {
+		return nil, fmt.Errorf("selecting llm candidates: %w", err)
+	}
+	defer rows.Close()
+
+	var out []PromotionCandidate
+	for rows.Next() {
+		var pc PromotionCandidate
+		if err := rows.Scan(
+			&pc.ID, &pc.Tier, &pc.Type, &pc.ReadCount, &pc.ModifyCount,
+			&pc.SearchHitCount, &pc.TierVotes, &pc.DerivedFromCount, &pc.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		out = append(out, pc)
+	}
+	return out, rows.Err()
+}
+
 // PromotionCandidates returns every active trace in the given tier
 // whose created_at falls within the rolling window. The caller does
 // the scoring; this method is only responsible for narrowing to the

--- a/internal/cortex/candidates_test.go
+++ b/internal/cortex/candidates_test.go
@@ -185,3 +185,47 @@ func TestPromotionCandidates_WindowBound(t *testing.T) {
 		t.Errorf("expected zero candidates outside window, got %d (%+v)", len(got), got)
 	}
 }
+
+func TestLLMCandidates_ExcludesAlreadyConsolidatedSources(t *testing.T) {
+	// Once CreateDistilledTrace fires for a pair of sources, the
+	// resulting ActionConsolidate event should keep those source IDs
+	// out of the LLM candidate pool — even though they're still at
+	// short tier under the no-auto-promote policy. PromotionCandidates
+	// (the heuristic pass's pool) is unaffected and still surfaces
+	// them, since the heuristic gates on score not on consolidation
+	// history.
+	cx := setup(t)
+	src1 := trace.New("s1", "note", "", nil, "b1")
+	src2 := trace.New("s2", "note", "", nil, "b2")
+	independent := trace.New("indep", "note", "", nil, "b3")
+	for _, tr := range []*trace.Trace{src1, src2, independent} {
+		if err := cx.Add(tr); err != nil {
+			t.Fatalf("Add %s: %v", tr.Title, err)
+		}
+	}
+	if _, err := cx.CreateDistilledTrace(cortex.DistilledTraceSpec{
+		Title: "dist", Body: "b", SourceIDs: []string{src1.ID, src2.ID},
+	}); err != nil {
+		t.Fatalf("CreateDistilledTrace: %v", err)
+	}
+
+	llm, err := cx.LLMCandidates(24 * time.Hour)
+	if err != nil {
+		t.Fatalf("LLMCandidates: %v", err)
+	}
+	if len(llm) != 1 || llm[0].ID != independent.ID {
+		var ids []string
+		for _, pc := range llm {
+			ids = append(ids, pc.ID)
+		}
+		t.Errorf("LLMCandidates = %v, want only %s (consumed sources excluded)", ids, independent.ID)
+	}
+
+	heuristic, err := cx.PromotionCandidates(trace.TierShort, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("PromotionCandidates: %v", err)
+	}
+	if len(heuristic) != 3 {
+		t.Errorf("PromotionCandidates(short) = %d, want 3 (heuristic pool sees all short-tier traces, including ex-sources)", len(heuristic))
+	}
+}

--- a/internal/cortex/distill.go
+++ b/internal/cortex/distill.go
@@ -46,26 +46,17 @@ type DistilledTraceSpec struct {
 // which model produced it / how confident" as separate, replayable
 // records.
 //
-// Source handling (v1 — "net-add with source promotion"): every
-// short-tier source is promoted to mid once the distillation lands.
-// The distilled trace is the retrievable summary; sources remain
-// individually addressable at mid so agents can pull the full
-// detail via derived_from when the distillation's compression is
-// lossy. This also prevents the next consolidation pass from
-// re-clustering the same sources into a duplicate distillation —
-// the candidate query filters to tier='short', so promoted sources
-// drop out of the candidate pool.
-//
-// FUTURE (v2+): "source archival" — instead of promoting sources
-// to mid, move them to archived once the distillation is trusted
-// (confidence threshold + retention window). That keeps mid-tier
-// curated and closer to the biological metaphor where the detailed
-// memory fades as the distillation takes its place. Not v1 because
-// the grace-period machinery adds a new daemon and needs a
-// confidence-calibration pass first. The current design's derived_from
-// lineage already supports the retrieval path that option 2 would
-// need, so the switch is local to this function + a new archival
-// sweep — no schema changes.
+// Source handling: sources stay at their original tier. The distilled
+// trace is the retrievable summary, and derived_from lineage keeps the
+// originals reachable for the cases where the distillation's
+// compression is lossy. Earlier versions auto-promoted every source to
+// mid alongside the distillation, which polluted the mid tier with
+// zero-engagement traces (a single ActionConsolidate run could promote
+// 5+ sources that had no reads, modifies, or votes of their own).
+// Re-clustering protection is now provided by LLMCandidates, which
+// excludes any short-tier trace that already appears as a source in a
+// past ActionConsolidate event — so a source isn't re-fed into a
+// duplicate distillation just because it stayed at short.
 func (c *Cortex) CreateDistilledTrace(spec DistilledTraceSpec) (string, error) {
 	if spec.Title == "" {
 		return "", fmt.Errorf("distilled trace: title is required")
@@ -126,36 +117,6 @@ func (c *Cortex) CreateDistilledTrace(spec DistilledTraceSpec) (string, error) {
 	}
 	if err := tx.Commit(); err != nil {
 		return t.ID, fmt.Errorf("committing consolidate event: %w", err)
-	}
-
-	// Promote each source from short to mid. Best-effort per source —
-	// the distillation itself has already landed, so a partial
-	// promotion failure doesn't invalidate anything, it just leaves
-	// one or more sources at short. They'd surface again in the next
-	// consolidation pass, which is suboptimal but self-correcting.
-	// Sources that are not at 'short' are skipped quietly: they may
-	// already have been promoted by a previous run (re-consolidation
-	// after a crash), or they're at a tier this function shouldn't
-	// touch (mid/long — isValidPromotion would reject anyway).
-	for _, sid := range spec.SourceIDs {
-		srow, err := c.Get(sid)
-		if err != nil {
-			// Source vanished between the earlier existence check and
-			// now — log and skip rather than abort the whole operation.
-			// The distilled trace is already committed; lineage is
-			// intact.
-			continue
-		}
-		if srow.Tier != trace.TierShort {
-			continue
-		}
-		if err := c.Promote(sid, trace.TierMid); err != nil {
-			// Non-fatal per the "best-effort" contract. The ActionPromote
-			// event is what keeps federation peers consistent; if this
-			// fails here it fails everywhere, and the next run will
-			// retry.
-			continue
-		}
 	}
 
 	return t.ID, nil

--- a/internal/cortex/distill_test.go
+++ b/internal/cortex/distill_test.go
@@ -148,16 +148,13 @@ func TestCreateDistilledTrace_RejectsEmptyTitleOrBody(t *testing.T) {
 	}
 }
 
-func TestCreateDistilledTrace_PromotesSourcesToMid(t *testing.T) {
-	// v1 policy: once a distillation lands, every short-tier source
-	// is promoted to mid. This keeps both representations available
-	// (distillation as the summary, sources as full-detail backing
-	// store reachable via derived_from) and takes the sources out of
-	// the PromotionCandidates pool so the next pass doesn't
-	// re-consolidate them into a duplicate distillation.
-	//
-	// v2+ will likely replace this with archival-after-grace-period
-	// (see the doc-comment on CreateDistilledTrace).
+func TestCreateDistilledTrace_LeavesSourcesAtShort(t *testing.T) {
+	// Sources stay at their original tier when a distillation lands.
+	// derived_from on the distilled trace keeps them reachable, and
+	// LLMCandidates filters them out of subsequent LLM passes via the
+	// ActionConsolidate event log — so they don't get re-clustered
+	// into duplicate distillations and they don't pollute mid with
+	// zero-engagement promotions either.
 	cx := setup(t)
 	src1 := trace.New("s1", "note", "", nil, "b1")
 	src2 := trace.New("s2", "note", "", nil, "b2")
@@ -177,8 +174,8 @@ func TestCreateDistilledTrace_PromotesSourcesToMid(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Get source: %v", err)
 		}
-		if row.Tier != trace.TierMid {
-			t.Errorf("source %s tier = %q, want mid (sources promoted on distillation)", id, row.Tier)
+		if row.Tier != trace.TierShort {
+			t.Errorf("source %s tier = %q, want short (sources stay put on distillation)", id, row.Tier)
 		}
 	}
 }

--- a/internal/mcp/consolidation_test.go
+++ b/internal/mcp/consolidation_test.go
@@ -90,26 +90,26 @@ func TestRecordConsolidationResult_CreatesMidTrace(t *testing.T) {
 		t.Errorf("response missing confirmation: %s", text)
 	}
 
-	// Under the v1 "net-add with source promotion" policy, mid-tier
-	// contains the distilled trace PLUS the two promoted sources, so
-	// the expected count is 3 and the check is "distilled title is
-	// present" rather than "list has exactly one row".
+	// Sources stay at their original tier; only the distilled trace
+	// lands in mid. derived_from on the distilled row keeps the
+	// originals reachable, and LLMCandidates filters them out of
+	// subsequent passes via the ActionConsolidate event log.
 	rows, err := cx.List(cortex.ListOptions{Tiers: []string{trace.TierMid}})
 	if err != nil {
 		t.Fatalf("List mid: %v", err)
 	}
-	if len(rows) != 3 {
-		t.Fatalf("mid tier rows = %d, want 3 (1 distilled + 2 promoted sources): %+v", len(rows), rows)
+	if len(rows) != 1 {
+		t.Fatalf("mid tier rows = %d, want 1 (distilled only): %+v", len(rows), rows)
 	}
-	var foundDistilled bool
-	for _, r := range rows {
-		if r.Title == "Auth strategy — distilled" {
-			foundDistilled = true
-			break
-		}
+	if rows[0].Title != "Auth strategy — distilled" {
+		t.Errorf("mid-tier row title = %q, want %q", rows[0].Title, "Auth strategy — distilled")
 	}
-	if !foundDistilled {
-		t.Errorf("distilled title %q not found among mid-tier rows: %+v", "Auth strategy — distilled", rows)
+	shortRows, err := cx.List(cortex.ListOptions{Tiers: []string{trace.TierShort}})
+	if err != nil {
+		t.Fatalf("List short: %v", err)
+	}
+	if len(shortRows) != 2 {
+		t.Errorf("short tier rows = %d, want 2 (sources untouched): %+v", len(shortRows), shortRows)
 	}
 }
 


### PR DESCRIPTION
## Summary

`Cortex.CreateDistilledTrace` was promoting every short-tier source trace to mid as a side effect of materialising a distilled trace. The header comment acknowledged this as a v1 shortcut for a future "promote-then-archive" archival sweep that never landed; in practice it produced the same zero-engagement mid-tier pollution PR #86 patched on the heuristic side. Every distillation cycle was promoting 2–5 sources with `read=modify=votes=0` just because they were inputs to a cluster.

This PR drops the auto-promote loop. Sources stay at their original tier; `derived_from` keeps them reachable. To prevent the next pass from re-clustering ex-sources into duplicate distillations, a new `LLMCandidates(window)` filters out any short-tier trace whose ID appears in a past `ActionConsolidate` event's `source_ids`. The standalone heuristic pass keeps using the unchanged `PromotionCandidates` and gates on score, which is the correct signal there.

`heuristicFallback` in `pipeline.go` was also promoting every candidate in a chunk unconditionally when the LLM step failed, despite the "heuristic" in its name. It now applies `scoreCandidate` against the configured threshold, so a fallback pass behaves like a standalone heuristic pass on the failed cluster instead of dragging zero-signal chunkmates forward. `PipelineConfig` grows a `Heuristic PassConfig` field so the fallback gate can be tuned independently of the scheduled `HeuristicPass` cadence; zero-value defaults match `HeuristicPass`.

## Background

Diagnosed against agentbrain after PR #88 made the symptoms visible. Pre-fix snapshot (2026-05-05): 1-source mids = 63. Post-deploy snapshot (2026-05-08, three days later): 1-source mids = 71 (+8). The post-2026-05-05 promotions all had read=0, modify=0, votes=0 — heuristic score = 0, well under the threshold of 5. The leak was 100% from the distillation path, not the heuristic.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` clean (updated 4 test expectations, added 2 new tests for `LLMCandidates` filter and gated fallback)
- [x] Deployed to internal cluster (ai-1/2/3) and Mac for live testing
- [x] Verified post-deploy that 1-source mid count stops climbing

🤖 Generated with [Claude Code](https://claude.com/claude-code)