### PR TITLE
feat(memory): engagement surface — popular traces + tag activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ noema verify drift                        Check federated traces for drift from 
 noema memory stats [--detailed]           Show tier counts and (with --detailed) engagement signal
 noema memory health [--since 24h]         Show consolidation activity over the window, promotion-latency
                                           percentiles, and the 1-source mid leak detector
+noema memory popular [--top 10]           Top traces by search popularity and top tags by aggregate engagement
 noema memory promote <id> [--to mid|long] Advance a trace one tier (short→mid or mid→long)
 noema memory demote <id>                  Step a mid trace back to short
 noema memory purge <id> --tier <t> --reason "..." --confirm [--hard]

--- a/internal/cli/cmd_memory.go
+++ b/internal/cli/cmd_memory.go
@@ -36,11 +36,123 @@ is distributed across the cortex without opening the DB.`,
 		memoryPurgeCmd(),
 		memoryStatsCmd(),
 		memoryHealthCmd(),
+		memoryPopularCmd(),
 		memoryPromoteCmd(),
 		memoryDemoteCmd(),
 	)
 	return cmd
 }
+
+// memoryPopularReport is the JSON envelope shared between the CLI
+// (`noema memory popular --output json`) and the MCP tool
+// `search_activity`. Same schema_version namespace as memoryHealthReport
+// — separate report types intentionally so consumers can pin to one
+// without coupling to the other.
+type memoryPopularReport struct {
+	SchemaVersion int                   `json:"schema_version"`
+	Top           int                   `json:"top"`
+	Traces        []cortex.PopularTrace `json:"traces"`
+	Tags          []cortex.TagSummary   `json:"tags"`
+}
+
+func memoryPopularCmd() *cobra.Command {
+	var (
+		topFlag    int
+		outputFlag string
+	)
+	cmd := &cobra.Command{
+		Use:   "popular",
+		Short: "Top traces by search popularity and top tags by aggregate engagement",
+		Long: `Reports two leaderboards over the cortex's federation-wide engagement
+counters:
+
+  - Top-N traces by search_hit_count (primary) and read_count
+    (tiebreaker). search_hit_count is the auto-injection-friendly
+    signal — Hermes-style providers that fold search results into a
+    context window without ever calling get_trace bump this counter
+    but not read_count, so it's the better "what's worth surfacing"
+    proxy than reads alone.
+
+  - Top-N tags by aggregate search hits / reads / modifies across
+    every active trace carrying the tag. A trace with multiple tags
+    contributes its engagement to each tag, so two columns are
+    directly comparable.
+
+Cumulative all-time counters — no --since flag. The trace_usage rows
+don't carry timestamps so a window filter would need a different
+table (per-day usage snapshots), which is deferred to a future
+iteration.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cx, err := resolveCortex()
+			if err != nil {
+				return err
+			}
+			defer cx.Close()
+			return runMemoryPopular(cmd.OutOrStdout(), cx, topFlag, outputFlag)
+		},
+	}
+	cmd.Flags().IntVar(&topFlag, "top", 10, "how many top traces and top tags to return")
+	cmd.Flags().StringVar(&outputFlag, "output", "text", "output format: text, json")
+	return cmd
+}
+
+func runMemoryPopular(w io.Writer, cx *cortex.Cortex, top int, output string) error {
+	if top <= 0 {
+		top = 10
+	}
+	traces, err := cx.TopSearchedTraces(top)
+	if err != nil {
+		return fmt.Errorf("top searched traces: %w", err)
+	}
+	tags, err := cx.TagActivity(top)
+	if err != nil {
+		return fmt.Errorf("tag activity: %w", err)
+	}
+	report := memoryPopularReport{
+		SchemaVersion: 1,
+		Top:           top,
+		Traces:        traces,
+		Tags:          tags,
+	}
+	switch output {
+	case "json":
+		buf, _ := json.MarshalIndent(report, "", "  ")
+		fmt.Fprintln(w, string(buf))
+	case "text", "":
+		renderMemoryPopularText(w, report)
+	default:
+		return fmt.Errorf("unsupported --output %q (try: text, json)", output)
+	}
+	return nil
+}
+
+func renderMemoryPopularText(w io.Writer, r memoryPopularReport) {
+	fmt.Fprintf(w, "Top %d traces by search popularity\n", r.Top)
+	if len(r.Traces) == 0 {
+		fmt.Fprintln(w, "  (no traces with engagement yet)")
+	} else {
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "  Hits\tReads\tTier\tType\tTitle")
+		for _, p := range r.Traces {
+			fmt.Fprintf(tw, "  %d\t%d\t%s\t%s\t%s\n", p.SearchHits, p.ReadCount, p.Tier, p.Type, truncate(p.Title, 60))
+		}
+		tw.Flush()
+	}
+	fmt.Fprintln(w)
+
+	fmt.Fprintf(w, "Top %d tags by aggregate engagement\n", r.Top)
+	if len(r.Tags) == 0 {
+		fmt.Fprintln(w, "  (no tagged traces with engagement yet)")
+		return
+	}
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "  Tag\tTraces\tHits\tReads\tModifies")
+	for _, t := range r.Tags {
+		fmt.Fprintf(tw, "  %s\t%d\t%d\t%d\t%d\n", t.Tag, t.TraceCount, t.SearchHits, t.ReadCount, t.ModifyCount)
+	}
+	tw.Flush()
+}
+
 
 // memoryHealthReport wraps the three cortex methods that answer "is
 // consolidation actually doing anything, and is anything leaking?"

--- a/internal/cli/cmd_memory_popular_test.go
+++ b/internal/cli/cmd_memory_popular_test.go
@@ -1,0 +1,99 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Fail-Safe/Noema/internal/cortex"
+	"github.com/Fail-Safe/Noema/internal/trace"
+)
+
+func TestRunMemoryPopular_JSONEnvelope(t *testing.T) {
+	cx := newCortexForHealth(t, "poptest")
+	var buf bytes.Buffer
+	if err := runMemoryPopular(&buf, cx, 10, "json"); err != nil {
+		t.Fatalf("runMemoryPopular: %v", err)
+	}
+	var got struct {
+		SchemaVersion int             `json:"schema_version"`
+		Top           int             `json:"top"`
+		Traces        json.RawMessage `json:"traces"`
+		Tags          json.RawMessage `json:"tags"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, buf.String())
+	}
+	if got.SchemaVersion != 1 {
+		t.Errorf("schema_version = %d, want 1", got.SchemaVersion)
+	}
+	if got.Top != 10 {
+		t.Errorf("top = %d, want 10", got.Top)
+	}
+}
+
+// TestRunMemoryPopular_RenderShowsRealData seeds a tagged trace,
+// generates a search hit, and asserts the trace title and tag both
+// appear in the text output. Locks the CLI rendering against drift
+// from the underlying cortex method's column order.
+func TestRunMemoryPopular_RenderShowsRealData(t *testing.T) {
+	cx := newCortexForHealth(t, "popdata")
+
+	tr := trace.New("findme", "note", "", []string{"sample-tag"}, "body")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if _, err := cx.SearchAs("findme", cortex.ListOptions{}, cortex.ActorAgent, cortex.DefaultSearchHitTopN); err != nil {
+		t.Fatalf("SearchAs: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := runMemoryPopular(&buf, cx, 5, "text"); err != nil {
+		t.Fatalf("runMemoryPopular: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "findme") {
+		t.Errorf("text output missing trace title:\n%s", out)
+	}
+	if !strings.Contains(out, "sample-tag") {
+		t.Errorf("text output missing tag:\n%s", out)
+	}
+}
+
+// TestRunMemoryPopular_EmptyShowsBothPlaceholders pins that even on
+// an empty cortex, both leaderboard sections render with explicit
+// "no engagement yet" placeholders rather than blank space — keeps
+// the layout legible the first time an operator runs the command.
+func TestRunMemoryPopular_EmptyShowsBothPlaceholders(t *testing.T) {
+	cx := newCortexForHealth(t, "popempty")
+	var buf bytes.Buffer
+	if err := runMemoryPopular(&buf, cx, 10, "text"); err != nil {
+		t.Fatalf("runMemoryPopular: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Top 10 traces") {
+		t.Errorf("missing traces section header:\n%s", out)
+	}
+	if !strings.Contains(out, "Top 10 tags") {
+		t.Errorf("missing tags section header:\n%s", out)
+	}
+	if !strings.Contains(out, "no traces with engagement yet") {
+		t.Errorf("missing traces empty placeholder:\n%s", out)
+	}
+	if !strings.Contains(out, "no tagged traces with engagement yet") {
+		t.Errorf("missing tags empty placeholder:\n%s", out)
+	}
+}
+
+func TestRunMemoryPopular_InvalidOutput(t *testing.T) {
+	cx := newCortexForHealth(t, "poperr")
+	var buf bytes.Buffer
+	err := runMemoryPopular(&buf, cx, 10, "yaml")
+	if err == nil {
+		t.Fatal("expected error for unsupported --output, got nil")
+	}
+	if !strings.Contains(err.Error(), "yaml") {
+		t.Errorf("error should name the bad value: %v", err)
+	}
+}

--- a/internal/cortex/observability.go
+++ b/internal/cortex/observability.go
@@ -119,6 +119,121 @@ type PromotionStats struct {
 	P95Label string        `json:"p95"`
 }
 
+// PopularTrace is one row in the top-N-by-search-popularity table.
+// SearchHits and ReadCount are federation-wide aggregates (sum across
+// every peer's trace_usage row for this trace), matching the
+// convention EngagementStats already uses.
+type PopularTrace struct {
+	ID         string `json:"id"`
+	Title      string `json:"title"`
+	Type       string `json:"type"`
+	Tier       string `json:"tier"`
+	SearchHits int    `json:"search_hits"`
+	ReadCount  int    `json:"read_count"`
+}
+
+// TagSummary is one row in the per-tag activity table. TraceCount is
+// the number of distinct active traces carrying the tag; the
+// SearchHits / ReadCount / ModifyCount sums attribute the trace's
+// total signal to each of its tags, so a trace with three tags
+// contributes its 10 reads three times across the table (once per
+// tag). That's the right semantic for "which tags are accumulating
+// engagement" — a multi-tagged trace IS engagement for all of its
+// tags. Comparing two tag rows is fair because both columns use the
+// same attribution rule.
+type TagSummary struct {
+	Tag         string `json:"tag"`
+	TraceCount  int    `json:"trace_count"`
+	SearchHits  int    `json:"search_hits"`
+	ReadCount   int    `json:"read_count"`
+	ModifyCount int    `json:"modify_count"`
+}
+
+// TopSearchedTraces returns the top-N active traces ranked by
+// search_hit_count (primary) and read_count (tiebreaker). Cumulative
+// counters across all-time — a since-window filter doesn't apply
+// because the counter rows don't carry timestamps. If the question is
+// "what's hot lately" rather than "what's been hot all-time," the
+// answer needs a different table (per-day usage snapshots), which is
+// deferred to a future iteration.
+func (c *Cortex) TopSearchedTraces(n int) ([]PopularTrace, error) {
+	if n <= 0 {
+		n = 10
+	}
+	q := `
+		SELECT t.id, t.title, t.type, t.tier,
+		       COALESCE(SUM(u.search_hit_count), 0) AS hits,
+		       COALESCE(SUM(u.read_count), 0)       AS reads
+		FROM traces t
+		LEFT JOIN trace_usage u ON u.trace_id = t.id
+		WHERE t.archived_at IS NULL
+		  AND t.trashed_at IS NULL
+		  AND t.purged_at IS NULL
+		GROUP BY t.id
+		HAVING hits > 0 OR reads > 0
+		ORDER BY hits DESC, reads DESC, t.id ASC
+		LIMIT ?`
+	rows, err := c.DB.Query(q, n)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []PopularTrace
+	for rows.Next() {
+		var p PopularTrace
+		if err := rows.Scan(&p.ID, &p.Title, &p.Type, &p.Tier, &p.SearchHits, &p.ReadCount); err != nil {
+			return nil, err
+		}
+		out = append(out, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// TagActivity returns the top-N tags ranked by total engagement
+// (search hits primary, reads secondary). Empty cortex returns an
+// empty slice (not nil) so JSON serializes as `[]` rather than `null`
+// — JSON consumers shouldn't have to special-case absence.
+func (c *Cortex) TagActivity(n int) ([]TagSummary, error) {
+	if n <= 0 {
+		n = 20
+	}
+	q := `
+		SELECT tt.tag,
+		       COUNT(DISTINCT t.id)                AS trace_count,
+		       COALESCE(SUM(u.search_hit_count), 0) AS hits,
+		       COALESCE(SUM(u.read_count), 0)       AS reads,
+		       COALESCE(SUM(u.modify_count), 0)     AS mods
+		FROM trace_tags tt
+		JOIN traces t ON t.id = tt.trace_id
+		LEFT JOIN trace_usage u ON u.trace_id = t.id
+		WHERE t.archived_at IS NULL
+		  AND t.trashed_at IS NULL
+		  AND t.purged_at IS NULL
+		GROUP BY tt.tag
+		ORDER BY hits DESC, reads DESC, mods DESC, tt.tag ASC
+		LIMIT ?`
+	rows, err := c.DB.Query(q, n)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []TagSummary{}
+	for rows.Next() {
+		var s TagSummary
+		if err := rows.Scan(&s.Tag, &s.TraceCount, &s.SearchHits, &s.ReadCount, &s.ModifyCount); err != nil {
+			return nil, err
+		}
+		out = append(out, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // OneSourceMidCount is the leak detector for the 1-source mid bucket.
 // PRs #86 and #90 closed two distinct paths that were promoting
 // single-derived-from traces past the heuristic; this surface lets us

--- a/internal/cortex/observability_test.go
+++ b/internal/cortex/observability_test.go
@@ -225,6 +225,159 @@ func TestPromotionLatency_MidToLong_UsesMidEntry(t *testing.T) {
 	}
 }
 
+// TestTopSearchedTraces_RanksByHitsThenReads pins the primary/secondary
+// sort: search_hit_count first, then read_count as tiebreaker. A trace
+// with more reads but fewer search hits should still rank below a trace
+// with more search hits, because the surface is named "popular by
+// search" — the search counter dominates intentionally.
+func TestTopSearchedTraces_RanksByHitsThenReads(t *testing.T) {
+	cx := setup(t)
+	a := trace.New("alpha", "note", "", nil, "body")
+	if err := cx.Add(a); err != nil {
+		t.Fatalf("Add a: %v", err)
+	}
+	b := trace.New("beta", "note", "", nil, "body")
+	if err := cx.Add(b); err != nil {
+		t.Fatalf("Add b: %v", err)
+	}
+	// alpha: 1 search hit, no reads. beta: 0 search hits, many reads.
+	if _, err := cx.SearchAs("alpha", cortex.ListOptions{}, cortex.ActorAgent, cortex.DefaultSearchHitTopN); err != nil {
+		t.Fatalf("SearchAs: %v", err)
+	}
+	for range 5 {
+		if _, err := cx.GetAs(b.ID, cortex.ActorAgent); err != nil {
+			t.Fatalf("GetAs b: %v", err)
+		}
+	}
+	got, err := cx.TopSearchedTraces(10)
+	if err != nil {
+		t.Fatalf("TopSearchedTraces: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d rows, want 2: %+v", len(got), got)
+	}
+	if got[0].ID != a.ID {
+		t.Errorf("rank 1 = %q, want alpha (search hits dominate over reads)", got[0].ID)
+	}
+	if got[1].ID != b.ID {
+		t.Errorf("rank 2 = %q, want beta", got[1].ID)
+	}
+}
+
+// TestTopSearchedTraces_LimitAndZeroFilter pins two things in one test:
+// the LIMIT cap is honored, and traces with zero engagement on both
+// counters drop out entirely (HAVING clause). Otherwise a fresh cortex
+// would return a long list of just-created untouched traces, drowning
+// out the few actually-searched ones.
+func TestTopSearchedTraces_LimitAndZeroFilter(t *testing.T) {
+	cx := setup(t)
+	for i := range 5 {
+		tr := trace.New(fmt.Sprintf("t%d", i), "note", "", nil, "body")
+		if err := cx.Add(tr); err != nil {
+			t.Fatalf("Add: %v", err)
+		}
+	}
+	// Add one searched trace.
+	hot := trace.New("hot", "note", "", nil, "body")
+	if err := cx.Add(hot); err != nil {
+		t.Fatalf("Add hot: %v", err)
+	}
+	if _, err := cx.SearchAs("hot", cortex.ListOptions{}, cortex.ActorAgent, cortex.DefaultSearchHitTopN); err != nil {
+		t.Fatalf("SearchAs: %v", err)
+	}
+
+	got, err := cx.TopSearchedTraces(3)
+	if err != nil {
+		t.Fatalf("TopSearchedTraces: %v", err)
+	}
+	if len(got) != 1 {
+		t.Errorf("got %d rows, want 1 (zero-engagement traces should be filtered):\n%+v", len(got), got)
+	}
+}
+
+func TestTopSearchedTraces_EmptyCortex(t *testing.T) {
+	cx := setup(t)
+	got, err := cx.TopSearchedTraces(10)
+	if err != nil {
+		t.Fatalf("TopSearchedTraces: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty result on empty cortex, got %+v", got)
+	}
+}
+
+// TestTagActivity_AggregatesAcrossTags pins that a trace with multiple
+// tags contributes its engagement to each tag — a trace tagged
+// [go, language] with 10 reads adds 10 reads to BOTH tag rows. That's
+// the intended semantic: each tag's row answers "what's this tag's
+// total engagement footprint," not "what's exclusively this tag's."
+func TestTagActivity_AggregatesAcrossTags(t *testing.T) {
+	cx := setup(t)
+	dual := trace.New("dual", "note", "", []string{"go", "language"}, "body")
+	if err := cx.Add(dual); err != nil {
+		t.Fatalf("Add dual: %v", err)
+	}
+	if _, err := cx.GetAs(dual.ID, cortex.ActorAgent); err != nil {
+		t.Fatalf("GetAs: %v", err)
+	}
+
+	got, err := cx.TagActivity(10)
+	if err != nil {
+		t.Fatalf("TagActivity: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d tags, want 2: %+v", len(got), got)
+	}
+	for _, ts := range got {
+		if ts.TraceCount != 1 {
+			t.Errorf("tag %q TraceCount = %d, want 1", ts.Tag, ts.TraceCount)
+		}
+		if ts.ReadCount != 1 {
+			t.Errorf("tag %q ReadCount = %d, want 1 (each tag gets full attribution of its trace's reads)", ts.Tag, ts.ReadCount)
+		}
+	}
+}
+
+// TestTagActivity_ExcludesArchived pins the active-only convention:
+// a tag whose only carrier is archived should not appear in the
+// output. Otherwise an operator browsing "what's hot" sees ghost
+// tags from traces they explicitly demoted to archive.
+func TestTagActivity_ExcludesArchived(t *testing.T) {
+	cx := setup(t)
+	tr := trace.New("ghosted", "note", "", []string{"obsolete-tag"}, "body")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if _, err := cx.GetAs(tr.ID, cortex.ActorAgent); err != nil {
+		t.Fatalf("GetAs: %v", err)
+	}
+	if err := cx.Archive(tr.ID); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+
+	got, err := cx.TagActivity(10)
+	if err != nil {
+		t.Fatalf("TagActivity: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty (archived trace's tag should be excluded), got %+v", got)
+	}
+}
+
+func TestTagActivity_EmptyReturnsEmptySlice(t *testing.T) {
+	cx := setup(t)
+	got, err := cx.TagActivity(10)
+	if err != nil {
+		t.Fatalf("TagActivity: %v", err)
+	}
+	if got == nil {
+		t.Error("got nil, want non-nil empty slice (JSON should serialize as [] not null)")
+	}
+	if len(got) != 0 {
+		t.Errorf("got %+v, want empty", got)
+	}
+}
+
 func TestOneSourceMidCount_Empty(t *testing.T) {
 	cx := setup(t)
 	got, err := cx.OneSourceMidCount()

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -454,6 +454,40 @@ func NewServer(cx *cortex.Cortex, noemaVersion string, federationMode string) *s
 		return mcp.NewToolResultText(string(buf)), nil
 	})
 
+	s.AddTool(mcp.NewTool("search_activity",
+		mcp.WithDescription("Top-N traces by federation-wide search popularity (search_hit_count then read_count) plus top-N tags by aggregate engagement. Lets an agent answer 'what's worth reading?' or 'which topics are hot?' without scanning every trace. Active traces only; archived/trashed are excluded."),
+		mcp.WithNumber("top", mcp.Description("How many top traces and top tags to return. Default 10. Capped at 100.")),
+	), func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		top := int(req.GetFloat("top", 10))
+		if top <= 0 {
+			top = 10
+		}
+		if top > 100 {
+			top = 100
+		}
+		traces, err := cx.TopSearchedTraces(top)
+		if err != nil {
+			return nil, fmt.Errorf("top searched traces: %w", err)
+		}
+		tags, err := cx.TagActivity(top)
+		if err != nil {
+			return nil, fmt.Errorf("tag activity: %w", err)
+		}
+		out := struct {
+			SchemaVersion int                   `json:"schema_version"`
+			Top           int                   `json:"top"`
+			Traces        []cortex.PopularTrace `json:"traces"`
+			Tags          []cortex.TagSummary   `json:"tags"`
+		}{
+			SchemaVersion: 1,
+			Top:           top,
+			Traces:        traces,
+			Tags:          tags,
+		}
+		buf, _ := json.MarshalIndent(out, "", "  ")
+		return mcp.NewToolResultText(string(buf)), nil
+	})
+
 	s.AddTool(mcp.NewTool("record_consolidation_result",
 		mcp.WithDescription("Internal tool. Materialises a distilled mid-tier trace from a set of short-term sources. Validates the source IDs exist (>=2 required), creates the new trace with derived_from lineage pointing at the sources, and emits an ActionConsolidate event carrying model/profile/confidence telemetry for the quality dashboard."),
 		mcp.WithString("title", mcp.Description("Title for the distilled trace"), mcp.Required()),
@@ -978,6 +1012,12 @@ Choose the type that best reflects the intent of the memory:
                                    and the 1-source mid leak detector. since
                                    accepts Go duration syntax plus d/w (e.g.
                                    24h, 7d). Defaults to 24h.
+  search_activity [top]          → top-N traces by federation-wide search
+                                   popularity, plus top-N tags by aggregate
+                                   engagement (hits + reads + modifies). Use
+                                   this to surface what's worth reading or to
+                                   discover which topics are hot. top defaults
+                                   to 10, capped at 100.
   sync_events [since] [limit]    → pull events for federation (JSON array)
   federation_status              → MCP access posture, federation config,
                                    peer states, vector clock


### PR DESCRIPTION
> **Note**: stacked on #95 (`feat/memory-health-surface`). GitHub will show #95's diff plus this PR's diff combined; once #95 merges, the duplicates drop out automatically. Merge #95 first, then this.

## Summary

- Second PR in the observability v1 series (after #95). Answers **"what's worth reading?"** and **"which topics are hot?"** without scanning every trace or hand-writing aggregation SQL.

## What's new

**Cortex methods** (extends `internal/cortex/observability.go`):

- `TopSearchedTraces(n)` — top-N active traces ranked by federation-wide `search_hit_count` (primary) and `read_count` (tiebreaker). `search_hit_count` is the auto-injection-friendly signal: providers that fold search results into a context window without ever calling `get_trace` bump only this counter, so it's the better "worth surfacing" proxy than read counts alone.
- `TagActivity(n)` — top-N tags by aggregate search hits / reads / modifies across every active trace carrying the tag. Multi-tagged traces contribute their engagement to each of their tags, so two rows are directly comparable.

Both methods exclude archived/trashed/purged traces and emit empty slices (not nil) so JSON serializes as \`[]\` rather than \`null\`.

**No \`--since\` parameter** on either method (design deviation worth flagging): \`trace_usage\` rows are cumulative counters without per-day timestamps, so a window filter would silently return cumulative-since-forever and mislead the operator. A real time-windowed variant needs per-day snapshots and is deferred to the v2 catalog in \`observability-plan.md\`.

**Surfaces**:

- \`noema memory popular [--top 10] [--output json|text]\` — new CLI subcommand.
- \`search_activity [top]\` — new MCP tool. \`top\` capped at 100 so a runaway agent can't ask for the full cortex.

Both share the \`memoryPopularReport\` envelope with a single top-level \`schema_version\`, a traces leaderboard, and a tags leaderboard.

## Smoke test against agentbrain

Verified live — not pasted here because some trace titles contain internal hostnames and other private identifiers that shouldn't end up in a public PR description. Observed:

- 10 traces with non-zero engagement counters; top trace has high \`search_hit_count\` but zero \`get_trace\` reads — exactly the auto-injection asymmetry that motivated PR #84's search-hit instrumentation.
- Top tags include the \`to-future-mark\` / \`to-future-agents\` markers (high reads + hits, low modifies — write-once-read-many shape) and \`hermes-session\` (84 traces, only 5 reads — session-summary archive pattern, low recall).
- Empty-cortex run shows both \`(no engagement yet)\` placeholders.
- JSON envelope round-trips through \`jq\` cleanly.

## Test plan

- [x] 6 new tests in \`internal/cortex/observability_test.go\`: hits/reads ranking order, LIMIT + zero-engagement filtering, empty cortex, multi-tag attribution, archived-trace exclusion, empty-slice-not-nil JSON contract
- [x] 4 new tests in \`internal/cli/cmd_memory_popular_test.go\`: JSON envelope shape, text rendering shows real data, empty cortex placeholders for both sections, invalid \`--output\` error path
- [x] \`go build ./...\` clean
- [x] \`go test ./...\` clean (full suite)
- [x] \`go vet ./...\` clean
- [x] Live smoke against agentbrain — both text and JSON output read correctly

## Follow-ups

- **PR 3** — federation peer health (\`PeerLag\` + \`DivergenceActivity\`, extends \`federation_status\` MCP, \`noema federation lag\` CLI)
- **PR 4** — TUI dashboard view (\`M\` key, parallel to \`?:help\`, surfaces PR 1–3 metrics inline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)