### PR TITLE
fix(create_trace): typed error + structured MCP envelope on id collision

### DIFF
--- a/internal/cli/cmd_add.go
+++ b/internal/cli/cmd_add.go
@@ -1,12 +1,14 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
 
+	"github.com/Fail-Safe/Noema/internal/cortex"
 	"github.com/Fail-Safe/Noema/internal/trace"
 )
 
@@ -100,7 +102,12 @@ func addCmd() *cobra.Command {
 			}
 
 			t := trace.New(title, traceType, author, tags, body)
-			if err := cx.Add(t); err != nil {
+			err = cx.Add(t)
+			var collision *cortex.ErrTraceIDExists
+			if errors.As(err, &collision) {
+				return resolveCollisionInteractive(cx, t, collision, traceType, author, tags, body)
+			}
+			if err != nil {
 				return err
 			}
 			fmt.Printf("Trace added: %s\n", t.ID)

--- a/internal/cli/cmd_add_collision.go
+++ b/internal/cli/cmd_add_collision.go
@@ -1,0 +1,189 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/Fail-Safe/Noema/internal/cortex"
+	"github.com/Fail-Safe/Noema/internal/trace"
+)
+
+// resolveCollisionInteractive runs the post-collision recovery flow for
+// `noema add`. The user has already produced body content; we don't want
+// to throw it away just because the deterministic id slot is held by an
+// archived/trashed/purged sibling. Offers exactly the options that are
+// valid for the existing row's state and reattempts the add when the
+// caller picks one that frees the slot.
+//
+// `t` is the trace the caller tried to add; we mutate its title (and id
+// via trace.New) on a vary-title retry rather than constructing a fresh
+// Trace, so author/tags/body/derived_from carry through unchanged.
+func resolveCollisionInteractive(cx *cortex.Cortex, t *trace.Trace, collision *cortex.ErrTraceIDExists, traceType, author string, tags []string, body string) error {
+	fmt.Fprintln(os.Stderr, collision.Error())
+	for {
+		choice, err := promptCollisionChoice(collision.State)
+		if err != nil {
+			return err
+		}
+		switch choice {
+		case "v":
+			return retryWithNewTitle(cx, traceType, author, tags, body)
+		case "r":
+			if err := cx.Recover(collision.ID); err != nil {
+				return fmt.Errorf("recover failed: %w", err)
+			}
+			fmt.Printf("Recovered %s. New content was discarded — edit the recovered trace if you want to update it.\n", collision.ID)
+			return nil
+		case "u":
+			if err := cx.Unarchive(collision.ID); err != nil {
+				return fmt.Errorf("unarchive failed: %w", err)
+			}
+			fmt.Printf("Unarchived %s. New content was discarded — edit the unarchived trace if you want to update it.\n", collision.ID)
+			return nil
+		case "p":
+			if err := purgeAndRetry(cx, t, collision); err != nil {
+				return err
+			}
+			fmt.Printf("Trace added: %s\n", t.ID)
+			return nil
+		case "q":
+			return collision
+		}
+	}
+}
+
+// promptCollisionChoice loops until the user picks an option valid for
+// the existing row's state. State-dependent letters keep the prompt
+// honest — offering (R)ecover for an archived row would just confuse.
+// EOF on stdin (closed pipe, no terminal) is treated as Q-quit so the
+// caller surfaces the original collision instead of looping forever
+// against an empty buffer — important when this resolver runs in a
+// non-interactive context (script piping into `noema add`, automated
+// test, etc.).
+func promptCollisionChoice(state string) (string, error) {
+	var menu string
+	var valid map[string]struct{}
+	switch state {
+	case "trashed":
+		menu = "(R)ecover trashed / (P)urge & retry / (V)ary title / (Q)uit"
+		valid = map[string]struct{}{"r": {}, "p": {}, "v": {}, "q": {}}
+	case "archived":
+		menu = "(U)narchive / (P)urge & retry / (V)ary title / (Q)uit"
+		valid = map[string]struct{}{"u": {}, "p": {}, "v": {}, "q": {}}
+	case "purged":
+		menu = "(V)ary title / (Q)uit  (the slot can only be freed via `noema memory purge --hard`)"
+		valid = map[string]struct{}{"v": {}, "q": {}}
+	default:
+		menu = "(V)ary title / (Q)uit  (an active trace already holds this id)"
+		valid = map[string]struct{}{"v": {}, "q": {}}
+	}
+	for {
+		raw, eof, err := readChoiceLine(menu)
+		if err != nil {
+			return "", err
+		}
+		if eof {
+			return "q", nil
+		}
+		raw = strings.ToLower(strings.TrimSpace(raw))
+		if raw == "" {
+			continue
+		}
+		key := raw[:1]
+		if _, ok := valid[key]; ok {
+			return key, nil
+		}
+		fmt.Fprintln(os.Stderr, "  unrecognised option")
+	}
+}
+
+// readChoiceLine reads one line from the package-level stdin, returning
+// (line, eof, err). Unlike prompt() in input.go which silently swallows
+// io.EOF as an empty string, this distinguishes a closed stream from a
+// bare-Enter so the collision loop can bail rather than spin.
+func readChoiceLine(label string) (string, bool, error) {
+	fmt.Print(label + ": ")
+	line, err := stdin.ReadString('\n')
+	switch {
+	case errors.Is(err, io.EOF):
+		// EOF mid-line still counts as the line, but if no bytes
+		// arrived at all we treat the stream as closed.
+		return strings.TrimSpace(line), strings.TrimSpace(line) == "", nil
+	case err != nil:
+		return "", false, err
+	}
+	return strings.TrimSpace(line), false, nil
+}
+
+// retryWithNewTitle prompts for a fresh title, mints a new id from it,
+// and attempts the add again. Recursion is bounded by the user's
+// patience — if the new title also collides we re-enter the same
+// resolver, but since each iteration requires a human keypress this
+// can't loop unbounded.
+func retryWithNewTitle(cx *cortex.Cortex, traceType, author string, tags []string, body string) error {
+	for {
+		newTitle, eof, err := readChoiceLine("New title")
+		if err != nil {
+			return err
+		}
+		if eof {
+			return fmt.Errorf("input closed before a new title was supplied")
+		}
+		if newTitle == "" {
+			fmt.Fprintln(os.Stderr, "  title cannot be empty")
+			continue
+		}
+		t := trace.New(newTitle, traceType, author, tags, body)
+		err = cx.Add(t)
+		var collision *cortex.ErrTraceIDExists
+		if asCollision(err, &collision) {
+			fmt.Fprintln(os.Stderr, collision.Error())
+			return resolveCollisionInteractive(cx, t, collision, traceType, author, tags, body)
+		}
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Trace added: %s\n", t.ID)
+		return nil
+	}
+}
+
+// purgeAndRetry tombstones the colliding row at its current tier (read
+// straight off the live row to avoid the AdminPurge tier-mismatch
+// safety rail tripping over a stale assumption) then retries the add.
+// AdminPurge soft-deletes by default — the row is wiped to a tombstone
+// that still occupies the id slot. So we follow up with --hard to
+// actually free the slot for our retry, scoped to the trashed/archived
+// case where the user has already committed to discarding the prior
+// row.
+func purgeAndRetry(cx *cortex.Cortex, t *trace.Trace, collision *cortex.ErrTraceIDExists) error {
+	row, err := cx.Get(collision.ID)
+	if err != nil {
+		return fmt.Errorf("looking up colliding row before purge: %w", err)
+	}
+	const reason = "freed by interactive `noema add` to recreate id"
+	if err := cx.AdminPurge(collision.ID, reason, row.Tier, true, cortex.ActorHuman); err != nil {
+		return fmt.Errorf("hard purge failed: %w", err)
+	}
+	if err := cx.Add(t); err != nil {
+		return err
+	}
+	return nil
+}
+
+// asCollision is errors.As specialised on *ErrTraceIDExists so the
+// retry flow stays readable. Same pattern as the import-side caller.
+func asCollision(err error, target **cortex.ErrTraceIDExists) bool {
+	if err == nil {
+		return false
+	}
+	c, ok := err.(*cortex.ErrTraceIDExists)
+	if ok {
+		*target = c
+		return true
+	}
+	return false
+}

--- a/internal/cli/cmd_add_collision_test.go
+++ b/internal/cli/cmd_add_collision_test.go
@@ -1,0 +1,184 @@
+package cli
+
+import (
+	"bufio"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Fail-Safe/Noema/internal/cortex"
+	"github.com/Fail-Safe/Noema/internal/trace"
+)
+
+func newCortexForCollision(t *testing.T) *cortex.Cortex {
+	t.Helper()
+	parent := t.TempDir()
+	if _, err := cortex.Create("colltest", parent); err != nil {
+		t.Fatalf("cortex.Create: %v", err)
+	}
+	cx, err := cortex.Open("colltest", filepath.Join(parent, "colltest"))
+	if err != nil {
+		t.Fatalf("cortex.Open: %v", err)
+	}
+	t.Cleanup(func() { cx.Close() })
+	return cx
+}
+
+// scriptStdin replaces the package-level stdin reader with one backed
+// by the supplied lines. The original is restored on test cleanup so
+// parallel-safe.
+func scriptStdin(t *testing.T, lines ...string) {
+	t.Helper()
+	previous := stdin
+	stdin = bufio.NewReader(strings.NewReader(strings.Join(lines, "\n") + "\n"))
+	t.Cleanup(func() { stdin = previous })
+}
+
+// TestResolveCollision_VaryTitle pins the V-vary path: a colliding
+// trashed slot doesn't get touched, the user supplies a fresh title,
+// and the new trace lands at the new id with the original body intact.
+func TestResolveCollision_VaryTitle(t *testing.T) {
+	cx := newCortexForCollision(t)
+	original := trace.New("airlock", "note", "", nil, "first body")
+	if err := cx.Add(original); err != nil {
+		t.Fatalf("seed Add: %v", err)
+	}
+	if err := cx.Trash(original.ID); err != nil {
+		t.Fatalf("Trash: %v", err)
+	}
+
+	dup := trace.New("airlock", "note", "", []string{"safety"}, "rebuilt body")
+	collision, ok := cx.Add(dup).(*cortex.ErrTraceIDExists)
+	if !ok {
+		t.Fatalf("expected ErrTraceIDExists, got %v", collision)
+	}
+
+	scriptStdin(t, "v", "airlock-v2")
+	if err := resolveCollisionInteractive(cx, dup, collision, "note", "", []string{"safety"}, "rebuilt body"); err != nil {
+		t.Fatalf("resolveCollisionInteractive: %v", err)
+	}
+	// Original (trashed) row stays put.
+	row, err := cx.Get(original.ID)
+	if err != nil {
+		t.Fatalf("Get original: %v", err)
+	}
+	if row.TrashedAt == "" {
+		t.Errorf("trashed row should remain trashed, got TrashedAt empty")
+	}
+	// New row landed at the new id with the user's body intact.
+	rows, err := cx.List(cortex.ListOptions{})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	var newID string
+	for _, r := range rows {
+		if r.ID != original.ID {
+			newID = r.ID
+		}
+	}
+	if newID == "" || !strings.Contains(newID, "airlock-v2") {
+		t.Errorf("new row id = %q, want one containing airlock-v2", newID)
+	}
+}
+
+// TestResolveCollision_RecoverTrashed pins the R path: user picks
+// recover, the trashed row comes back, no new row is created.
+func TestResolveCollision_RecoverTrashed(t *testing.T) {
+	cx := newCortexForCollision(t)
+	original := trace.New("relic", "note", "", nil, "valuable body")
+	if err := cx.Add(original); err != nil {
+		t.Fatalf("seed Add: %v", err)
+	}
+	if err := cx.Trash(original.ID); err != nil {
+		t.Fatalf("Trash: %v", err)
+	}
+
+	dup := trace.New("relic", "note", "", nil, "throwaway body")
+	collision := cx.Add(dup).(*cortex.ErrTraceIDExists)
+
+	scriptStdin(t, "r")
+	if err := resolveCollisionInteractive(cx, dup, collision, "note", "", nil, "throwaway body"); err != nil {
+		t.Fatalf("resolveCollisionInteractive: %v", err)
+	}
+	row, err := cx.Get(original.ID)
+	if err != nil {
+		t.Fatalf("Get recovered: %v", err)
+	}
+	if row.TrashedAt != "" {
+		t.Errorf("row should be recovered (TrashedAt cleared), got %q", row.TrashedAt)
+	}
+}
+
+// TestResolveCollision_PurgeAndRetry pins the P path: hard-purge the
+// colliding row to free the slot, then the new trace lands at the same
+// id with the new body. Distinguishes P from R semantically — under R
+// the user's new body is discarded; under P the new body wins.
+func TestResolveCollision_PurgeAndRetry(t *testing.T) {
+	cx := newCortexForCollision(t)
+	original := trace.New("kiln", "note", "", nil, "discardable body")
+	if err := cx.Add(original); err != nil {
+		t.Fatalf("seed Add: %v", err)
+	}
+	if err := cx.Trash(original.ID); err != nil {
+		t.Fatalf("Trash: %v", err)
+	}
+
+	dup := trace.New("kiln", "note", "", nil, "fresh body")
+	collision := cx.Add(dup).(*cortex.ErrTraceIDExists)
+
+	scriptStdin(t, "p")
+	if err := resolveCollisionInteractive(cx, dup, collision, "note", "", nil, "fresh body"); err != nil {
+		t.Fatalf("resolveCollisionInteractive: %v", err)
+	}
+	row, err := cx.Get(original.ID)
+	if err != nil {
+		t.Fatalf("Get after purge+retry: %v", err)
+	}
+	if row.TrashedAt != "" {
+		t.Errorf("retried row should be active (TrashedAt empty), got %q", row.TrashedAt)
+	}
+}
+
+// TestResolveCollision_EOFTreatedAsQuit pins a regression caught
+// during local smoke: when stdin is empty (closed pipe, prior prompt
+// consumed everything, scripted run with no input left), the resolver
+// must NOT spin re-prompting against an empty buffer. EOF should
+// cleanly fall through to the Q path and propagate the original
+// collision error.
+func TestResolveCollision_EOFTreatedAsQuit(t *testing.T) {
+	cx := newCortexForCollision(t)
+	original := trace.New("eofcase", "note", "", nil, "body")
+	if err := cx.Add(original); err != nil {
+		t.Fatalf("seed Add: %v", err)
+	}
+
+	dup := trace.New("eofcase", "note", "", nil, "body 2")
+	collision := cx.Add(dup).(*cortex.ErrTraceIDExists)
+
+	// Empty stdin — no choice supplied at all.
+	scriptStdin(t)
+	err := resolveCollisionInteractive(cx, dup, collision, "note", "", nil, "body 2")
+	if !cortex.IsTraceIDExists(err) {
+		t.Errorf("expected ErrTraceIDExists to propagate on EOF, got %v", err)
+	}
+}
+
+// TestResolveCollision_QuitReturnsError pins the Q path: user backs
+// out, original collision error propagates so the caller sees the
+// failure.
+func TestResolveCollision_QuitReturnsError(t *testing.T) {
+	cx := newCortexForCollision(t)
+	original := trace.New("vault", "note", "", nil, "body")
+	if err := cx.Add(original); err != nil {
+		t.Fatalf("seed Add: %v", err)
+	}
+
+	dup := trace.New("vault", "note", "", nil, "body 2")
+	collision := cx.Add(dup).(*cortex.ErrTraceIDExists)
+
+	scriptStdin(t, "q")
+	err := resolveCollisionInteractive(cx, dup, collision, "note", "", nil, "body 2")
+	if !cortex.IsTraceIDExists(err) {
+		t.Errorf("expected ErrTraceIDExists to propagate on quit, got %v", err)
+	}
+}

--- a/internal/consolidation/pipeline.go
+++ b/internal/consolidation/pipeline.go
@@ -13,7 +13,7 @@ import (
 // pipeline needs. Separate from the narrower scheduler interface in
 // agent.go so tests of cadence don't have to stub promotion paths.
 type LLMCortex interface {
-	PromotionCandidates(tier string, window time.Duration) ([]cortex.PromotionCandidate, error)
+	LLMCandidates(window time.Duration) ([]cortex.PromotionCandidate, error)
 	Promote(id, newTier string) error
 	CreateDistilledTrace(spec cortex.DistilledTraceSpec) (string, error)
 	TraceFile(id string, archived bool) string
@@ -29,6 +29,14 @@ type PipelineConfig struct {
 	ModelName  string
 	MaxRetries int
 	DryRun     bool
+
+	// Heuristic tunes the fallback scorer that runs when the LLM
+	// rejects a cluster or the endpoint errors out. Zero-value uses
+	// the same defaults as the standalone HeuristicPass (threshold=5,
+	// reads=1, modifies=2, lineage=3, votes=5). Independent from the
+	// scheduled HeuristicPass so an operator can tune the fallback
+	// gate without touching the scheduled cadence.
+	Heuristic PassConfig
 }
 
 // PipelineResult summarises a single pass so the CLI can log what
@@ -89,7 +97,7 @@ func RunLLMPass(ctx context.Context, cx LLMCortex, llm LLMClient, cfg PipelineCo
 	}
 	var result PipelineResult
 
-	candidates, err := cx.PromotionCandidates(trace.TierShort, cfg.Window)
+	candidates, err := cx.LLMCandidates(cfg.Window)
 	if err != nil {
 		return result, fmt.Errorf("selecting candidates: %w", err)
 	}
@@ -161,7 +169,7 @@ func RunLLMPass(ctx context.Context, cx LLMCortex, llm LLMClient, cfg PipelineCo
 					cr.Reason = fmt.Sprintf("llm error (dry-run fallback suppressed): %v", runErr)
 				} else {
 					log("[consolidate] cluster failed after retries: %v; falling back to heuristic promotion", runErr)
-					n := heuristicFallback(cx, chunk, log)
+					n := heuristicFallback(cx, chunk, cfg.Heuristic, log)
 					result.FallbackPromotions += n
 					cr.Outcome = "fallback"
 					cr.Reason = fmt.Sprintf("llm error, heuristic-promoted %d: %v", n, runErr)
@@ -311,15 +319,22 @@ func runWithRetry(ctx context.Context, llm LLMClient, profile Profile, model str
 	return Distillation{}, lastErr
 }
 
-// heuristicFallback promotes every candidate in the chunk 1:1 so a
-// pass that couldn't produce a distillation still moves qualifying
-// short-term traces into mid-term. Individual Promote failures are
-// logged but don't abort the fallback loop — the caller already
-// degraded from LLM to heuristic; one further failure shouldn't
-// cascade.
-func heuristicFallback(cx LLMCortex, chunk []cortex.PromotionCandidate, log func(format string, args ...any)) int {
+// heuristicFallback promotes only the candidates in the chunk that
+// pass the heuristic score gate, so an LLM-failed pass still moves
+// qualifying short-term traces forward without dragging zero-signal
+// chunkmates along. Earlier versions promoted every candidate
+// unconditionally, which produced the same low-engagement mid-tier
+// pollution that the heuristic was deliberately gating against.
+// Individual Promote failures are logged but don't abort the loop —
+// the caller already degraded from LLM to heuristic; one further
+// failure shouldn't cascade.
+func heuristicFallback(cx LLMCortex, chunk []cortex.PromotionCandidate, cfg PassConfig, log func(format string, args ...any)) int {
+	cfg = cfg.resolved()
 	promoted := 0
 	for _, pc := range chunk {
+		if scoreCandidate(pc, cfg) < cfg.PromotionThreshold {
+			continue
+		}
 		if err := cx.Promote(pc.ID, trace.TierMid); err != nil {
 			log("[consolidate] fallback promote failed id=%s: %v", pc.ID, err)
 			continue

--- a/internal/consolidation/pipeline_test.go
+++ b/internal/consolidation/pipeline_test.go
@@ -112,27 +112,27 @@ func TestRunLLMPass_HappyPath_Frontier(t *testing.T) {
 		t.Errorf("CandidatesConsidered = %d, want 3", result.CandidatesConsidered)
 	}
 
-	// Verify a mid-tier trace now exists with derived_from linking
-	// to all three sources. Under the v1 "net-add with source
-	// promotion" policy, mid also contains the three promoted
-	// sources, so the expected count is 4 (1 distillation + 3
-	// sources). The distillation is the one with derived_from set.
+	// Verify a single mid-tier trace exists for the distilled summary;
+	// sources stay at short under the current policy. derived_from on
+	// the distilled row keeps the originals reachable, and LLMCandidates
+	// will skip them on the next pass via the ActionConsolidate event.
 	rows, err := cx.List(cortex.ListOptions{Tiers: []string{trace.TierMid}})
 	if err != nil {
 		t.Fatalf("List mid: %v", err)
 	}
-	if len(rows) != 4 {
-		t.Fatalf("mid tier rows = %d, want 4 (1 distilled + 3 promoted sources)", len(rows))
+	if len(rows) != 1 {
+		t.Fatalf("mid tier rows = %d, want 1 (distilled only; sources stay at short)", len(rows))
 	}
-	var distilledID string
-	for _, r := range rows {
-		if r.Title == "Auth strategy — distilled" {
-			distilledID = r.ID
-			break
-		}
+	distilledID := rows[0].ID
+	if rows[0].Title != "Auth strategy — distilled" {
+		t.Fatalf("mid-tier row title = %q, want %q", rows[0].Title, "Auth strategy — distilled")
 	}
-	if distilledID == "" {
-		t.Fatalf("no mid-tier row titled %q among %d mid rows", "Auth strategy — distilled", len(rows))
+	shortRows, err := cx.List(cortex.ListOptions{Tiers: []string{trace.TierShort}})
+	if err != nil {
+		t.Fatalf("List short: %v", err)
+	}
+	if len(shortRows) != 3 {
+		t.Errorf("short tier rows = %d, want 3 (sources untouched)", len(shortRows))
 	}
 	// List doesn't populate DerivedFrom (that's a separate lineage
 	// query); fetch via Get to verify the derived_from links.
@@ -209,14 +209,15 @@ func TestRunLLMPass_DryRun_SkipsWrite(t *testing.T) {
 }
 
 // TestRunLLMPass_LLMError_FallsBackToHeuristic pins the graceful-
-// degradation rail from Phase 8: when the LLM step repeatedly fails,
-// the pipeline drops to 1:1 heuristic promotion rather than leaving
-// the candidates in short-term forever.
-func TestRunLLMPass_LLMError_FallsBackToHeuristic(t *testing.T) {
+// degradation rail when the LLM step repeatedly fails. The fallback
+// runs the same heuristic score gate as the standalone HeuristicPass:
+// candidates without enough signal stay at short rather than getting
+// dragged forward unconditionally. Three zero-engagement seed traces
+// score 0 — well under the threshold of 5 — so none should promote.
+func TestRunLLMPass_LLMError_FallsBackToHeuristic_GatedByScore(t *testing.T) {
 	cx := setupCortex(t)
 	seedTraces(t, cx, 3)
 
-	// Empty response queue — every call errors with "exhausted".
 	llm := &scriptedLLM{}
 
 	result, err := consolidation.RunLLMPass(context.Background(), cx, llm, consolidation.PipelineConfig{
@@ -231,15 +232,52 @@ func TestRunLLMPass_LLMError_FallsBackToHeuristic(t *testing.T) {
 	if result.DistillationsCreated != 0 {
 		t.Errorf("DistillationsCreated = %d, want 0 (all failed)", result.DistillationsCreated)
 	}
-	if result.FallbackPromotions != 3 {
-		t.Errorf("FallbackPromotions = %d, want 3 (one per candidate)", result.FallbackPromotions)
+	if result.FallbackPromotions != 0 {
+		t.Errorf("FallbackPromotions = %d, want 0 (zero-engagement seeds shouldn't pass the gate)", result.FallbackPromotions)
 	}
 
-	// The three originals should now be mid-tier via heuristic
-	// fallback rather than frozen at short-tier forever.
+	rows, _ := cx.List(cortex.ListOptions{Tiers: []string{trace.TierMid}})
+	if len(rows) != 0 {
+		t.Errorf("mid tier rows after gated fallback = %d, want 0", len(rows))
+	}
+}
+
+// TestRunLLMPass_LLMError_FallbackPromotesQualifyingCandidates pairs
+// with the gated test above: when a candidate has accumulated enough
+// signal to clear the heuristic threshold, the fallback should still
+// promote it. Three reads on the seeded trace gives score=3 with the
+// default reads weight (1) and a derived_from of 2 adds the lineage
+// credit (≥2 sources × WeightLineage 3 = 6) for a total of 9, well
+// over the threshold of 5.
+func TestRunLLMPass_LLMError_FallbackPromotesQualifyingCandidates(t *testing.T) {
+	cx := setupCortex(t)
+	ids := seedTraces(t, cx, 3)
+
+	// Bump tier_votes on each seed so the heuristic score reaches the
+	// threshold without needing to fabricate read/modify history.
+	// One vote × WeightVotes (5) = 5, exactly at threshold.
+	for _, id := range ids {
+		if err := cx.Vote(id, +1, cortex.ActorAgent); err != nil {
+			t.Fatalf("Vote %s: %v", id, err)
+		}
+	}
+
+	llm := &scriptedLLM{}
+	result, err := consolidation.RunLLMPass(context.Background(), cx, llm, consolidation.PipelineConfig{
+		Window:     24 * time.Hour,
+		ModelTier:  "frontier",
+		ModelName:  "m",
+		MaxRetries: 1,
+	}, nil)
+	if err != nil {
+		t.Fatalf("RunLLMPass: %v", err)
+	}
+	if result.FallbackPromotions != 3 {
+		t.Errorf("FallbackPromotions = %d, want 3 (one vote each clears threshold)", result.FallbackPromotions)
+	}
 	rows, _ := cx.List(cortex.ListOptions{Tiers: []string{trace.TierMid}})
 	if len(rows) != 3 {
-		t.Errorf("mid tier rows after fallback = %d, want 3", len(rows))
+		t.Errorf("mid tier rows after qualifying fallback = %d, want 3", len(rows))
 	}
 }
 

--- a/internal/cortex/add_errors.go
+++ b/internal/cortex/add_errors.go
@@ -1,0 +1,123 @@
+package cortex
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ErrTraceIDExists is returned by Add when the would-be trace's
+// deterministic ID (`YYYYMMDD-slug`) collides with a row that's already
+// in the cortex — active, archived, or trashed. The PK constraint on
+// traces.id is what surfaces in the underlying SQLite error
+// (extended code 1555 = SQLITE_CONSTRAINT_PRIMARYKEY); this typed wrapper
+// adds the existing row's state so callers can choose the right remedy
+// without an extra round-trip. Soft-deleted (trashed) and archived
+// rows are common collision sources because they hold their `id` slot
+// through their grace window — and `noema list` hides them by default.
+//
+// State takes one of "active", "archived", "trashed", "purged".
+// "purged" means a soft-purged tombstone whose row still occupies the
+// id slot — a `--hard` purge would have removed the row outright and
+// the Add wouldn't conflict at all. If the row vanishes between the
+// constraint failure and the state lookup (race with another mutator),
+// State is "unknown" and the original DB error is preserved via
+// Wrapped.
+type ErrTraceIDExists struct {
+	ID         string
+	State      string
+	ArchivedAt string
+	TrashedAt  string
+	PurgedAt   string
+	Wrapped    error
+}
+
+func (e *ErrTraceIDExists) Error() string {
+	state := e.State
+	if state == "" {
+		state = "unknown"
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "trace id %q already exists (currently %s).\n", e.ID, state)
+	b.WriteString("fix one of:\n")
+	b.WriteString("  - vary the title (different slug → different id)\n")
+	switch e.State {
+	case "trashed":
+		fmt.Fprintf(&b, "  - noema recover %s          (restore the trashed trace)\n", e.ID)
+		fmt.Fprintf(&b, "  - noema memory purge %s     (free the slot, irreversible)\n", e.ID)
+	case "archived":
+		fmt.Fprintf(&b, "  - noema unarchive %s        (restore the archived trace)\n", e.ID)
+		fmt.Fprintf(&b, "  - noema memory purge %s     (free the slot, irreversible)\n", e.ID)
+	case "purged":
+		fmt.Fprintf(&b, "  - noema memory purge --hard %s (remove the tombstone outright; only this frees the slot)\n", e.ID)
+	default:
+		fmt.Fprintf(&b, "  - read it first: noema get %s\n", e.ID)
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func (e *ErrTraceIDExists) Unwrap() error { return e.Wrapped }
+
+// IsTraceIDExists reports whether err is or wraps ErrTraceIDExists.
+// Convenience for callers that only need to branch on the kind, not
+// the metadata.
+func IsTraceIDExists(err error) bool {
+	var target *ErrTraceIDExists
+	return errors.As(err, &target)
+}
+
+// pkConflictOnTraceID matches the underlying driver error string for a
+// primary-key conflict on traces.id. modernc.org/sqlite reports the
+// failure as either "PRIMARY KEY constraint failed: traces.id" or
+// "UNIQUE constraint failed: traces.id" depending on driver version
+// and how the error gets wrapped — we accept both. Sibling tables in
+// the same INSERT path (trace_tags, trace_lineage) wouldn't surface
+// here because their inserts run after the traces row succeeds.
+func pkConflictOnTraceID(err error) bool {
+	if err == nil {
+		return false
+	}
+	s := err.Error()
+	return strings.Contains(s, "constraint failed: traces.id") ||
+		strings.Contains(s, "PRIMARY KEY constraint failed: traces.id") ||
+		strings.Contains(s, "UNIQUE constraint failed: traces.id")
+}
+
+// describeTraceIDCollision looks up the existing row's archived/trashed
+// timestamps and packages an ErrTraceIDExists with the resolved state.
+// The lookup runs against the live DB (not the failed transaction) so
+// it sees any row regardless of which tier or grace state holds the id.
+func (c *Cortex) describeTraceIDCollision(id string, wrapped error) error {
+	var archivedAt, trashedAt, purgedAt sql.NullString
+	row := c.DB.QueryRow(
+		`SELECT archived_at, trashed_at, purged_at FROM traces WHERE id = ?`, id,
+	)
+	if err := row.Scan(&archivedAt, &trashedAt, &purgedAt); err != nil {
+		return &ErrTraceIDExists{ID: id, State: "unknown", Wrapped: wrapped}
+	}
+	state := "active"
+	switch {
+	case purgedAt.Valid && purgedAt.String != "":
+		state = "purged"
+	case trashedAt.Valid && trashedAt.String != "":
+		state = "trashed"
+	case archivedAt.Valid && archivedAt.String != "":
+		state = "archived"
+	}
+	return &ErrTraceIDExists{
+		ID:         id,
+		State:      state,
+		ArchivedAt: nullString(archivedAt),
+		TrashedAt:  nullString(trashedAt),
+		PurgedAt:   nullString(purgedAt),
+		Wrapped:    wrapped,
+	}
+}
+
+func nullString(s sql.NullString) string {
+	if s.Valid {
+		return s.String
+	}
+	return ""
+}

--- a/internal/cortex/add_errors_test.go
+++ b/internal/cortex/add_errors_test.go
@@ -1,0 +1,144 @@
+package cortex_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Fail-Safe/Noema/internal/cortex"
+	"github.com/Fail-Safe/Noema/internal/trace"
+)
+
+// PK collisions on traces.id are the failure mode an end-user actually
+// hits when they retry a create on the same day with the same title (or
+// when an agent recreates a title held by a trashed/archived trace).
+// The raw modernc.org/sqlite error string ("UNIQUE constraint failed:
+// traces.id (1555)") is incomprehensible to a human and routinely
+// misdiagnosed by LLM agents (the (1555) is the SQLITE_CONSTRAINT_PRIMARYKEY
+// extended code, not a rowid). These tests pin the typed wrapper that
+// Add returns instead.
+
+func TestAdd_CollidesActive_ReturnsTypedError(t *testing.T) {
+	cx := setup(t)
+	first := trace.New("collision-target", "note", "", nil, "first body")
+	if err := cx.Add(first); err != nil {
+		t.Fatalf("seed Add: %v", err)
+	}
+	dup := trace.New("collision-target", "note", "", nil, "second body")
+	err := cx.Add(dup)
+	var collision *cortex.ErrTraceIDExists
+	if !errors.As(err, &collision) {
+		t.Fatalf("err = %v, want *ErrTraceIDExists", err)
+	}
+	if collision.ID != first.ID {
+		t.Errorf("ID = %q, want %q", collision.ID, first.ID)
+	}
+	if collision.State != "active" {
+		t.Errorf("State = %q, want active", collision.State)
+	}
+	if !strings.Contains(collision.Error(), "already exists (currently active)") {
+		t.Errorf("Error() should mention active state, got: %s", collision.Error())
+	}
+}
+
+func TestAdd_CollidesTrashed_StateReportedAsTrashed(t *testing.T) {
+	cx := setup(t)
+	first := trace.New("ghost", "note", "", nil, "body")
+	if err := cx.Add(first); err != nil {
+		t.Fatalf("seed Add: %v", err)
+	}
+	if err := cx.Trash(first.ID); err != nil {
+		t.Fatalf("Trash: %v", err)
+	}
+	dup := trace.New("ghost", "note", "", nil, "different body")
+	err := cx.Add(dup)
+	var collision *cortex.ErrTraceIDExists
+	if !errors.As(err, &collision) {
+		t.Fatalf("err = %v, want *ErrTraceIDExists", err)
+	}
+	if collision.State != "trashed" {
+		t.Errorf("State = %q, want trashed", collision.State)
+	}
+	if collision.TrashedAt == "" {
+		t.Errorf("TrashedAt should be populated, got empty")
+	}
+	// Recovery hint should be appropriate to a trashed row.
+	if !strings.Contains(collision.Error(), "noema recover") {
+		t.Errorf("Error() should suggest recover for trashed state: %s", collision.Error())
+	}
+}
+
+func TestAdd_CollidesArchived_StateReportedAsArchived(t *testing.T) {
+	cx := setup(t)
+	first := trace.New("dust", "note", "", nil, "body")
+	if err := cx.Add(first); err != nil {
+		t.Fatalf("seed Add: %v", err)
+	}
+	if err := cx.Archive(first.ID); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	dup := trace.New("dust", "note", "", nil, "different body")
+	err := cx.Add(dup)
+	var collision *cortex.ErrTraceIDExists
+	if !errors.As(err, &collision) {
+		t.Fatalf("err = %v, want *ErrTraceIDExists", err)
+	}
+	if collision.State != "archived" {
+		t.Errorf("State = %q, want archived", collision.State)
+	}
+	if !strings.Contains(collision.Error(), "noema unarchive") {
+		t.Errorf("Error() should suggest unarchive for archived state: %s", collision.Error())
+	}
+}
+
+func TestAdd_CollidesPurgedTombstone_StateReportedAsPurged(t *testing.T) {
+	cx := setup(t)
+	first := trace.New("ash", "note", "", nil, "body")
+	if err := cx.Add(first); err != nil {
+		t.Fatalf("seed Add: %v", err)
+	}
+	if err := cx.AdminPurge(first.ID, "test purge", trace.TierShort, false, cortex.ActorHuman); err != nil {
+		t.Fatalf("AdminPurge soft: %v", err)
+	}
+	dup := trace.New("ash", "note", "", nil, "different body")
+	err := cx.Add(dup)
+	var collision *cortex.ErrTraceIDExists
+	if !errors.As(err, &collision) {
+		t.Fatalf("err = %v, want *ErrTraceIDExists", err)
+	}
+	if collision.State != "purged" {
+		t.Errorf("State = %q, want purged", collision.State)
+	}
+	if !strings.Contains(collision.Error(), "--hard") {
+		t.Errorf("Error() should explain that only --hard purge frees the slot: %s", collision.Error())
+	}
+}
+
+func TestAdd_HardPurgeFreesIDSlot(t *testing.T) {
+	// Counterpart to the soft-purge test above: a --hard purge actually
+	// removes the row, so a follow-up Add with the same title should
+	// succeed cleanly with no ErrTraceIDExists.
+	cx := setup(t)
+	first := trace.New("phoenix", "note", "", nil, "body")
+	if err := cx.Add(first); err != nil {
+		t.Fatalf("seed Add: %v", err)
+	}
+	if err := cx.AdminPurge(first.ID, "test hard purge", trace.TierShort, true, cortex.ActorHuman); err != nil {
+		t.Fatalf("AdminPurge hard: %v", err)
+	}
+	dup := trace.New("phoenix", "note", "", nil, "rebirth body")
+	if err := cx.Add(dup); err != nil {
+		t.Fatalf("Add after hard purge should succeed, got: %v", err)
+	}
+}
+
+func TestIsTraceIDExists_RecognisesWrappedError(t *testing.T) {
+	// errors.As should reach the typed error even if a caller wraps it.
+	wrapped := &cortex.ErrTraceIDExists{ID: "x", State: "active"}
+	if !cortex.IsTraceIDExists(wrapped) {
+		t.Errorf("IsTraceIDExists should report true for direct error")
+	}
+	if cortex.IsTraceIDExists(errors.New("unrelated")) {
+		t.Errorf("IsTraceIDExists should report false for unrelated error")
+	}
+}

--- a/internal/cortex/candidates.go
+++ b/internal/cortex/candidates.go
@@ -79,6 +79,76 @@ func (c *Cortex) GraduationCandidates(minAge time.Duration) ([]PromotionCandidat
 	return out, rows.Err()
 }
 
+// LLMCandidates returns the short-tier candidate pool for the LLM
+// distillation pass — same shape as PromotionCandidates, but with
+// already-consolidated sources filtered out. A trace is considered
+// "already consolidated" if its ID appears in the source_ids array of
+// any past ActionConsolidate event.
+//
+// CreateDistilledTrace used to keep these out of the pool by promoting
+// every source to mid as a side effect; that polluted mid with
+// zero-engagement traces. Filtering on the event log instead leaves
+// sources at their natural tier while still preventing the next pass
+// from re-clustering them into a duplicate distillation.
+//
+// json_each is part of SQLite's JSON1 extension, which is enabled by
+// modernc.org/sqlite at compile time; no driver flag is needed.
+func (c *Cortex) LLMCandidates(window time.Duration) ([]PromotionCandidate, error) {
+	cutoff := time.Now().UTC().Add(-window).Format(time.RFC3339)
+	q := `
+		SELECT
+			t.id,
+			t.tier,
+			t.type,
+			COALESCE(u.total_reads, 0)        AS read_count,
+			COALESCE(u.total_modifies, 0)     AS modify_count,
+			COALESCE(u.total_search_hits, 0)  AS search_hit_count,
+			t.tier_votes,
+			COALESCE(v.n, 0) AS derived_from_count,
+			t.created_at
+		FROM traces t
+		LEFT JOIN (
+			SELECT trace_id,
+			       SUM(read_count)       AS total_reads,
+			       SUM(modify_count)     AS total_modifies,
+			       SUM(search_hit_count) AS total_search_hits
+			FROM trace_usage
+			GROUP BY trace_id
+		) u ON u.trace_id = t.id
+		LEFT JOIN v_derived_from_count v ON v.trace_id = t.id
+		WHERE t.tier = 'short'
+		  AND t.archived_at IS NULL
+		  AND t.trashed_at IS NULL
+		  AND t.purged_at IS NULL
+		  AND t.created_at >= ?
+		  AND t.id != ''
+		  AND t.id NOT IN (
+		      SELECT je.value
+		      FROM events e, json_each(json_extract(e.data, '$.source_ids')) je
+		      WHERE e.action = 'consolidate'
+		  )
+		ORDER BY t.created_at DESC
+	`
+	rows, err := c.DB.Query(q, cutoff)
+	if err != nil {
+		return nil, fmt.Errorf("selecting llm candidates: %w", err)
+	}
+	defer rows.Close()
+
+	var out []PromotionCandidate
+	for rows.Next() {
+		var pc PromotionCandidate
+		if err := rows.Scan(
+			&pc.ID, &pc.Tier, &pc.Type, &pc.ReadCount, &pc.ModifyCount,
+			&pc.SearchHitCount, &pc.TierVotes, &pc.DerivedFromCount, &pc.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+		out = append(out, pc)
+	}
+	return out, rows.Err()
+}
+
 // PromotionCandidates returns every active trace in the given tier
 // whose created_at falls within the rolling window. The caller does
 // the scoring; this method is only responsible for narrowing to the

--- a/internal/cortex/candidates_test.go
+++ b/internal/cortex/candidates_test.go
@@ -185,3 +185,47 @@ func TestPromotionCandidates_WindowBound(t *testing.T) {
 		t.Errorf("expected zero candidates outside window, got %d (%+v)", len(got), got)
 	}
 }
+
+func TestLLMCandidates_ExcludesAlreadyConsolidatedSources(t *testing.T) {
+	// Once CreateDistilledTrace fires for a pair of sources, the
+	// resulting ActionConsolidate event should keep those source IDs
+	// out of the LLM candidate pool — even though they're still at
+	// short tier under the no-auto-promote policy. PromotionCandidates
+	// (the heuristic pass's pool) is unaffected and still surfaces
+	// them, since the heuristic gates on score not on consolidation
+	// history.
+	cx := setup(t)
+	src1 := trace.New("s1", "note", "", nil, "b1")
+	src2 := trace.New("s2", "note", "", nil, "b2")
+	independent := trace.New("indep", "note", "", nil, "b3")
+	for _, tr := range []*trace.Trace{src1, src2, independent} {
+		if err := cx.Add(tr); err != nil {
+			t.Fatalf("Add %s: %v", tr.Title, err)
+		}
+	}
+	if _, err := cx.CreateDistilledTrace(cortex.DistilledTraceSpec{
+		Title: "dist", Body: "b", SourceIDs: []string{src1.ID, src2.ID},
+	}); err != nil {
+		t.Fatalf("CreateDistilledTrace: %v", err)
+	}
+
+	llm, err := cx.LLMCandidates(24 * time.Hour)
+	if err != nil {
+		t.Fatalf("LLMCandidates: %v", err)
+	}
+	if len(llm) != 1 || llm[0].ID != independent.ID {
+		var ids []string
+		for _, pc := range llm {
+			ids = append(ids, pc.ID)
+		}
+		t.Errorf("LLMCandidates = %v, want only %s (consumed sources excluded)", ids, independent.ID)
+	}
+
+	heuristic, err := cx.PromotionCandidates(trace.TierShort, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("PromotionCandidates: %v", err)
+	}
+	if len(heuristic) != 3 {
+		t.Errorf("PromotionCandidates(short) = %d, want 3 (heuristic pool sees all short-tier traces, including ex-sources)", len(heuristic))
+	}
+}

--- a/internal/cortex/cortex.go
+++ b/internal/cortex/cortex.go
@@ -1170,6 +1170,9 @@ func (c *Cortex) Add(t *trace.Trace) error {
 	}
 	if err := c.insertDB(t); err != nil {
 		os.Remove(path)
+		if pkConflictOnTraceID(err) {
+			return c.describeTraceIDCollision(t.ID, err)
+		}
 		return fmt.Errorf("inserting into database: %w", err)
 	}
 	return nil

--- a/internal/cortex/distill.go
+++ b/internal/cortex/distill.go
@@ -46,26 +46,17 @@ type DistilledTraceSpec struct {
 // which model produced it / how confident" as separate, replayable
 // records.
 //
-// Source handling (v1 — "net-add with source promotion"): every
-// short-tier source is promoted to mid once the distillation lands.
-// The distilled trace is the retrievable summary; sources remain
-// individually addressable at mid so agents can pull the full
-// detail via derived_from when the distillation's compression is
-// lossy. This also prevents the next consolidation pass from
-// re-clustering the same sources into a duplicate distillation —
-// the candidate query filters to tier='short', so promoted sources
-// drop out of the candidate pool.
-//
-// FUTURE (v2+): "source archival" — instead of promoting sources
-// to mid, move them to archived once the distillation is trusted
-// (confidence threshold + retention window). That keeps mid-tier
-// curated and closer to the biological metaphor where the detailed
-// memory fades as the distillation takes its place. Not v1 because
-// the grace-period machinery adds a new daemon and needs a
-// confidence-calibration pass first. The current design's derived_from
-// lineage already supports the retrieval path that option 2 would
-// need, so the switch is local to this function + a new archival
-// sweep — no schema changes.
+// Source handling: sources stay at their original tier. The distilled
+// trace is the retrievable summary, and derived_from lineage keeps the
+// originals reachable for the cases where the distillation's
+// compression is lossy. Earlier versions auto-promoted every source to
+// mid alongside the distillation, which polluted the mid tier with
+// zero-engagement traces (a single ActionConsolidate run could promote
+// 5+ sources that had no reads, modifies, or votes of their own).
+// Re-clustering protection is now provided by LLMCandidates, which
+// excludes any short-tier trace that already appears as a source in a
+// past ActionConsolidate event — so a source isn't re-fed into a
+// duplicate distillation just because it stayed at short.
 func (c *Cortex) CreateDistilledTrace(spec DistilledTraceSpec) (string, error) {
 	if spec.Title == "" {
 		return "", fmt.Errorf("distilled trace: title is required")
@@ -126,36 +117,6 @@ func (c *Cortex) CreateDistilledTrace(spec DistilledTraceSpec) (string, error) {
 	}
 	if err := tx.Commit(); err != nil {
 		return t.ID, fmt.Errorf("committing consolidate event: %w", err)
-	}
-
-	// Promote each source from short to mid. Best-effort per source —
-	// the distillation itself has already landed, so a partial
-	// promotion failure doesn't invalidate anything, it just leaves
-	// one or more sources at short. They'd surface again in the next
-	// consolidation pass, which is suboptimal but self-correcting.
-	// Sources that are not at 'short' are skipped quietly: they may
-	// already have been promoted by a previous run (re-consolidation
-	// after a crash), or they're at a tier this function shouldn't
-	// touch (mid/long — isValidPromotion would reject anyway).
-	for _, sid := range spec.SourceIDs {
-		srow, err := c.Get(sid)
-		if err != nil {
-			// Source vanished between the earlier existence check and
-			// now — log and skip rather than abort the whole operation.
-			// The distilled trace is already committed; lineage is
-			// intact.
-			continue
-		}
-		if srow.Tier != trace.TierShort {
-			continue
-		}
-		if err := c.Promote(sid, trace.TierMid); err != nil {
-			// Non-fatal per the "best-effort" contract. The ActionPromote
-			// event is what keeps federation peers consistent; if this
-			// fails here it fails everywhere, and the next run will
-			// retry.
-			continue
-		}
 	}
 
 	return t.ID, nil

--- a/internal/cortex/distill_test.go
+++ b/internal/cortex/distill_test.go
@@ -148,16 +148,13 @@ func TestCreateDistilledTrace_RejectsEmptyTitleOrBody(t *testing.T) {
 	}
 }
 
-func TestCreateDistilledTrace_PromotesSourcesToMid(t *testing.T) {
-	// v1 policy: once a distillation lands, every short-tier source
-	// is promoted to mid. This keeps both representations available
-	// (distillation as the summary, sources as full-detail backing
-	// store reachable via derived_from) and takes the sources out of
-	// the PromotionCandidates pool so the next pass doesn't
-	// re-consolidate them into a duplicate distillation.
-	//
-	// v2+ will likely replace this with archival-after-grace-period
-	// (see the doc-comment on CreateDistilledTrace).
+func TestCreateDistilledTrace_LeavesSourcesAtShort(t *testing.T) {
+	// Sources stay at their original tier when a distillation lands.
+	// derived_from on the distilled trace keeps them reachable, and
+	// LLMCandidates filters them out of subsequent LLM passes via the
+	// ActionConsolidate event log — so they don't get re-clustered
+	// into duplicate distillations and they don't pollute mid with
+	// zero-engagement promotions either.
 	cx := setup(t)
 	src1 := trace.New("s1", "note", "", nil, "b1")
 	src2 := trace.New("s2", "note", "", nil, "b2")
@@ -177,8 +174,8 @@ func TestCreateDistilledTrace_PromotesSourcesToMid(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Get source: %v", err)
 		}
-		if row.Tier != trace.TierMid {
-			t.Errorf("source %s tier = %q, want mid (sources promoted on distillation)", id, row.Tier)
+		if row.Tier != trace.TierShort {
+			t.Errorf("source %s tier = %q, want short (sources stay put on distillation)", id, row.Tier)
 		}
 	}
 }

--- a/internal/mcp/consolidation_test.go
+++ b/internal/mcp/consolidation_test.go
@@ -90,26 +90,26 @@ func TestRecordConsolidationResult_CreatesMidTrace(t *testing.T) {
 		t.Errorf("response missing confirmation: %s", text)
 	}
 
-	// Under the v1 "net-add with source promotion" policy, mid-tier
-	// contains the distilled trace PLUS the two promoted sources, so
-	// the expected count is 3 and the check is "distilled title is
-	// present" rather than "list has exactly one row".
+	// Sources stay at their original tier; only the distilled trace
+	// lands in mid. derived_from on the distilled row keeps the
+	// originals reachable, and LLMCandidates filters them out of
+	// subsequent passes via the ActionConsolidate event log.
 	rows, err := cx.List(cortex.ListOptions{Tiers: []string{trace.TierMid}})
 	if err != nil {
 		t.Fatalf("List mid: %v", err)
 	}
-	if len(rows) != 3 {
-		t.Fatalf("mid tier rows = %d, want 3 (1 distilled + 2 promoted sources): %+v", len(rows), rows)
+	if len(rows) != 1 {
+		t.Fatalf("mid tier rows = %d, want 1 (distilled only): %+v", len(rows), rows)
 	}
-	var foundDistilled bool
-	for _, r := range rows {
-		if r.Title == "Auth strategy — distilled" {
-			foundDistilled = true
-			break
-		}
+	if rows[0].Title != "Auth strategy — distilled" {
+		t.Errorf("mid-tier row title = %q, want %q", rows[0].Title, "Auth strategy — distilled")
 	}
-	if !foundDistilled {
-		t.Errorf("distilled title %q not found among mid-tier rows: %+v", "Auth strategy — distilled", rows)
+	shortRows, err := cx.List(cortex.ListOptions{Tiers: []string{trace.TierShort}})
+	if err != nil {
+		t.Fatalf("List short: %v", err)
+	}
+	if len(shortRows) != 2 {
+		t.Errorf("short tier rows = %d, want 2 (sources untouched): %+v", len(shortRows), shortRows)
 	}
 }
 

--- a/internal/mcp/create_trace_collision_test.go
+++ b/internal/mcp/create_trace_collision_test.go
@@ -1,0 +1,80 @@
+package mcp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Fail-Safe/Noema/internal/trace"
+)
+
+// When create_trace's INSERT collides on the deterministic id slot, the
+// raw SQLite error string ("UNIQUE constraint failed: traces.id (1555)")
+// gets misread by LLM agents as a sequence-counter / rowid issue (the
+// (1555) is actually SQLITE_CONSTRAINT_PRIMARYKEY, a constant). The MCP
+// handler now returns a structured JSON envelope with the existing
+// row's state so an agent can branch on `kind` and `existing_state`
+// instead of having to parse English.
+func TestCreateTrace_CollisionReturnsStructuredError(t *testing.T) {
+	cx := newTestCortex(t)
+	first := trace.New("collide-me", "note", "", nil, "first body")
+	if err := cx.Add(first); err != nil {
+		t.Fatalf("seed Add: %v", err)
+	}
+	if err := cx.Trash(first.ID); err != nil {
+		t.Fatalf("Trash: %v", err)
+	}
+
+	s := NewServer(cx, "test", "")
+	initServer(t, s)
+
+	text, isErr := callTool(t, s, "create_trace", map[string]any{
+		"title": "collide-me",
+		"type":  "note",
+		"body":  "second body",
+	})
+	if !isErr {
+		t.Fatalf("expected error result, got success: %s", text)
+	}
+
+	var payload struct {
+		Kind          string   `json:"kind"`
+		ID            string   `json:"id"`
+		ExistingState string   `json:"existing_state"`
+		TrashedAt     string   `json:"trashed_at"`
+		Fix           []string `json:"fix"`
+		Summary       string   `json:"summary"`
+	}
+	if err := json.Unmarshal([]byte(text), &payload); err != nil {
+		t.Fatalf("response is not JSON: %v\nraw=%s", err, text)
+	}
+	if payload.Kind != "trace_id_collision" {
+		t.Errorf("kind = %q, want trace_id_collision", payload.Kind)
+	}
+	if payload.ID != first.ID {
+		t.Errorf("id = %q, want %q", payload.ID, first.ID)
+	}
+	if payload.ExistingState != "trashed" {
+		t.Errorf("existing_state = %q, want trashed", payload.ExistingState)
+	}
+	if payload.TrashedAt == "" {
+		t.Errorf("trashed_at should be populated, got empty")
+	}
+	if len(payload.Fix) == 0 {
+		t.Errorf("fix should list remediation options, got empty")
+	}
+	// At least one fix line should mention recover (since the row is
+	// trashed, that's the soft path; purge is the hard path).
+	var sawRecover bool
+	for _, f := range payload.Fix {
+		if strings.Contains(f, "recover") {
+			sawRecover = true
+		}
+	}
+	if !sawRecover {
+		t.Errorf("fix list should include `noema recover` for trashed state, got: %v", payload.Fix)
+	}
+	if payload.Summary == "" {
+		t.Errorf("summary should carry human-readable text for non-parsing readers")
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -175,6 +176,10 @@ func NewServer(cx *cortex.Cortex, noemaVersion string, federationMode string) *s
 			t.SourceHash = sh
 		}
 		if err := cx.Add(t); err != nil {
+			var collision *cortex.ErrTraceIDExists
+			if errors.As(err, &collision) {
+				return mcp.NewToolResultError(formatTraceIDCollision(collision)), nil
+			}
 			return nil, err
 		}
 		return mcp.NewToolResultText(fmt.Sprintf("Trace created: %s", t.ID)), nil
@@ -944,6 +949,27 @@ Choose the type that best reflects the intent of the memory:
   origin=<name>        traces from a specific cortex
   (no trashed filter via MCP — use the CLI for trash operations)
 
+## Errors with structured payloads
+
+Some create_trace failures return an error result whose text body is a
+JSON object rather than a plain string. Currently:
+
+  trace_id_collision   create_trace's would-be id (YYYYMMDD-slug form)
+                       is already held by an existing row. Fields:
+                         kind="trace_id_collision"
+                         id=<the colliding id>
+                         existing_state=active|archived|trashed|purged
+                         archived_at, trashed_at, purged_at (RFC3339, may be empty)
+                         fix=[<remediation strings>]
+                         summary=<human-readable rendering>
+                       The (1555) you may see in the underlying SQLite
+                       error string is SQLITE_CONSTRAINT_PRIMARYKEY (a
+                       constant), NOT a rowid — do not chase
+                       AUTOINCREMENT / sqlite_sequence remediations.
+                       The fix array names the right command for
+                       existing_state (recover, unarchive, or
+                       memory purge --hard).
+
 ## Provenance
 - origin is auto-set to the current cortex name on creation. Override it when
   replaying events from a remote peer.
@@ -1092,6 +1118,50 @@ runs.
 - Use derived_from when creating traces based on other traces — it builds a knowledge graph.
 - search_traces supports FTS5 syntax: quoted phrases, AND/OR/NOT, prefix* matching.
 `, m.Name, noemaVersion, m.Version, purposeLine, ownerLine, m.Name)
+}
+
+// formatTraceIDCollision renders an ErrTraceIDExists into a JSON
+// envelope with a human-readable summary. Agents that parse the body
+// can branch on `kind == "trace_id_collision"` and `existing_state`;
+// agents (or LLMs) that read the text directly still get the
+// human-readable lines under `summary`. The MCP error result still
+// carries the same payload as text — clients see `isError: true` plus
+// this JSON body.
+func formatTraceIDCollision(c *cortex.ErrTraceIDExists) string {
+	fix := []string{"vary the title (different slug → different id)"}
+	switch c.State {
+	case "trashed":
+		fix = append(fix,
+			fmt.Sprintf("noema recover %s   (restore the trashed trace)", c.ID),
+			fmt.Sprintf("noema memory purge %s   (free the slot, irreversible)", c.ID),
+		)
+	case "archived":
+		fix = append(fix,
+			fmt.Sprintf("noema unarchive %s (restore the archived trace)", c.ID),
+			fmt.Sprintf("noema memory purge %s (free the slot, irreversible)", c.ID),
+		)
+	case "purged":
+		fix = append(fix,
+			fmt.Sprintf("noema memory purge --hard %s (only a hard purge frees the slot)", c.ID),
+		)
+	default:
+		fix = append(fix, fmt.Sprintf("noema get %s (read the existing trace before deciding)", c.ID))
+	}
+	payload := map[string]any{
+		"kind":           "trace_id_collision",
+		"id":             c.ID,
+		"existing_state": c.State,
+		"archived_at":    c.ArchivedAt,
+		"trashed_at":     c.TrashedAt,
+		"purged_at":      c.PurgedAt,
+		"fix":            fix,
+		"summary":        c.Error(),
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return c.Error()
+	}
+	return string(b)
 }
 
 func formatRows(rows []cortex.Row) string {


### PR DESCRIPTION
## Summary

When `Cortex.Add` hits a primary-key collision on `traces.id`, the raw modernc.org/sqlite error string ("`UNIQUE constraint failed: traces.id (1555)`") used to bubble straight to the caller. The `(1555)` is the `SQLITE_CONSTRAINT_PRIMARYKEY` extended result code (a constant), not a rowid — but LLM agents pattern-match it as a stuck `AUTOINCREMENT` counter and propose `sqlite_sequence` remediations that apply to a different schema entirely. This PR moves the policy decision into `Cortex.Add` so every consumer (CLI, TUI, MCP) inherits a correct, actionable error.

### A. Typed error from `Cortex.Add`

`Cortex.Add` now returns `*ErrTraceIDExists` carrying the colliding id and the existing row's state (`active` / `archived` / `trashed` / `purged`) plus the relevant timestamps. The `Error()` rendering names the right recovery command for each state — `recover` for trashed, `unarchive` for archived, `memory purge --hard` for the purged-tombstone case where only hard removal frees the slot. State is resolved with one extra DB read against the live row so we don't depend on the failed transaction's visibility.

### B. Structured MCP error envelope

The MCP `create_trace` handler unwraps the typed error and returns a JSON envelope (`kind=trace_id_collision`, `existing_state`, `archived_at`/`trashed_at`/`purged_at`, `fix[]`, `summary`) as the error result body. Agents can branch on `kind` and `existing_state` instead of having to parse English. `get_instructions` gains a section explaining the envelope and explicitly calling out the `(1555)` red-herring so future agents don't repeat the misdiagnosis.

### C. Interactive recovery in `noema add`

When `Add` returns `ErrTraceIDExists` the CLI offers state-appropriate options:

- **(R)ecover** — for trashed state; restores the trashed trace, discards the new content
- **(U)narchive** — for archived state; same shape
- **(P)urge & retry** — hard-purges the colliding row (user has already committed to discarding it) and retries the add with the new body
- **(V)ary title** — prompts for a fresh title, regenerates the id, retries with the original body intact
- **(Q)uit** — propagates the error

EOF on stdin (closed pipe, scripted run) is treated as quit so the resolver doesn't spin against an empty buffer in non-interactive contexts. The TUI is left alone for now; it inherits the friendly multi-line error string for free via its existing `m.err` render path.

## Validation

End-to-end with testbot on ai-1 against a fresh cortex: pre-staged a trashed trace, asked testbot to create a colliding trace via MCP `noema_remember`. The agent correctly identified `existing_state=trashed`, proposed `noema recover <id>` as the fix, and listed the alternatives accurately — no AUTOINCREMENT diagnosis, no rowid speculation. Compared to a real-world failure where a different agent saw the same underlying SQLite condition and proposed `sqlite_sequence` cleanup against the wrong DB path, the structured envelope is the difference between "agent self-resolves" and "agent writes a misleading bug report."

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` clean
- [x] 6 new cortex tests covering active/archived/trashed/purged collision states + hard-purge slot release + `IsTraceIDExists` predicate
- [x] 1 new MCP test asserting the JSON envelope shape end-to-end
- [x] 5 new CLI tests covering R/U/P/V/Q paths + EOF-as-quit regression
- [x] Local CLI smoke against a fresh cortex confirmed all four paths render correctly and emit zero phantom events on failed inserts
- [x] Testbot end-to-end on ai-1 confirmed the structured error unblocks an LLM agent

## Notes for reviewers
- Stacked on top of #90 (distill fix) — depends on no code there but rebased so the deployed binary carries both.
- `Add()`'s error type changed from `fmt.Errorf("inserting into database: ...")` to `*ErrTraceIDExists` for the PK case. No internal callers string-match that error message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)