### PR TITLE
fix(consolidation): kill watchdog races on same-peer and remote-peer claims

### DIFF
--- a/internal/cli/cmd_serve.go
+++ b/internal/cli/cmd_serve.go
@@ -230,8 +230,15 @@ func serveCmd() *cobra.Command {
 			// background-work lock so the cron scheduler only fires
 			// once per cortex even when multiple processes are serving
 			// MCP traffic.
+			//
+			// The in-flight registry is shared with the watchdog so
+			// the sweeper can recognize the local runner's active
+			// claims and skip them (Pattern B in the consolidation
+			// race analysis). Built unconditionally — both startups
+			// are cheap and a nil registry is safe-but-race-prone.
+			inFlight := consolidation.NewInFlightRegistry()
 			if gotLock && manifestErr == nil && m.Consolidation != nil && m.Consolidation.Enabled {
-				consolidator = startConsolidator(cx, m.Consolidation, m.Federation)
+				consolidator = startConsolidator(cx, m.Consolidation, m.Federation, inFlight)
 			}
 
 			// Eligibility loop: advertises this cortex's consolidation
@@ -251,7 +258,7 @@ func serveCmd() *cobra.Command {
 			// need a parallel sweeper.
 			if gotLock && manifestErr == nil && m.Consolidation != nil && m.Consolidation.Enabled &&
 				m.Federation != nil && len(m.Federation.Peers) > 0 {
-				watchdog = startWatchdog(cx, m.Consolidation)
+				watchdog = startWatchdog(cx, m.Consolidation, m.Federation, inFlight)
 			}
 
 			switch transport {
@@ -468,7 +475,13 @@ func startWatcher(cx *cortex.Cortex, cfg *cortex.WatchConfig) *watch.Watcher {
 // actually runs a cycle. Single-node cortexes skip the wrapper — the
 // gate would work there too, but it would emit a Claim+Success pair on
 // every pass for a degenerate election with a single participant.
-func startConsolidator(cx *cortex.Cortex, cfg *cortex.ConsolidationConfig, fed *cortex.FederationConfig) *consolidation.Agent {
+//
+// registry is the process-local in-flight tracker shared with the
+// watchdog (built once in the caller). It is consulted by the watchdog
+// to skip windows the local runner is currently executing, eliminating
+// the same-peer race where a Sweep tick fires between the inner pass
+// completing and the Success event being emitted.
+func startConsolidator(cx *cortex.Cortex, cfg *cortex.ConsolidationConfig, fed *cortex.FederationConfig, registry *consolidation.InFlightRegistry) *consolidation.Agent {
 	if cfg == nil || !cfg.Enabled {
 		return nil
 	}
@@ -540,7 +553,7 @@ func startConsolidator(cx *cortex.Cortex, cfg *cortex.ConsolidationConfig, fed *
 			Emitter:     cx,
 			Log:         logger,
 		})
-		pass = consolidation.WithElection(pass, election, logger)
+		pass = consolidation.WithElection(pass, election, registry, logger)
 		fmt.Fprintf(os.Stderr, "[consolidation] election gate enabled (peers=%d quiet=%s)\n",
 			len(peerNames), 2*interval)
 	}
@@ -617,20 +630,41 @@ func startEligibility(cx *cortex.Cortex, cfg *cortex.ConsolidationConfig, fed *c
 // pass trips the watchdog before the local consolidator emits success.
 // Sweep cadence is still an internal default (1 minute) — promoting
 // that to manifest config can wait until someone needs it.
-func startWatchdog(cx *cortex.Cortex, cfg *cortex.ConsolidationConfig) *consolidation.Watchdog {
+func startWatchdog(cx *cortex.Cortex, cfg *cortex.ConsolidationConfig, fed *cortex.FederationConfig, registry *consolidation.InFlightRegistry) *consolidation.Watchdog {
 	logger := func(format string, args ...any) {
 		fmt.Fprintf(os.Stderr, format+"\n", args...)
 	}
 	timeout := cfg.EffectiveWatchdogTimeout()
+
+	// Remote claims need an extra grace period so federation sync has
+	// time to deliver the runner's Success before the observer's
+	// watchdog ticks. Without it, every long-running pass produces one
+	// spurious watchdog_expired fail per observer whose sync interval
+	// hadn't yet caught up. The 2 × interval default mirrors the
+	// election quiet-period and the syncer's worst-case staleness.
+	remoteGrace := time.Duration(0)
+	if fed != nil && len(fed.Peers) > 0 {
+		interval := 30 * time.Second
+		if fed.Interval != "" {
+			if parsed, err := time.ParseDuration(fed.Interval); err == nil && parsed > 0 {
+				interval = parsed
+			}
+		}
+		remoteGrace = 2 * interval
+	}
+
 	w := consolidation.NewWatchdog(consolidation.WatchdogConfig{
 		DB:            cx.DB.DB,
 		Emitter:       cx,
 		LocalCortexID: cx.ID,
 		Timeout:       timeout,
+		RemoteGrace:   remoteGrace,
+		Registry:      registry,
 		Log:           logger,
 	})
 	w.Start()
-	fmt.Fprintf(os.Stderr, "[consolidation] watchdog started (timeout=%s)\n", timeout)
+	fmt.Fprintf(os.Stderr, "[consolidation] watchdog started (timeout=%s remote_grace=%s)\n",
+		timeout, remoteGrace)
 	return w
 }
 

--- a/internal/consolidation/inflight.go
+++ b/internal/consolidation/inflight.go
@@ -1,0 +1,68 @@
+package consolidation
+
+import "sync"
+
+// InFlightRegistry tracks consolidation windows the local pass-gate has
+// claimed but not yet emitted a terminal (success/fail) event for. The
+// watchdog consults it to skip the local runner's own active claims, so
+// a sweep that fires while the runner is mid-pass cannot race ahead of
+// the pending Success event and emit a spurious watchdog_expired fail.
+//
+// The registry is process-local and intentionally not persisted. A
+// crash mid-pass leaves the claim with no Success/Fail in the event
+// log; the next process boot starts with an empty registry, and the
+// watchdog correctly observes the orphan and closes it out (the very
+// situation the watchdog exists for). Persisting would defeat that.
+//
+// Safe for concurrent use; the pass-gate's Begin and the watchdog's
+// IsActive routinely race in production.
+type InFlightRegistry struct {
+	mu      sync.Mutex
+	windows map[string]struct{}
+}
+
+// NewInFlightRegistry returns a ready-to-use registry. The zero value
+// is also usable for tests that want to assert the watchdog tolerates a
+// nil registry (the production wiring always supplies one).
+func NewInFlightRegistry() *InFlightRegistry {
+	return &InFlightRegistry{windows: make(map[string]struct{})}
+}
+
+// Begin records that the local runner is about to invoke the inner
+// PassFn for windowID. Pair with End in a defer so a panic in the
+// inner function doesn't leave a stuck entry behind.
+func (r *InFlightRegistry) Begin(windowID string) {
+	if r == nil || windowID == "" {
+		return
+	}
+	r.mu.Lock()
+	if r.windows == nil {
+		r.windows = make(map[string]struct{})
+	}
+	r.windows[windowID] = struct{}{}
+	r.mu.Unlock()
+}
+
+// End clears the in-flight marker for windowID. Idempotent: calling
+// End on an unknown window is a no-op so defer chains stay simple.
+func (r *InFlightRegistry) End(windowID string) {
+	if r == nil || windowID == "" {
+		return
+	}
+	r.mu.Lock()
+	delete(r.windows, windowID)
+	r.mu.Unlock()
+}
+
+// IsActive reports whether the local runner is currently executing
+// windowID. The watchdog checks this before emitting a fail; a true
+// answer means "trust the runner, the Success event is on its way."
+func (r *InFlightRegistry) IsActive(windowID string) bool {
+	if r == nil || windowID == "" {
+		return false
+	}
+	r.mu.Lock()
+	_, ok := r.windows[windowID]
+	r.mu.Unlock()
+	return ok
+}

--- a/internal/consolidation/pass_gate.go
+++ b/internal/consolidation/pass_gate.go
@@ -39,7 +39,7 @@ import (
 // wrapper degenerates to "emit Claim, brief sleep, emit Success
 // around the pass" — correct but mildly wasteful. Phase 4 can add a
 // no-peers fast path if the overhead ever matters.
-func WithElection(inner PassFn, election *Election, log func(format string, args ...any)) PassFn {
+func WithElection(inner PassFn, election *Election, registry *InFlightRegistry, log func(format string, args ...any)) PassFn {
 	if log == nil {
 		log = func(string, ...any) {}
 	}
@@ -77,6 +77,13 @@ func WithElection(inner PassFn, election *Election, log func(format string, args
 			_ = election.Fail(windowID, reason)
 			return nil
 		}
+
+		// Mark the window in-flight before invoking inner() so the
+		// watchdog's Sweep can recognize this peer's own active pass
+		// and skip it. Cleared in a defer so a panic in inner() (or
+		// in Success/Fail emission) still releases the marker.
+		registry.Begin(windowID)
+		defer registry.End(windowID)
 
 		log("[consolidation] running as elected winner (trigger=%s window=%s)",
 			trigger, windowID)

--- a/internal/consolidation/pass_gate_test.go
+++ b/internal/consolidation/pass_gate_test.go
@@ -38,7 +38,7 @@ func TestWithElection_SkipsWhenNotElected(t *testing.T) {
 	})
 
 	inner := &callTracker{}
-	wrapped := consolidation.WithElection(inner.pass, e, nil)
+	wrapped := consolidation.WithElection(inner.pass, e, nil, nil)
 
 	if err := wrapped(context.Background(), "cron"); err != nil {
 		t.Fatalf("wrapped: %v", err)
@@ -70,7 +70,7 @@ func TestWithElection_RunsWhenElected(t *testing.T) {
 	})
 
 	inner := &callTracker{}
-	wrapped := consolidation.WithElection(inner.pass, e, nil)
+	wrapped := consolidation.WithElection(inner.pass, e, nil, nil)
 
 	if err := wrapped(context.Background(), "cron"); err != nil {
 		t.Fatalf("wrapped: %v", err)
@@ -105,7 +105,7 @@ func TestWithElection_EmitsFailOnPassError(t *testing.T) {
 
 	passErr := errors.New("LLM backend returned 500")
 	inner := &callTracker{err: passErr}
-	wrapped := consolidation.WithElection(inner.pass, e, nil)
+	wrapped := consolidation.WithElection(inner.pass, e, nil, nil)
 
 	err := wrapped(context.Background(), "cron")
 	if err == nil || !errors.Is(err, passErr) {
@@ -138,7 +138,7 @@ func TestWithElection_HonorsContextCancellationDuringQuietPeriod(t *testing.T) {
 	})
 
 	inner := &callTracker{}
-	wrapped := consolidation.WithElection(inner.pass, e, nil)
+	wrapped := consolidation.WithElection(inner.pass, e, nil, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // pre-cancel so the sleep returns immediately
@@ -217,7 +217,7 @@ func TestWithElection_EmitsNoWinnerAtRecheck(t *testing.T) {
 	})
 
 	inner := &callTracker{}
-	wrapped := consolidation.WithElection(inner.pass, e, nil)
+	wrapped := consolidation.WithElection(inner.pass, e, nil, nil)
 
 	// Demote local rank to 0 partway through the quiet period so the
 	// recheck finds zero eligible peers.
@@ -260,7 +260,7 @@ func TestWithElection_EmitsPeerOutrankedAtRecheck(t *testing.T) {
 	})
 
 	inner := &callTracker{}
-	wrapped := consolidation.WithElection(inner.pass, e, nil)
+	wrapped := consolidation.WithElection(inner.pass, e, nil, nil)
 
 	// Higher-ranked peer surfaces during the quiet wait.
 	go func() {

--- a/internal/consolidation/watchdog.go
+++ b/internal/consolidation/watchdog.go
@@ -47,6 +47,29 @@ type WatchdogConfig struct {
 	// closed out. Zero defaults to defaultWatchdogInterval.
 	Interval time.Duration
 
+	// RemoteGrace is added to Timeout when evaluating claims emitted by
+	// a peer other than LocalCortexID. The motivation is the
+	// observer-side race in §14 of the consolidation plan: a peer's
+	// successful pass produces a Success event that takes one
+	// federation.interval to propagate. Without an extra grace, every
+	// observer's watchdog tick that falls between Timeout-elapsed and
+	// Success-arrived emits a spurious watchdog_expired fail, and
+	// `consolidation_health.totals.fail` ends up double-counting the
+	// completed pass by exactly the number of observers whose sync
+	// hadn't caught up. Recommend setting to ~2 × federation.interval;
+	// zero disables the grace (every claim, local or remote, gets the
+	// same Timeout).
+	RemoteGrace time.Duration
+
+	// Registry tracks windows the local pass-gate is currently
+	// executing. Sweep skips windows where IsActive(window) is true to
+	// kill the same-peer race: the runner is about to emit Success but
+	// the watchdog sweep saw the claim as orphaned because it ticked
+	// just before Success landed. A nil registry is permitted (tests
+	// and pre-wiring shims rely on it) and degrades to the previous
+	// race-prone behavior.
+	Registry *InFlightRegistry
+
 	// Now is injected for tests; zero defaults to time.Now.
 	Now func() time.Time
 
@@ -151,17 +174,47 @@ type orphanedClaim struct {
 // Not safe for concurrent invocation — the loop goroutine is the only
 // expected caller in production. The internal mutex serializes any
 // stray test calls against the loop.
+//
+// The SQL prefilter uses the LOCAL cutoff (now − Timeout) so it
+// returns every claim old enough for the local cortex to consider
+// closing. The Go filter then enforces the stricter remote cutoff
+// (now − (Timeout + RemoteGrace)) on claims attributed to a different
+// cortex, plus the in-flight registry check that protects this peer's
+// own active passes.
 func (w *Watchdog) Sweep() error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	cutoff := w.cfg.Now().Add(-w.cfg.Timeout).UTC().Format(time.RFC3339)
-	orphans, err := w.findOrphans(cutoff)
+	now := w.cfg.Now()
+	// "Older than X" reads as "timestamp earlier than now − X." The
+	// SQL filter uses the bound that lets the most rows through (the
+	// shorter age) so per-row policy can be applied in Go.
+	localCutoff := now.Add(-w.cfg.Timeout)
+	remoteCutoff := now.Add(-(w.cfg.Timeout + w.cfg.RemoteGrace))
+
+	orphans, err := w.findOrphans(localCutoff.UTC().Format(time.RFC3339))
 	if err != nil {
 		return fmt.Errorf("watchdog query: %w", err)
 	}
 
 	for _, o := range orphans {
+		if w.cfg.Registry.IsActive(o.WindowID) {
+			// Local runner is still executing this window; trust
+			// the runner. Pattern B (runner-Sweep race on the same
+			// peer) lives here.
+			continue
+		}
+		if w.cfg.RemoteGrace > 0 && o.WinnerID != w.cfg.LocalCortexID {
+			// Remote-emitted claim: defer until the federation-sync
+			// grace window has also elapsed. Pattern C (observer's
+			// watchdog firing before the runner's Success replicates)
+			// lives here.
+			claimedAt, perr := time.Parse(time.RFC3339, o.Timestamp)
+			if perr == nil && claimedAt.After(remoteCutoff) {
+				continue
+			}
+		}
+
 		// Each emission goes through the same EmitCoordinationEvent
 		// path used by Election, so the closing fail lands in the
 		// event log with the local cortex as the emitter and the

--- a/internal/consolidation/watchdog_test.go
+++ b/internal/consolidation/watchdog_test.go
@@ -269,3 +269,148 @@ func TestWatchdog_StopWithoutStartIsSafe(t *testing.T) {
 	})
 	w.Stop() // should be a no-op
 }
+
+// TestWatchdog_SkipsInFlightLocalClaim pins the Pattern B fix: when the
+// local pass-gate has registered a window as in-flight, the watchdog
+// must not close it out even if Timeout has elapsed. The runner is
+// about to emit Success; the watchdog beating it by milliseconds was
+// the actual production race we observed on 2026-05-15.
+func TestWatchdog_SkipsInFlightLocalClaim(t *testing.T) {
+	cx := buildWatchdogCortex(t)
+	// Emit the claim with cortex_id = local. EmitCoordinationEvent
+	// stamps cortex_id from the cortex itself, so the claim's
+	// WinnerID will match LocalCortexID below.
+	windowID := emitClaim(t, cx, cx.ID)
+
+	registry := consolidation.NewInFlightRegistry()
+	registry.Begin(windowID)
+	defer registry.End(windowID)
+
+	future := time.Now().Add(20 * time.Minute)
+	w := consolidation.NewWatchdog(consolidation.WatchdogConfig{
+		DB:            cx.DB.DB,
+		Emitter:       cx,
+		LocalCortexID: cx.ID,
+		Timeout:       10 * time.Minute,
+		Registry:      registry,
+		Now:           func() time.Time { return future },
+	})
+
+	if err := w.Sweep(); err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if got := countActions(t, cx, event.ActionConsolidationFail); got != 0 {
+		t.Errorf("fail events = %d, want 0 (registry says local runner is still executing)", got)
+	}
+}
+
+// TestWatchdog_RemoteGraceDefersClosure pins the Pattern C fix: a
+// remote-emitted claim must not be closed out until Timeout + RemoteGrace
+// has elapsed, giving federation sync time to deliver the runner's
+// Success event. Without this, every long-running pass produces one
+// spurious watchdog_expired fail per observer whose sync lagged.
+func TestWatchdog_RemoteGraceDefersClosure(t *testing.T) {
+	cx := buildWatchdogCortex(t)
+	// Different cortex_id than the local cortex so the row is treated
+	// as remote-emitted. emitClaim stamps the WinnerID into FailData,
+	// but EmitCoordinationEvent stamps the cortex_id column from the
+	// cortex's own ID — which for findOrphans IS the row's cortex_id.
+	// So this test exercises the local-cortex path; for the true
+	// remote case the row would have come through federation replay.
+	// We approximate by inserting a raw event with a foreign cortex_id.
+	otherCortexID := "01REMOTECORTEXIDXXXXXXXXXXX"
+	windowID := "01REMOTECLAIMWINDOWXXXXXXXX"
+	insertRawWatchdogEvent(t, cx, event.ActionConsolidationClaim, windowID,
+		time.Now().Add(-12*time.Minute), otherCortexID)
+
+	// Timeout has elapsed (12m > 10m) but Timeout+RemoteGrace has not
+	// (12m < 10m + 5m). The watchdog must hold off.
+	w := consolidation.NewWatchdog(consolidation.WatchdogConfig{
+		DB:            cx.DB.DB,
+		Emitter:       cx,
+		LocalCortexID: cx.ID,
+		Timeout:       10 * time.Minute,
+		RemoteGrace:   5 * time.Minute,
+	})
+	if err := w.Sweep(); err != nil {
+		t.Fatalf("Sweep within grace: %v", err)
+	}
+	if got := countActions(t, cx, event.ActionConsolidationFail); got != 0 {
+		t.Errorf("fail events within remote grace = %d, want 0", got)
+	}
+
+	// Past the grace window — now the watchdog should close it out.
+	future := time.Now().Add(20 * time.Minute)
+	w2 := consolidation.NewWatchdog(consolidation.WatchdogConfig{
+		DB:            cx.DB.DB,
+		Emitter:       cx,
+		LocalCortexID: cx.ID,
+		Timeout:       10 * time.Minute,
+		RemoteGrace:   5 * time.Minute,
+		Now:           func() time.Time { return future },
+	})
+	if err := w2.Sweep(); err != nil {
+		t.Fatalf("Sweep past grace: %v", err)
+	}
+	if got := countActions(t, cx, event.ActionConsolidationFail); got != 1 {
+		t.Errorf("fail events past remote grace = %d, want 1", got)
+	}
+}
+
+// TestWatchdog_LocalClaimUsesStrictTimeout pins that RemoteGrace does
+// NOT delay closure of the local cortex's own orphaned claims. Only
+// remote claims need the federation-sync buffer; local claims racing
+// the runner are handled by the InFlightRegistry instead.
+func TestWatchdog_LocalClaimUsesStrictTimeout(t *testing.T) {
+	cx := buildWatchdogCortex(t)
+	// Local-emitted claim that has exceeded Timeout but not yet
+	// Timeout+RemoteGrace. The registry is empty (no in-flight pass),
+	// so the watchdog should close it on the strict timeout despite
+	// the configured remote grace.
+	windowID := emitClaim(t, cx, cx.ID)
+
+	future := time.Now().Add(11 * time.Minute) // past 10m timeout, within 10+5m
+	w := consolidation.NewWatchdog(consolidation.WatchdogConfig{
+		DB:            cx.DB.DB,
+		Emitter:       cx,
+		LocalCortexID: cx.ID,
+		Timeout:       10 * time.Minute,
+		RemoteGrace:   5 * time.Minute,
+		Registry:      consolidation.NewInFlightRegistry(),
+		Now:           func() time.Time { return future },
+	})
+	if err := w.Sweep(); err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if got := countActions(t, cx, event.ActionConsolidationFail); got != 1 {
+		t.Errorf("fail events = %d, want 1 (local claim past strict timeout, registry empty)", got)
+	}
+	// Sanity: the closed window should be the one we emitted.
+	if r := findFailReason(t, cx, windowID); r != consolidation.FailReasonWatchdogExpired {
+		t.Errorf("fail reason for %s = %q, want %q", windowID, r, consolidation.FailReasonWatchdogExpired)
+	}
+}
+
+// insertRawWatchdogEvent writes an events row with a foreign cortex_id
+// so tests can exercise the "claim emitted by a remote peer" code path
+// without standing up a federation syncer. EmitCoordinationEvent
+// always stamps the LOCAL cortex_id, so the production-path emitClaim
+// helper can't produce a remote-attributed row.
+func insertRawWatchdogEvent(t *testing.T, cx *consolidationCortex, action event.Action, windowID string, ts time.Time, cortexID string) {
+	t.Helper()
+	payload := `{"window_id":"` + windowID + `","cortex_id":"` + cortexID + `"}`
+	id := "test-" + windowID + "-" + string(action)
+	_, err := cx.DB.Exec(
+		`INSERT INTO events (id, action, trace_id, origin, timestamp, data, vclock, cortex_id)
+		 VALUES (?, ?, ?, ?, ?, ?, '{}', ?)`,
+		id, string(action), windowID, "remote-peer", ts.UTC().Format(time.RFC3339), payload, cortexID,
+	)
+	if err != nil {
+		t.Fatalf("insert raw event: %v", err)
+	}
+}
+
+// consolidationCortex is a narrow alias so insertRawWatchdogEvent can
+// accept the *cortex.Cortex from buildWatchdogCortex without dragging
+// the cortex package import into the helper signature.
+type consolidationCortex = cortex.Cortex


### PR DESCRIPTION
## Summary

Closes two race patterns that surfaced on 2026-05-14/15 and produced spurious `watchdog_expired` events. The patterns are detailed in the commit message; quick summary:

- **Pattern B (same-peer race):** agentbrain's pass completed at 07:56:25, but its own watchdog Sweep emitted Fail at 07:56:24 — beat the runner to the event log by one second. Spurious fail for a window that actually succeeded.
- **Pattern C (cross-peer race):** agentbrain emitted Success at 07:57:01; ai-2's watchdog emitted Fail at 07:57:14 because federation sync hadn't yet delivered the Success. Every observing peer maintained an independent watchdog timer, so a long pass produced N-1 spurious fails per successful run.

Fixes:

- **New `InFlightRegistry`** (`internal/consolidation/inflight.go`) — process-local tracker of windows the local pass-gate has begun but not yet emitted Success/Fail for. `Sweep` consults it and skips. Kills Pattern B. Registry state is intentionally not persisted; a crash mid-pass leaves the claim with no terminal event, and the watchdog correctly closes it on next boot (the whole reason the watchdog exists).
- **`RemoteGrace` field on `WatchdogConfig`** — claims emitted by a different `cortex_id` are deferred until `Timeout + RemoteGrace` has elapsed, giving federation sync time to deliver the runner's Success before the observer's watchdog ticks. Local claims still fire on the strict `Timeout`. Kills Pattern C.
- **`WithElection` plumbing** — gate calls `registry.Begin(windowID)` before `inner()` and `defer registry.End(windowID)` so panics still release the marker. New signature: `WithElection(inner, election, registry, log)`.
- **`cmd_serve.go` wiring** — single `InFlightRegistry` constructed at startup, shared between `startConsolidator` and `startWatchdog`. `RemoteGrace` defaults to `2 × federation.interval` (mirrors the election quiet-period heuristic). Startup log includes `remote_grace=…`.

Builds on PR #97 (LostElection split) — once both land, the surface for the 2026-05-14/15 cluster reads correctly and the underlying races stop generating the noise in the first place.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `TestWatchdog_SkipsInFlightLocalClaim` — registry-active window is left alone past Timeout
- [x] `TestWatchdog_RemoteGraceDefersClosure` — within-grace = no fail; past-grace = exactly one fail
- [x] `TestWatchdog_LocalClaimUsesStrictTimeout` — local claims with empty registry still fire on strict Timeout
- [x] All six existing `pass_gate_test.go` WithElection tests pass with the new signature (passed `nil` for the registry, which the gate tolerates)
- [x] Full `go test ./...` green
- [ ] Reviewer to confirm the cmd_serve startup log change (`remote_grace=…`) is acceptable wording
- [ ] **Soak recommendation:** suggest landing on one fleet host first and watching `consolidation_health` for a week before rolling to the full ring. The default `RemoteGrace = 2 × federation.interval` may need tuning if sync intervals are unusually long.

🤖 Generated with [Claude Code](https://claude.com/claude-code)