### PR TITLE
feat(memory): consolidation health surface (CLI + MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,14 @@ noema verify traces [--backfill]          Check trace content hashes against fro
 noema verify cortex                       Validate manifest, config, db, access posture, and federation
 noema verify drift                        Check federated traces for drift from their source hash
 
+noema memory stats [--detailed]           Show tier counts and (with --detailed) engagement signal
+noema memory health [--since 24h]         Show consolidation activity over the window, promotion-latency
+                                          percentiles, and the 1-source mid leak detector
+noema memory promote <id> [--to mid|long] Advance a trace one tier (short→mid or mid→long)
+noema memory demote <id>                  Step a mid trace back to short
+noema memory purge <id> --tier <t> --reason "..." --confirm [--hard]
+                                          Ceremoniously destroy a trace with audit trail (GDPR path)
+
 noema federation status                   Show federation config, MCP access posture, peer sync state, and vector clock
 noema federation peers                    List configured federation peers
 noema federation add-peer <name> <endpoint>

--- a/internal/cli/cmd_memory.go
+++ b/internal/cli/cmd_memory.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"text/tabwriter"
 	"time"
 
@@ -34,10 +35,171 @@ is distributed across the cortex without opening the DB.`,
 	cmd.AddCommand(
 		memoryPurgeCmd(),
 		memoryStatsCmd(),
+		memoryHealthCmd(),
 		memoryPromoteCmd(),
 		memoryDemoteCmd(),
 	)
 	return cmd
+}
+
+// memoryHealthReport wraps the three cortex methods that answer "is
+// consolidation actually doing anything, and is anything leaking?"
+// into a single JSON envelope with a top-level schema_version (design
+// doc §3 — single top-level version per output, not per-section). The
+// MCP `consolidation_health` tool returns the same shape modulo field
+// naming.
+type memoryHealthReport struct {
+	SchemaVersion int                          `json:"schema_version"`
+	Activity      cortex.ConsolidationActivity `json:"activity"`
+	Latency       cortex.PromotionLatency      `json:"latency"`
+	OneSourceMid  cortex.OneSourceMidCount     `json:"one_source_mid"`
+}
+
+func memoryHealthCmd() *cobra.Command {
+	var (
+		sinceFlag  string
+		outputFlag string
+	)
+	cmd := &cobra.Command{
+		Use:   "health",
+		Short: "Show consolidation activity, promotion latency, and the 1-source mid leak detector",
+		Long: `Reports the consolidation pipeline's recent behavior — the question
+that motivated the observability surface: "how did consolidation fare
+overnight, and is anything leaking?"
+
+Three sections:
+
+  - Activity over the --since window: per-day counts of consolidation_claim,
+    consolidation_success, consolidation_fail, promote (any tier transition),
+    and consolidate (real LLM distillation events). Totals roll up the same
+    counters across the window.
+
+  - Promotion latency (all-time): count and p50/p95 of short→mid and
+    mid→long transition durations. mid→long measures from when the trace
+    entered the mid tier, not its created_at — a trace that lives short
+    for 30 days then promotes mid→long the next day shows up here as a
+    1-day mid→long latency.
+
+  - 1-source mid leak detector: current count of active mid-tier traces
+    with derived_from_count == 1 (the bucket PR #86 and PR #90 closed),
+    plus the count of traces that landed in that bucket within the last
+    7 days. A healthy gate keeps the recent count at zero.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cx, err := resolveCortex()
+			if err != nil {
+				return err
+			}
+			defer cx.Close()
+			return runMemoryHealth(cmd.OutOrStdout(), cx, sinceFlag, outputFlag)
+		},
+	}
+	cmd.Flags().StringVar(&sinceFlag, "since", "24h", "lookback window for activity buckets (e.g. 24h, 7d, 2w)")
+	cmd.Flags().StringVar(&outputFlag, "output", "text", "output format: text, json")
+	return cmd
+}
+
+// runMemoryHealth is the testable core of the memory-health CLI: it
+// composes the three cortex observability calls into a single report
+// and dispatches to either JSON or text rendering. Split out from the
+// cobra RunE so unit tests can drive it with a constructed Cortex and
+// a captured writer without spinning up the full command tree.
+func runMemoryHealth(w io.Writer, cx *cortex.Cortex, sinceLabel, output string) error {
+	since, err := cortex.ParseSince(sinceLabel)
+	if err != nil {
+		return err
+	}
+	activity, err := cx.ConsolidationActivity(since)
+	if err != nil {
+		return fmt.Errorf("consolidation activity: %w", err)
+	}
+	latency, err := cx.PromotionLatency()
+	if err != nil {
+		return fmt.Errorf("promotion latency: %w", err)
+	}
+	leak, err := cx.OneSourceMidCount()
+	if err != nil {
+		return fmt.Errorf("one-source mid count: %w", err)
+	}
+
+	report := memoryHealthReport{
+		SchemaVersion: 1,
+		Activity:      activity,
+		Latency:       latency,
+		OneSourceMid:  leak,
+	}
+
+	switch output {
+	case "json":
+		buf, _ := json.MarshalIndent(report, "", "  ")
+		fmt.Fprintln(w, string(buf))
+	case "text", "":
+		renderMemoryHealthText(w, report, sinceLabel)
+	default:
+		return fmt.Errorf("unsupported --output %q (try: text, json)", output)
+	}
+	return nil
+}
+
+// renderMemoryHealthText formats the report for a terminal. Two
+// tabwriter blocks (activity table + totals; latency rows) and a
+// final paragraph for the leak detector. Tabwriter rather than
+// hand-aligned spaces keeps the columns clean when day counts grow
+// to 3-digit numbers under busy cortexes.
+func renderMemoryHealthText(w io.Writer, r memoryHealthReport, sinceLabel string) {
+	fmt.Fprintf(w, "Consolidation activity — last %s\n", sinceLabel)
+	if len(r.Activity.Daily) == 0 {
+		fmt.Fprintln(w, "  (no events in window)")
+	} else {
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "  Date\tClaim\tSuccess\tFail\tPromote\tDistill")
+		for _, d := range r.Activity.Daily {
+			fmt.Fprintf(tw, "  %s\t%d\t%d\t%d\t%d\t%d\n",
+				d.Date, d.Claim, d.Success, d.Fail, d.Promote, d.Distill)
+		}
+		fmt.Fprintf(tw, "  ----\t-----\t-------\t----\t-------\t-------\n")
+		fmt.Fprintf(tw, "  Total\t%d\t%d\t%d\t%d\t%d\n",
+			r.Activity.Totals.Claim, r.Activity.Totals.Success, r.Activity.Totals.Fail,
+			r.Activity.Totals.Promote, r.Activity.Totals.Distill)
+		tw.Flush()
+	}
+	fmt.Fprintln(w)
+
+	fmt.Fprintln(w, "Promotion latency (all-time)")
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "  Transition\tCount\tp50\tp95")
+	fmt.Fprintf(tw, "  short→mid\t%d\t%s\t%s\n",
+		r.Latency.ShortToMid.Count, formatDuration(r.Latency.ShortToMid.P50), formatDuration(r.Latency.ShortToMid.P95))
+	fmt.Fprintf(tw, "  mid→long\t%d\t%s\t%s\n",
+		r.Latency.MidToLong.Count, formatDuration(r.Latency.MidToLong.P50), formatDuration(r.Latency.MidToLong.P95))
+	tw.Flush()
+	fmt.Fprintln(w)
+
+	fmt.Fprintln(w, "1-source mid leak detector")
+	fmt.Fprintf(w, "  Current:           %d trace(s)\n", r.OneSourceMid.Current)
+	status := "✓ gate is holding"
+	if r.OneSourceMid.PromotedLast7d > 0 {
+		status = "⚠ recent leak — investigate"
+	}
+	fmt.Fprintf(w, "  Promoted last 7d:  %d  %s\n", r.OneSourceMid.PromotedLast7d, status)
+}
+
+// formatDuration renders a duration in days/hours/minutes/seconds for
+// operator-friendly text output. JSON output keeps the raw nanosecond
+// integer so scripts can do whatever bucketing they want.
+func formatDuration(d time.Duration) string {
+	if d == 0 {
+		return "-"
+	}
+	if d >= 24*time.Hour {
+		return fmt.Sprintf("%.1fd", float64(d)/float64(24*time.Hour))
+	}
+	if d >= time.Hour {
+		return fmt.Sprintf("%.1fh", d.Hours())
+	}
+	if d >= time.Minute {
+		return fmt.Sprintf("%.1fm", d.Minutes())
+	}
+	return fmt.Sprintf("%.1fs", d.Seconds())
 }
 
 // memoryPromoteCmd surfaces Cortex.Promote as an operator-facing CLI

--- a/internal/cli/cmd_memory_health_test.go
+++ b/internal/cli/cmd_memory_health_test.go
@@ -1,0 +1,136 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Fail-Safe/Noema/internal/cortex"
+	"github.com/Fail-Safe/Noema/internal/trace"
+)
+
+// newCortexForHealth builds an on-disk cortex with no traces. Used by
+// the health-command tests where the cortex methods do the real work
+// and we only care that the CLI dispatch / output formatting wires
+// them up correctly.
+func newCortexForHealth(t *testing.T, name string) *cortex.Cortex {
+	t.Helper()
+	parent := t.TempDir()
+	if _, err := cortex.Create(name, parent); err != nil {
+		t.Fatalf("cortex.Create: %v", err)
+	}
+	cx, err := cortex.Open(name, filepath.Join(parent, name))
+	if err != nil {
+		t.Fatalf("cortex.Open: %v", err)
+	}
+	t.Cleanup(func() { cx.Close() })
+	return cx
+}
+
+// TestRunMemoryHealth_JSONEnvelope locks in the wire contract: a
+// single top-level schema_version per the design doc, plus the three
+// expected sections. External tooling will pin to this shape, so
+// silently dropping schema_version or renaming a section is a
+// breaking change this test should fail on.
+func TestRunMemoryHealth_JSONEnvelope(t *testing.T) {
+	cx := newCortexForHealth(t, "envtest")
+	var buf bytes.Buffer
+	if err := runMemoryHealth(&buf, cx, "24h", "json"); err != nil {
+		t.Fatalf("runMemoryHealth: %v", err)
+	}
+	var got struct {
+		SchemaVersion int             `json:"schema_version"`
+		Activity      json.RawMessage `json:"activity"`
+		Latency       json.RawMessage `json:"latency"`
+		OneSourceMid  json.RawMessage `json:"one_source_mid"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal output: %v\n%s", err, buf.String())
+	}
+	if got.SchemaVersion != 1 {
+		t.Errorf("schema_version = %d, want 1", got.SchemaVersion)
+	}
+	if len(got.Activity) == 0 {
+		t.Error("activity section missing")
+	}
+	if len(got.Latency) == 0 {
+		t.Error("latency section missing")
+	}
+	if len(got.OneSourceMid) == 0 {
+		t.Error("one_source_mid section missing")
+	}
+}
+
+// TestRunMemoryHealth_TextRendersAllSections pins that every section
+// header appears in the text output even on an empty cortex — the
+// operator should always see the layout, with "(no events)" rather
+// than a missing block when there's nothing to show.
+func TestRunMemoryHealth_TextRendersAllSections(t *testing.T) {
+	cx := newCortexForHealth(t, "texttest")
+	var buf bytes.Buffer
+	if err := runMemoryHealth(&buf, cx, "24h", "text"); err != nil {
+		t.Fatalf("runMemoryHealth: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{
+		"Consolidation activity",
+		"(no events in window)",
+		"Promotion latency",
+		"1-source mid leak detector",
+		"gate is holding",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("text output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestRunMemoryHealth_LeakSignalFlipsWhenPromoteFires is the
+// load-bearing test for the leak detector's operator-facing message.
+// A clean cortex shows "gate is holding"; the moment a 1-source
+// trace is promoted to mid, the message must flip to the warn line.
+// If the threshold check ever inverts this would silently mask leaks.
+func TestRunMemoryHealth_LeakSignalFlipsWhenPromoteFires(t *testing.T) {
+	cx := newCortexForHealth(t, "leaktest")
+
+	src := trace.New("source", "note", "", nil, "body")
+	if err := cx.Add(src); err != nil {
+		t.Fatalf("Add src: %v", err)
+	}
+	leaker := trace.New("leaker", "note", "", nil, "body")
+	leaker.DerivedFrom = []string{src.ID}
+	if err := cx.Add(leaker); err != nil {
+		t.Fatalf("Add leaker: %v", err)
+	}
+	if err := cx.Promote(leaker.ID, trace.TierMid); err != nil {
+		t.Fatalf("Promote: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := runMemoryHealth(&buf, cx, "24h", "text"); err != nil {
+		t.Fatalf("runMemoryHealth: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "recent leak") {
+		t.Errorf("expected leak warning in output, got:\n%s", out)
+	}
+	if strings.Contains(out, "gate is holding") {
+		t.Errorf("'gate is holding' shouldn't appear when PromotedLast7d > 0:\n%s", out)
+	}
+}
+
+// TestRunMemoryHealth_InvalidOutput surfaces a typo in --output as a
+// clear error rather than silently falling through to text rendering.
+func TestRunMemoryHealth_InvalidOutput(t *testing.T) {
+	cx := newCortexForHealth(t, "errtest")
+	var buf bytes.Buffer
+	err := runMemoryHealth(&buf, cx, "24h", "yaml")
+	if err == nil {
+		t.Fatal("expected error for unsupported --output, got nil")
+	}
+	if !strings.Contains(err.Error(), "yaml") {
+		t.Errorf("error should name the bad value: %v", err)
+	}
+}

--- a/internal/cortex/observability.go
+++ b/internal/cortex/observability.go
@@ -1,0 +1,370 @@
+package cortex
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Fail-Safe/Noema/internal/event"
+	"github.com/Fail-Safe/Noema/internal/trace"
+)
+
+// ParseSince parses the standard observability lookback flag. Accepts
+// any duration string time.ParseDuration handles ("90m", "24h"), plus
+// "d" (days) and "w" (weeks) which the stdlib doesn't recognise. Used
+// by every CLI / MCP surface that takes a --since argument so a user
+// who types "7d" once finds it works everywhere — the design doc's
+// "--since <dur> universally" decision (§3).
+//
+// An empty string returns zero — interpreted by callers as "no window
+// / all time."
+func ParseSince(s string) (time.Duration, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, nil
+	}
+	// Strip a trailing "d" or "w" and multiply. We don't try to be
+	// clever about combined units like "1d12h" — if a user wants that
+	// they can pass "36h", which time.ParseDuration handles natively.
+	if n := len(s); n > 0 {
+		switch s[n-1] {
+		case 'd':
+			days, err := strconv.Atoi(s[:n-1])
+			if err == nil {
+				return time.Duration(days) * 24 * time.Hour, nil
+			}
+		case 'w':
+			weeks, err := strconv.Atoi(s[:n-1])
+			if err == nil {
+				return time.Duration(weeks) * 7 * 24 * time.Hour, nil
+			}
+		}
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid duration %q: use Go duration syntax (e.g. 24h, 90m) or days/weeks (7d, 2w)", s)
+	}
+	return d, nil
+}
+
+// ConsolidationActivity reports the consolidation pipeline's recent
+// behavior — election outcomes, promotions, and real distillation events
+// — bucketed by UTC day and totaled over the window. Lets an operator
+// answer "did consolidation actually do anything overnight, and was
+// any of it the LLM path?" without hand-writing SQL against the events
+// table.
+type ConsolidationActivity struct {
+	// Since is the lookback window. JSON-skipped so the wire format
+	// can use a human-readable string in SinceLabel instead of the
+	// default time.Duration encoding (nanoseconds as int64), which
+	// would silently mislead anyone treating the field name as a
+	// hint about its unit.
+	Since      time.Duration       `json:"-"`
+	SinceLabel string              `json:"since"` // "24h0m0s" — parseable via time.ParseDuration
+	SinceStart time.Time           `json:"since_start"`
+	Daily      []ConsolidationDay  `json:"daily"`
+	Totals     ConsolidationTotals `json:"totals"`
+}
+
+// ConsolidationDay buckets one UTC date's event counts. Days with zero
+// activity are omitted to keep the JSON compact — consumers should
+// treat a missing date as "no events that day" rather than "missing
+// data."
+type ConsolidationDay struct {
+	Date    string `json:"date"` // YYYY-MM-DD (UTC)
+	Success int    `json:"success"`
+	Fail    int    `json:"fail"`
+	Claim   int    `json:"claim"`
+	Promote int    `json:"promote"`
+	Distill int    `json:"distill"`
+}
+
+// ConsolidationTotals sums each action over the entire window.
+type ConsolidationTotals struct {
+	Success int `json:"success"`
+	Fail    int `json:"fail"`
+	Claim   int `json:"claim"`
+	Promote int `json:"promote"`
+	Distill int `json:"distill"`
+}
+
+// PromotionLatency reports the distribution of time-to-promotion for
+// short→mid and mid→long transitions. Latency is computed in Go from
+// the event log rather than in SQL because mid→long requires walking
+// each trace's tier history to find the timestamp when it entered the
+// mid tier (a previous promote event, or created_at if it was born
+// there).
+type PromotionLatency struct {
+	ShortToMid PromotionStats `json:"short_to_mid"`
+	MidToLong  PromotionStats `json:"mid_to_long"`
+}
+
+// PromotionStats is the per-transition rollup. Durations serialize as
+// nanoseconds (Go's time.Duration default); the CLI text renderer
+// formats them as human-readable spans for terminal output.
+type PromotionStats struct {
+	Count int `json:"count"`
+	// Duration fields skip JSON serialization (would emit raw
+	// nanoseconds); the *Label sibling carries the same value as a
+	// parseable string ("129h36m12s"). Callers doing math use the
+	// time.Duration; JSON consumers parse the string with
+	// time.ParseDuration.
+	P50      time.Duration `json:"-"`
+	P50Label string        `json:"p50"`
+	P95      time.Duration `json:"-"`
+	P95Label string        `json:"p95"`
+}
+
+// OneSourceMidCount is the leak detector for the 1-source mid bucket.
+// PRs #86 and #90 closed two distinct paths that were promoting
+// single-derived-from traces past the heuristic; this surface lets us
+// see at a glance whether either gate ever leaks again. Current is
+// the live count; PromotedLast7d is the count of distinct traces that
+// landed in the mid tier with derived_from_count=1 within the last 7
+// days (the operationally useful signal — Current can grow only via
+// recent promotions, so a healthy gate keeps PromotedLast7d at zero).
+type OneSourceMidCount struct {
+	Current        int `json:"current"`
+	PromotedLast7d int `json:"promoted_last_7d"`
+}
+
+// ConsolidationActivity queries the events table for the consolidation
+// pipeline's recent actions, bucketed by UTC day. since is the
+// look-back window; a zero or negative duration is treated as "since
+// the beginning of the event log." Active traces only — purged
+// tombstones and archived rows are unaffected because their promote
+// events remain in the log as part of the immutable audit trail.
+func (c *Cortex) ConsolidationActivity(since time.Duration) (ConsolidationActivity, error) {
+	out := ConsolidationActivity{Since: since, SinceLabel: since.String(), Daily: []ConsolidationDay{}}
+
+	var args []any
+	where := `WHERE action IN (?, ?, ?, ?, ?)`
+	args = append(args,
+		string(event.ActionConsolidationSuccess),
+		string(event.ActionConsolidationFail),
+		string(event.ActionConsolidationClaim),
+		string(event.ActionPromote),
+		string(event.ActionConsolidate),
+	)
+	if since > 0 {
+		cutoff := time.Now().UTC().Add(-since)
+		out.SinceStart = cutoff
+		where += ` AND timestamp >= ?`
+		args = append(args, cutoff.Format(time.RFC3339))
+	}
+
+	q := `
+		SELECT substr(timestamp, 1, 10) AS date, action, COUNT(*)
+		FROM events ` + where + `
+		GROUP BY date, action
+		ORDER BY date`
+	rows, err := c.DB.Query(q, args...)
+	if err != nil {
+		return out, err
+	}
+	defer rows.Close()
+
+	byDate := map[string]*ConsolidationDay{}
+	for rows.Next() {
+		var date, action string
+		var n int
+		if err := rows.Scan(&date, &action, &n); err != nil {
+			return out, err
+		}
+		d, ok := byDate[date]
+		if !ok {
+			d = &ConsolidationDay{Date: date}
+			byDate[date] = d
+		}
+		switch event.Action(action) {
+		case event.ActionConsolidationSuccess:
+			d.Success += n
+			out.Totals.Success += n
+		case event.ActionConsolidationFail:
+			d.Fail += n
+			out.Totals.Fail += n
+		case event.ActionConsolidationClaim:
+			d.Claim += n
+			out.Totals.Claim += n
+		case event.ActionPromote:
+			d.Promote += n
+			out.Totals.Promote += n
+		case event.ActionConsolidate:
+			d.Distill += n
+			out.Totals.Distill += n
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return out, err
+	}
+
+	dates := make([]string, 0, len(byDate))
+	for d := range byDate {
+		dates = append(dates, d)
+	}
+	sort.Strings(dates)
+	for _, d := range dates {
+		out.Daily = append(out.Daily, *byDate[d])
+	}
+	return out, nil
+}
+
+// PromotionLatency walks every promote event in the log and computes
+// the elapsed time since the trace entered the prior tier. short→mid
+// uses traces.created_at as the start (the vast majority of traces
+// are born at short). mid→long uses the most recent promote-to-mid
+// event for that trace, falling back to created_at for traces created
+// directly at mid (manual promotion). The result is sorted in Go to
+// derive p50/p95.
+func (c *Cortex) PromotionLatency() (PromotionLatency, error) {
+	var out PromotionLatency
+
+	q := `
+		SELECT
+			e.trace_id,
+			e.timestamp,
+			COALESCE(json_extract(e.data, '$.from'), '') AS from_tier,
+			COALESCE(json_extract(e.data, '$.to'), '')   AS to_tier,
+			t.created_at
+		FROM events e
+		JOIN traces t ON t.id = e.trace_id
+		WHERE e.action = ?
+		ORDER BY e.trace_id, e.timestamp`
+	rows, err := c.DB.Query(q, string(event.ActionPromote))
+	if err != nil {
+		return out, err
+	}
+	defer rows.Close()
+
+	type promote struct {
+		ts            time.Time
+		from, to      string
+		traceCreated  time.Time
+	}
+	byTrace := map[string][]promote{}
+	for rows.Next() {
+		var id, tsStr, from, to, createdStr string
+		if err := rows.Scan(&id, &tsStr, &from, &to, &createdStr); err != nil {
+			return out, err
+		}
+		ts, err := time.Parse(time.RFC3339, tsStr)
+		if err != nil {
+			continue
+		}
+		created, err := time.Parse(time.RFC3339, createdStr)
+		if err != nil {
+			continue
+		}
+		byTrace[id] = append(byTrace[id], promote{ts: ts, from: from, to: to, traceCreated: created})
+	}
+	if err := rows.Err(); err != nil {
+		return out, err
+	}
+
+	var shortToMid, midToLong []time.Duration
+	for _, events := range byTrace {
+		// In-order already (SQL ORDER BY trace_id, timestamp). Walk each
+		// trace's promotes, tracking the timestamp at which it entered
+		// the mid tier so we can measure mid→long against that.
+		midEntry := time.Time{}
+		for _, p := range events {
+			if p.to == trace.TierMid && p.from == trace.TierShort {
+				shortToMid = append(shortToMid, p.ts.Sub(p.traceCreated))
+				midEntry = p.ts
+			}
+			if p.to == trace.TierLong && p.from == trace.TierMid {
+				start := midEntry
+				if start.IsZero() {
+					// Trace was created at mid (no prior promote event);
+					// best available start is created_at.
+					start = p.traceCreated
+				}
+				midToLong = append(midToLong, p.ts.Sub(start))
+			}
+		}
+	}
+
+	out.ShortToMid = summarize(shortToMid)
+	out.MidToLong = summarize(midToLong)
+	return out, nil
+}
+
+// summarize computes count + p50 + p95 from an unsorted slice of
+// durations. Empty input returns the zero struct. Percentile uses the
+// nearest-rank method (ceil(p × N)) since linear interpolation buys
+// nothing on operator-facing latency reports and complicates tests.
+func summarize(ds []time.Duration) PromotionStats {
+	if len(ds) == 0 {
+		return PromotionStats{}
+	}
+	sort.Slice(ds, func(i, j int) bool { return ds[i] < ds[j] })
+	pick := func(p float64) time.Duration {
+		idx := int(float64(len(ds))*p + 0.999999) - 1
+		if idx < 0 {
+			idx = 0
+		}
+		if idx >= len(ds) {
+			idx = len(ds) - 1
+		}
+		return ds[idx]
+	}
+	p50 := pick(0.50)
+	p95 := pick(0.95)
+	return PromotionStats{
+		Count:    len(ds),
+		P50:      p50,
+		P50Label: p50.String(),
+		P95:      p95,
+		P95Label: p95.String(),
+	}
+}
+
+// OneSourceMidCount returns the current count of active mid-tier
+// traces with derived_from_count == 1 (the bucket PR #86 narrowed but
+// can't fully eliminate) and the count of distinct traces promoted
+// into that bucket within the last 7 days. A healthy gate keeps
+// PromotedLast7d at zero; a non-zero value names the operationally
+// useful signal "the 1-source leak path is open again, go investigate."
+func (c *Cortex) OneSourceMidCount() (OneSourceMidCount, error) {
+	var out OneSourceMidCount
+
+	q1 := `
+		SELECT COUNT(*)
+		FROM traces t
+		JOIN (
+			SELECT trace_id, COUNT(*) AS n
+			FROM trace_lineage
+			GROUP BY trace_id
+		) l ON l.trace_id = t.id
+		WHERE t.tier = ?
+		  AND t.archived_at IS NULL
+		  AND t.trashed_at IS NULL
+		  AND t.purged_at IS NULL
+		  AND l.n = 1`
+	if err := c.DB.QueryRow(q1, trace.TierMid).Scan(&out.Current); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return out, fmt.Errorf("current count: %w", err)
+	}
+
+	cutoff := time.Now().UTC().Add(-7 * 24 * time.Hour).Format(time.RFC3339)
+	q2 := `
+		SELECT COUNT(DISTINCT e.trace_id)
+		FROM events e
+		JOIN (
+			SELECT trace_id, COUNT(*) AS n
+			FROM trace_lineage
+			GROUP BY trace_id
+		) l ON l.trace_id = e.trace_id
+		WHERE e.action = ?
+		  AND COALESCE(json_extract(e.data, '$.to'), '') = ?
+		  AND e.timestamp >= ?
+		  AND l.n = 1`
+	if err := c.DB.QueryRow(q2, string(event.ActionPromote), trace.TierMid, cutoff).Scan(&out.PromotedLast7d); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return out, fmt.Errorf("recent promotes: %w", err)
+	}
+
+	return out, nil
+}

--- a/internal/cortex/observability_test.go
+++ b/internal/cortex/observability_test.go
@@ -1,0 +1,347 @@
+package cortex_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Fail-Safe/Noema/internal/cortex"
+	"github.com/Fail-Safe/Noema/internal/event"
+	"github.com/Fail-Safe/Noema/internal/trace"
+)
+
+// insertRawEvent writes an event row directly so tests can backdate
+// timestamps and exercise the time-window filters. Uses the same
+// columns the production emitter writes via internal/cortex/cortex.go
+// emitEvent (id, action, trace_id, origin, timestamp, data, vclock,
+// cortex_id). Production callers go through emitEvent inside a
+// transaction; tests are the only legitimate direct-insert path.
+func insertRawEvent(t *testing.T, cx *cortex.Cortex, action event.Action, traceID string, ts time.Time, data map[string]any) {
+	t.Helper()
+	payload := []byte("{}")
+	if data != nil {
+		b, err := json.Marshal(data)
+		if err != nil {
+			t.Fatalf("marshal event data: %v", err)
+		}
+		payload = b
+	}
+	// Synthesize a unique id so we can insert many events in one test.
+	id := fmt.Sprintf("test-%d-%s-%s", ts.UnixNano(), action, traceID)
+	_, err := cx.DB.Exec(
+		`INSERT INTO events (id, action, trace_id, origin, timestamp, data, vclock, cortex_id)
+		 VALUES (?, ?, ?, ?, ?, ?, '{}', ?)`,
+		id, string(action), traceID, cx.Name, ts.UTC().Format(time.RFC3339), string(payload), cx.ID,
+	)
+	if err != nil {
+		t.Fatalf("insert raw event: %v", err)
+	}
+}
+
+// TestParseSince pins the duration syntax accepted by every --since
+// surface. Go's time.ParseDuration handles "24h" / "90m" natively;
+// the "d" (days) and "w" (weeks) suffixes are added by ParseSince so
+// operators don't have to compute hours for week-scale lookbacks.
+func TestParseSince(t *testing.T) {
+	cases := []struct {
+		in   string
+		want time.Duration
+		err  bool
+	}{
+		{"", 0, false},
+		{"24h", 24 * time.Hour, false},
+		{"90m", 90 * time.Minute, false},
+		{"7d", 7 * 24 * time.Hour, false},
+		{"2w", 2 * 7 * 24 * time.Hour, false},
+		{"1d", 24 * time.Hour, false},
+		{"garbage", 0, true},
+		{"5x", 0, true},
+	}
+	for _, tc := range cases {
+		got, err := cortex.ParseSince(tc.in)
+		if tc.err && err == nil {
+			t.Errorf("ParseSince(%q): want error, got %v", tc.in, got)
+			continue
+		}
+		if !tc.err && err != nil {
+			t.Errorf("ParseSince(%q): unexpected error %v", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("ParseSince(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestConsolidationActivity_EmptyLog(t *testing.T) {
+	cx := setup(t)
+	got, err := cx.ConsolidationActivity(0)
+	if err != nil {
+		t.Fatalf("ConsolidationActivity: %v", err)
+	}
+	if len(got.Daily) != 0 {
+		t.Errorf("Daily = %v, want empty", got.Daily)
+	}
+	if (got.Totals != cortex.ConsolidationTotals{}) {
+		t.Errorf("Totals = %+v, want zero", got.Totals)
+	}
+}
+
+// TestConsolidationActivity_BucketsAndTotals pins that the day-bucket
+// keying is UTC-date (substr of RFC3339 timestamp) and that every
+// observed action increments both its day bucket and the rollup total.
+// Inserts a mix of action types across two days so a regression that
+// swaps action keys or off-by-ones a date boundary is visible.
+func TestConsolidationActivity_BucketsAndTotals(t *testing.T) {
+	cx := setup(t)
+	tr := trace.New("seed", "note", "", nil, "body")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	day1 := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	day2 := time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC)
+	insertRawEvent(t, cx, event.ActionConsolidationClaim, tr.ID, day1, nil)
+	insertRawEvent(t, cx, event.ActionConsolidationSuccess, tr.ID, day1, nil)
+	insertRawEvent(t, cx, event.ActionConsolidationSuccess, tr.ID, day2, nil)
+	insertRawEvent(t, cx, event.ActionConsolidationFail, tr.ID, day2, nil)
+	insertRawEvent(t, cx, event.ActionPromote, tr.ID, day2, map[string]any{"from": "short", "to": "mid"})
+	insertRawEvent(t, cx, event.ActionConsolidate, tr.ID, day2, nil)
+
+	got, err := cx.ConsolidationActivity(0)
+	if err != nil {
+		t.Fatalf("ConsolidationActivity: %v", err)
+	}
+	if len(got.Daily) != 2 {
+		t.Fatalf("Daily entries = %d, want 2: %+v", len(got.Daily), got.Daily)
+	}
+	if got.Daily[0].Date != "2026-05-01" || got.Daily[0].Claim != 1 || got.Daily[0].Success != 1 {
+		t.Errorf("Day 1 = %+v, want date=2026-05-01 claim=1 success=1", got.Daily[0])
+	}
+	if got.Daily[1].Date != "2026-05-02" || got.Daily[1].Success != 1 || got.Daily[1].Fail != 1 || got.Daily[1].Promote != 1 || got.Daily[1].Distill != 1 {
+		t.Errorf("Day 2 = %+v, want date=2026-05-02 success=1 fail=1 promote=1 distill=1", got.Daily[1])
+	}
+	want := cortex.ConsolidationTotals{Success: 2, Fail: 1, Claim: 1, Promote: 1, Distill: 1}
+	if got.Totals != want {
+		t.Errorf("Totals = %+v, want %+v", got.Totals, want)
+	}
+}
+
+// TestConsolidationActivity_SinceFilter pins that the time window
+// drops events older than the cutoff. Without this filter the
+// `noema memory health --since 24h` command would always show
+// all-time totals, defeating the point.
+func TestConsolidationActivity_SinceFilter(t *testing.T) {
+	cx := setup(t)
+	tr := trace.New("seed", "note", "", nil, "body")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	old := time.Now().UTC().Add(-72 * time.Hour)
+	recent := time.Now().UTC().Add(-1 * time.Hour)
+	insertRawEvent(t, cx, event.ActionConsolidationSuccess, tr.ID, old, nil)
+	insertRawEvent(t, cx, event.ActionConsolidationSuccess, tr.ID, recent, nil)
+
+	got, err := cx.ConsolidationActivity(24 * time.Hour)
+	if err != nil {
+		t.Fatalf("ConsolidationActivity: %v", err)
+	}
+	if got.Totals.Success != 1 {
+		t.Errorf("Totals.Success = %d, want 1 (since-window should drop the 72h-old event)", got.Totals.Success)
+	}
+}
+
+func TestPromotionLatency_EmptyLog(t *testing.T) {
+	cx := setup(t)
+	got, err := cx.PromotionLatency()
+	if err != nil {
+		t.Fatalf("PromotionLatency: %v", err)
+	}
+	if got.ShortToMid.Count != 0 || got.MidToLong.Count != 0 {
+		t.Errorf("expected zero counts, got %+v", got)
+	}
+}
+
+// TestPromotionLatency_ShortToMid_FromCreated pins that short→mid
+// measures elapsed time from the trace's created_at to the first
+// short→mid promote event. Uses a real Promote call so the event
+// payload (`from`/`to` fields) matches what production emits — a
+// regression that drops those JSON fields would silently break the
+// latency calculation here.
+func TestPromotionLatency_ShortToMid_FromCreated(t *testing.T) {
+	cx := setup(t)
+	tr := trace.New("subject", "note", "", nil, "body")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := cx.Promote(tr.ID, trace.TierMid); err != nil {
+		t.Fatalf("Promote: %v", err)
+	}
+	got, err := cx.PromotionLatency()
+	if err != nil {
+		t.Fatalf("PromotionLatency: %v", err)
+	}
+	if got.ShortToMid.Count != 1 {
+		t.Errorf("ShortToMid.Count = %d, want 1", got.ShortToMid.Count)
+	}
+	if got.ShortToMid.P50 < 0 {
+		t.Errorf("ShortToMid.P50 = %v, want >= 0", got.ShortToMid.P50)
+	}
+}
+
+// TestPromotionLatency_MidToLong_UsesMidEntry is the load-bearing test
+// for the two-stage promotion case. A trace created at short, promoted
+// to mid 10 days later, then promoted to long 5 days after that should
+// report mid→long latency as 5 days, not 15. If the code mistakenly
+// used created_at as the start for the mid→long bucket, this test
+// would catch it.
+func TestPromotionLatency_MidToLong_UsesMidEntry(t *testing.T) {
+	cx := setup(t)
+	tr := trace.New("two-stage", "note", "", nil, "body")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	// Backdate created_at so the elapsed deltas are meaningful.
+	created := time.Now().UTC().Add(-20 * 24 * time.Hour)
+	if _, err := cx.DB.Exec(`UPDATE traces SET created_at = ? WHERE id = ?`, created.Format(time.RFC3339), tr.ID); err != nil {
+		t.Fatalf("backdate created_at: %v", err)
+	}
+	midEntry := created.Add(10 * 24 * time.Hour)
+	longEntry := midEntry.Add(5 * 24 * time.Hour)
+	insertRawEvent(t, cx, event.ActionPromote, tr.ID, midEntry, map[string]any{"from": "short", "to": "mid"})
+	insertRawEvent(t, cx, event.ActionPromote, tr.ID, longEntry, map[string]any{"from": "mid", "to": "long"})
+
+	got, err := cx.PromotionLatency()
+	if err != nil {
+		t.Fatalf("PromotionLatency: %v", err)
+	}
+	if got.MidToLong.Count != 1 {
+		t.Fatalf("MidToLong.Count = %d, want 1", got.MidToLong.Count)
+	}
+	wantApprox := 5 * 24 * time.Hour
+	diff := got.MidToLong.P50 - wantApprox
+	if diff < -time.Hour || diff > time.Hour {
+		t.Errorf("MidToLong.P50 = %v, want ~%v (mid→long should measure from mid entry, not created_at)", got.MidToLong.P50, wantApprox)
+	}
+}
+
+func TestOneSourceMidCount_Empty(t *testing.T) {
+	cx := setup(t)
+	got, err := cx.OneSourceMidCount()
+	if err != nil {
+		t.Fatalf("OneSourceMidCount: %v", err)
+	}
+	if got.Current != 0 || got.PromotedLast7d != 0 {
+		t.Errorf("expected zero, got %+v", got)
+	}
+}
+
+// TestOneSourceMidCount_CountsActive1Source pins that the current
+// count includes only ACTIVE mid traces with exactly one derived_from
+// — archived/trashed are excluded (matches the engagement-stats
+// convention) and traces with 0 or 2+ sources don't count.
+func TestOneSourceMidCount_CountsActive1Source(t *testing.T) {
+	cx := setup(t)
+	src := trace.New("source", "note", "", nil, "body")
+	if err := cx.Add(src); err != nil {
+		t.Fatalf("Add src: %v", err)
+	}
+	// 1-source mid (counts).
+	single := trace.New("single", "note", "", nil, "body")
+	single.Tier = trace.TierMid
+	single.DerivedFrom = []string{src.ID}
+	if err := cx.Add(single); err != nil {
+		t.Fatalf("Add single: %v", err)
+	}
+	// 0-source mid (doesn't count).
+	zero := trace.New("zero", "note", "", nil, "body")
+	zero.Tier = trace.TierMid
+	if err := cx.Add(zero); err != nil {
+		t.Fatalf("Add zero: %v", err)
+	}
+	// Archived 1-source mid (doesn't count).
+	src2 := trace.New("source2", "note", "", nil, "body")
+	if err := cx.Add(src2); err != nil {
+		t.Fatalf("Add src2: %v", err)
+	}
+	hidden := trace.New("hidden", "note", "", nil, "body")
+	hidden.Tier = trace.TierMid
+	hidden.DerivedFrom = []string{src2.ID}
+	if err := cx.Add(hidden); err != nil {
+		t.Fatalf("Add hidden: %v", err)
+	}
+	if err := cx.Archive(hidden.ID); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+
+	got, err := cx.OneSourceMidCount()
+	if err != nil {
+		t.Fatalf("OneSourceMidCount: %v", err)
+	}
+	if got.Current != 1 {
+		t.Errorf("Current = %d, want 1 (only the active 1-source mid)", got.Current)
+	}
+}
+
+// TestOneSourceMidCount_PromotedLast7d pins the leak-detection
+// signal — a 1-source trace promoted to mid within the last 7 days
+// should appear in PromotedLast7d. This is the metric that should be
+// zero if PRs #86 and #90's gates are holding.
+func TestOneSourceMidCount_PromotedLast7d(t *testing.T) {
+	cx := setup(t)
+	src := trace.New("source", "note", "", nil, "body")
+	if err := cx.Add(src); err != nil {
+		t.Fatalf("Add src: %v", err)
+	}
+	leaker := trace.New("leaker", "note", "", nil, "body")
+	leaker.DerivedFrom = []string{src.ID}
+	if err := cx.Add(leaker); err != nil {
+		t.Fatalf("Add leaker: %v", err)
+	}
+	// Use a real Promote so the event payload shape matches production.
+	if err := cx.Promote(leaker.ID, trace.TierMid); err != nil {
+		t.Fatalf("Promote: %v", err)
+	}
+
+	got, err := cx.OneSourceMidCount()
+	if err != nil {
+		t.Fatalf("OneSourceMidCount: %v", err)
+	}
+	if got.PromotedLast7d != 1 {
+		t.Errorf("PromotedLast7d = %d, want 1", got.PromotedLast7d)
+	}
+	if got.Current != 1 {
+		t.Errorf("Current = %d, want 1", got.Current)
+	}
+}
+
+// TestOneSourceMidCount_OldPromoteExcluded pins that promotes older
+// than the 7-day window don't inflate PromotedLast7d — otherwise the
+// leak signal stays "on" forever once it fires once.
+func TestOneSourceMidCount_OldPromoteExcluded(t *testing.T) {
+	cx := setup(t)
+	src := trace.New("source", "note", "", nil, "body")
+	if err := cx.Add(src); err != nil {
+		t.Fatalf("Add src: %v", err)
+	}
+	old := trace.New("old", "note", "", nil, "body")
+	old.Tier = trace.TierMid
+	old.DerivedFrom = []string{src.ID}
+	if err := cx.Add(old); err != nil {
+		t.Fatalf("Add old: %v", err)
+	}
+	insertRawEvent(t, cx, event.ActionPromote, old.ID,
+		time.Now().UTC().Add(-30*24*time.Hour),
+		map[string]any{"from": "short", "to": "mid"})
+
+	got, err := cx.OneSourceMidCount()
+	if err != nil {
+		t.Fatalf("OneSourceMidCount: %v", err)
+	}
+	if got.PromotedLast7d != 0 {
+		t.Errorf("PromotedLast7d = %d, want 0 (30d-old promote should be outside the 7d window)", got.PromotedLast7d)
+	}
+	if got.Current != 1 {
+		t.Errorf("Current = %d, want 1", got.Current)
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -419,6 +419,41 @@ func NewServer(cx *cortex.Cortex, noemaVersion string, federationMode string) *s
 		return mcp.NewToolResultText(string(buf)), nil
 	})
 
+	s.AddTool(mcp.NewTool("consolidation_health",
+		mcp.WithDescription("Recent consolidation pipeline health: daily success/fail/promote/distill counts within the lookback window, short→mid and mid→long promotion-latency percentiles, and the 1-source mid leak detector. Lets an agent or operator answer 'is consolidation actually happening, and is anything leaking?' without raw SQL against the events table."),
+		mcp.WithString("since", mcp.Description("Lookback window for the activity buckets, e.g. \"24h\", \"7d\". Default 24h. Latency percentiles and the leak detector ignore this — they are all-time / fixed-window respectively.")),
+	), func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		since, err := cortex.ParseSince(req.GetString("since", "24h"))
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		activity, err := cx.ConsolidationActivity(since)
+		if err != nil {
+			return nil, fmt.Errorf("consolidation activity: %w", err)
+		}
+		latency, err := cx.PromotionLatency()
+		if err != nil {
+			return nil, fmt.Errorf("promotion latency: %w", err)
+		}
+		leak, err := cx.OneSourceMidCount()
+		if err != nil {
+			return nil, fmt.Errorf("one-source mid count: %w", err)
+		}
+		out := struct {
+			SchemaVersion int                          `json:"schema_version"`
+			Activity      cortex.ConsolidationActivity `json:"activity"`
+			Latency       cortex.PromotionLatency      `json:"latency"`
+			OneSourceMid  cortex.OneSourceMidCount     `json:"one_source_mid"`
+		}{
+			SchemaVersion: 1,
+			Activity:      activity,
+			Latency:       latency,
+			OneSourceMid:  leak,
+		}
+		buf, _ := json.MarshalIndent(out, "", "  ")
+		return mcp.NewToolResultText(string(buf)), nil
+	})
+
 	s.AddTool(mcp.NewTool("record_consolidation_result",
 		mcp.WithDescription("Internal tool. Materialises a distilled mid-tier trace from a set of short-term sources. Validates the source IDs exist (>=2 required), creates the new trace with derived_from lineage pointing at the sources, and emits an ActionConsolidate event carrying model/profile/confidence telemetry for the quality dashboard."),
 		mcp.WithString("title", mcp.Description("Title for the distilled trace"), mcp.Required()),
@@ -937,6 +972,12 @@ Choose the type that best reflects the intent of the memory:
   cortex_identity                → return this cortex's stable ULID + name +
                                    manifest version (used by federation peers
                                    to verify identity on every sync)
+  consolidation_health [since]   → daily consolidation activity (success/fail/
+                                   promote/distill) over the window, plus
+                                   short→mid and mid→long latency percentiles
+                                   and the 1-source mid leak detector. since
+                                   accepts Go duration syntax plus d/w (e.g.
+                                   24h, 7d). Defaults to 24h.
   sync_events [since] [limit]    → pull events for federation (JSON array)
   federation_status              → MCP access posture, federation config,
                                    peer states, vector clock


### PR DESCRIPTION
## Summary

- First observability v1 deliverable per the brainstorm doc Noema-design/docs/plans/observability-plan.md.
- "How did consolidation fare overnight, and is anything leaking?" becomes a single CLI command and a single MCP tool, both backed by the same three cortex methods.

## What's new

**Cortex methods** (new `internal/cortex/observability.go`):

- `ConsolidationActivity(since)` — daily success/fail/claim/promote/distill counts within the lookback window, plus rolled-up totals.
- `PromotionLatency()` — all-time p50/p95 of short→mid and mid→long transitions. mid→long measures from the trace's mid-entry timestamp (most recent `promote-to-mid` event), not `created_at` — a trace can sit short for months and then graduate fast.
- `OneSourceMidCount()` — current count of active mid-tier traces with `derived_from_count == 1` (the bucket PRs #86 and #90 closed) plus the count of distinct traces that landed in that bucket within the last 7 days. A healthy gate keeps the recent count at zero; a non-zero value names the leak.

**Shared utility**: `cortex.ParseSince()` so every `--since` flag accepts the same syntax: Go duration (`90m`, `24h`) plus `d` (days) and `w` (weeks) which the stdlib doesn't recognize.

**Surfaces**:

- `noema memory health [--since 24h] [--output json|text]` — new CLI subcommand.
- `consolidation_health [since]` — new MCP tool.

Both return the same JSON envelope with a single top-level `schema_version` field per the design doc's "JSON-first, single top-level version" principle. Durations are emitted as `time.Duration.String()` output (`"129h36m"`) so consumers can round-trip via `time.ParseDuration` without guessing units.

**Docs**:

- README adds an enumerated `noema memory ...` block; previously only `purge`/`promote`/`demote` were referenced in prose, none in the command listing.
- `get_instructions` documents the new MCP tool.

## Smoke test against agentbrain

```
Consolidation activity — last 24h
  Date        Claim  Success  Fail  Promote  Distill
  2026-05-10  4      4        0     0        1
  Total       4      4        0     0        1

Promotion latency (all-time)
  Transition  Count  p50    p95
  short→mid   370    5.4d   14.0d
  mid→long    3      12.5d  12.5d

1-source mid leak detector
  Current:           71 trace(s)
  Promoted last 7d:  14  ⚠ recent leak — investigate
```

The "recent leak" signal surfaced 14 distinct 1-source promotes, all from 2026-05-04 through 2026-05-07 — the pre-#90 era. PR #90 merged 2026-05-09 and the gate has held since (zero promotes on 5/8, 5/9, 5/10). The 7-day window will naturally self-clear around 2026-05-14. Working as designed.

## Test plan

- [x] 11 new tests in `internal/cortex/observability_test.go` covering empty-state, day-bucket keying, since-window filter, short→mid latency, mid→long-uses-mid-entry (the load-bearing case), 1-source counting / promote detection / old-event exclusion, and `ParseSince` syntax (incl. `d` / `w` extensions and invalid input)
- [x] 4 new tests in `internal/cli/cmd_memory_health_test.go` covering the JSON envelope shape (locks the wire contract), text rendering of all sections, leak-warning flip behavior, and invalid `--output` error path
- [x] `go build ./...` clean
- [x] `go test ./...` clean (full suite)
- [x] `go vet ./...` clean
- [x] Live smoke test against agentbrain — CLI text + JSON + `--help` all read correctly

## Follow-ups

PRs 2-4 of this series follow the same shape:

- **PR 2** — engagement surface (`TopSearchedTraces` + `TagActivity`, `search_activity` MCP, `noema memory popular` CLI)
- **PR 3** — federation peer health (`PeerLag` + `DivergenceActivity`, extends `federation_status` MCP, `noema federation lag` CLI)
- **PR 4** — TUI dashboard view (`M` key, parallel to `?:help`, surfaces PR 1–3 metrics inline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
