### PR TITLE
release: v0.11.0 — observability surfaces + consolidation race fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,15 @@ noema verify traces [--backfill]          Check trace content hashes against fro
 noema verify cortex                       Validate manifest, config, db, access posture, and federation
 noema verify drift                        Check federated traces for drift from their source hash
 
+noema memory stats [--detailed]           Show tier counts and (with --detailed) engagement signal
+noema memory health [--since 24h]         Show consolidation activity over the window, promotion-latency
+                                          percentiles, and the 1-source mid leak detector
+noema memory popular [--top 10]           Top traces by search popularity and top tags by aggregate engagement
+noema memory promote <id> [--to mid|long] Advance a trace one tier (short→mid or mid→long)
+noema memory demote <id>                  Step a mid trace back to short
+noema memory purge <id> --tier <t> --reason "..." --confirm [--hard]
+                                          Ceremoniously destroy a trace with audit trail (GDPR path)
+
 noema federation status                   Show federation config, MCP access posture, peer sync state, and vector clock
 noema federation peers                    List configured federation peers
 noema federation add-peer <name> <endpoint>

--- a/internal/cli/cmd_memory.go
+++ b/internal/cli/cmd_memory.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"text/tabwriter"
 	"time"
 
@@ -34,10 +35,284 @@ is distributed across the cortex without opening the DB.`,
 	cmd.AddCommand(
 		memoryPurgeCmd(),
 		memoryStatsCmd(),
+		memoryHealthCmd(),
+		memoryPopularCmd(),
 		memoryPromoteCmd(),
 		memoryDemoteCmd(),
 	)
 	return cmd
+}
+
+// memoryPopularReport is the JSON envelope shared between the CLI
+// (`noema memory popular --output json`) and the MCP tool
+// `search_activity`. Same schema_version namespace as memoryHealthReport
+// — separate report types intentionally so consumers can pin to one
+// without coupling to the other.
+type memoryPopularReport struct {
+	SchemaVersion int                   `json:"schema_version"`
+	Top           int                   `json:"top"`
+	Traces        []cortex.PopularTrace `json:"traces"`
+	Tags          []cortex.TagSummary   `json:"tags"`
+}
+
+func memoryPopularCmd() *cobra.Command {
+	var (
+		topFlag    int
+		outputFlag string
+	)
+	cmd := &cobra.Command{
+		Use:   "popular",
+		Short: "Top traces by search popularity and top tags by aggregate engagement",
+		Long: `Reports two leaderboards over the cortex's federation-wide engagement
+counters:
+
+  - Top-N traces by search_hit_count (primary) and read_count
+    (tiebreaker). search_hit_count is the auto-injection-friendly
+    signal — Hermes-style providers that fold search results into a
+    context window without ever calling get_trace bump this counter
+    but not read_count, so it's the better "what's worth surfacing"
+    proxy than reads alone.
+
+  - Top-N tags by aggregate search hits / reads / modifies across
+    every active trace carrying the tag. A trace with multiple tags
+    contributes its engagement to each tag, so two columns are
+    directly comparable.
+
+Cumulative all-time counters — no --since flag. The trace_usage rows
+don't carry timestamps so a window filter would need a different
+table (per-day usage snapshots), which is deferred to a future
+iteration.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cx, err := resolveCortex()
+			if err != nil {
+				return err
+			}
+			defer cx.Close()
+			return runMemoryPopular(cmd.OutOrStdout(), cx, topFlag, outputFlag)
+		},
+	}
+	cmd.Flags().IntVar(&topFlag, "top", 10, "how many top traces and top tags to return")
+	cmd.Flags().StringVar(&outputFlag, "output", "text", "output format: text, json")
+	return cmd
+}
+
+func runMemoryPopular(w io.Writer, cx *cortex.Cortex, top int, output string) error {
+	if top <= 0 {
+		top = 10
+	}
+	traces, err := cx.TopSearchedTraces(top)
+	if err != nil {
+		return fmt.Errorf("top searched traces: %w", err)
+	}
+	tags, err := cx.TagActivity(top)
+	if err != nil {
+		return fmt.Errorf("tag activity: %w", err)
+	}
+	report := memoryPopularReport{
+		SchemaVersion: 1,
+		Top:           top,
+		Traces:        traces,
+		Tags:          tags,
+	}
+	switch output {
+	case "json":
+		buf, _ := json.MarshalIndent(report, "", "  ")
+		fmt.Fprintln(w, string(buf))
+	case "text", "":
+		renderMemoryPopularText(w, report)
+	default:
+		return fmt.Errorf("unsupported --output %q (try: text, json)", output)
+	}
+	return nil
+}
+
+func renderMemoryPopularText(w io.Writer, r memoryPopularReport) {
+	fmt.Fprintf(w, "Top %d traces by search popularity\n", r.Top)
+	if len(r.Traces) == 0 {
+		fmt.Fprintln(w, "  (no traces with engagement yet)")
+	} else {
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "  Hits\tReads\tTier\tType\tTitle")
+		for _, p := range r.Traces {
+			fmt.Fprintf(tw, "  %d\t%d\t%s\t%s\t%s\n", p.SearchHits, p.ReadCount, p.Tier, p.Type, truncate(p.Title, 60))
+		}
+		tw.Flush()
+	}
+	fmt.Fprintln(w)
+
+	fmt.Fprintf(w, "Top %d tags by aggregate engagement\n", r.Top)
+	if len(r.Tags) == 0 {
+		fmt.Fprintln(w, "  (no tagged traces with engagement yet)")
+		return
+	}
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "  Tag\tTraces\tHits\tReads\tModifies")
+	for _, t := range r.Tags {
+		fmt.Fprintf(tw, "  %s\t%d\t%d\t%d\t%d\n", t.Tag, t.TraceCount, t.SearchHits, t.ReadCount, t.ModifyCount)
+	}
+	tw.Flush()
+}
+
+
+// memoryHealthReport wraps the three cortex methods that answer "is
+// consolidation actually doing anything, and is anything leaking?"
+// into a single JSON envelope with a top-level schema_version (design
+// doc §3 — single top-level version per output, not per-section). The
+// MCP `consolidation_health` tool returns the same shape modulo field
+// naming.
+type memoryHealthReport struct {
+	SchemaVersion int                          `json:"schema_version"`
+	Activity      cortex.ConsolidationActivity `json:"activity"`
+	Latency       cortex.PromotionLatency      `json:"latency"`
+	OneSourceMid  cortex.OneSourceMidCount     `json:"one_source_mid"`
+}
+
+func memoryHealthCmd() *cobra.Command {
+	var (
+		sinceFlag  string
+		outputFlag string
+	)
+	cmd := &cobra.Command{
+		Use:   "health",
+		Short: "Show consolidation activity, promotion latency, and the 1-source mid leak detector",
+		Long: `Reports the consolidation pipeline's recent behavior — the question
+that motivated the observability surface: "how did consolidation fare
+overnight, and is anything leaking?"
+
+Three sections:
+
+  - Activity over the --since window: per-day counts of consolidation_claim,
+    consolidation_success, consolidation_fail, promote (any tier transition),
+    and consolidate (real LLM distillation events). Totals roll up the same
+    counters across the window.
+
+  - Promotion latency (all-time): count and p50/p95 of short→mid and
+    mid→long transition durations. mid→long measures from when the trace
+    entered the mid tier, not its created_at — a trace that lives short
+    for 30 days then promotes mid→long the next day shows up here as a
+    1-day mid→long latency.
+
+  - 1-source mid leak detector: current count of active mid-tier traces
+    with derived_from_count == 1 (the bucket PR #86 and PR #90 closed),
+    plus the count of traces that landed in that bucket within the last
+    7 days. A healthy gate keeps the recent count at zero.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cx, err := resolveCortex()
+			if err != nil {
+				return err
+			}
+			defer cx.Close()
+			return runMemoryHealth(cmd.OutOrStdout(), cx, sinceFlag, outputFlag)
+		},
+	}
+	cmd.Flags().StringVar(&sinceFlag, "since", "24h", "lookback window for activity buckets (e.g. 24h, 7d, 2w)")
+	cmd.Flags().StringVar(&outputFlag, "output", "text", "output format: text, json")
+	return cmd
+}
+
+// runMemoryHealth is the testable core of the memory-health CLI: it
+// composes the three cortex observability calls into a single report
+// and dispatches to either JSON or text rendering. Split out from the
+// cobra RunE so unit tests can drive it with a constructed Cortex and
+// a captured writer without spinning up the full command tree.
+func runMemoryHealth(w io.Writer, cx *cortex.Cortex, sinceLabel, output string) error {
+	since, err := cortex.ParseSince(sinceLabel)
+	if err != nil {
+		return err
+	}
+	activity, err := cx.ConsolidationActivity(since)
+	if err != nil {
+		return fmt.Errorf("consolidation activity: %w", err)
+	}
+	latency, err := cx.PromotionLatency()
+	if err != nil {
+		return fmt.Errorf("promotion latency: %w", err)
+	}
+	leak, err := cx.OneSourceMidCount()
+	if err != nil {
+		return fmt.Errorf("one-source mid count: %w", err)
+	}
+
+	report := memoryHealthReport{
+		SchemaVersion: 1,
+		Activity:      activity,
+		Latency:       latency,
+		OneSourceMid:  leak,
+	}
+
+	switch output {
+	case "json":
+		buf, _ := json.MarshalIndent(report, "", "  ")
+		fmt.Fprintln(w, string(buf))
+	case "text", "":
+		renderMemoryHealthText(w, report, sinceLabel)
+	default:
+		return fmt.Errorf("unsupported --output %q (try: text, json)", output)
+	}
+	return nil
+}
+
+// renderMemoryHealthText formats the report for a terminal. Two
+// tabwriter blocks (activity table + totals; latency rows) and a
+// final paragraph for the leak detector. Tabwriter rather than
+// hand-aligned spaces keeps the columns clean when day counts grow
+// to 3-digit numbers under busy cortexes.
+func renderMemoryHealthText(w io.Writer, r memoryHealthReport, sinceLabel string) {
+	fmt.Fprintf(w, "Consolidation activity — last %s\n", sinceLabel)
+	if len(r.Activity.Daily) == 0 {
+		fmt.Fprintln(w, "  (no events in window)")
+	} else {
+		tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "  Date\tClaim\tSuccess\tFail\tLostElec\tPromote\tDistill")
+		for _, d := range r.Activity.Daily {
+			fmt.Fprintf(tw, "  %s\t%d\t%d\t%d\t%d\t%d\t%d\n",
+				d.Date, d.Claim, d.Success, d.Fail, d.LostElection, d.Promote, d.Distill)
+		}
+		fmt.Fprintf(tw, "  ----\t-----\t-------\t----\t--------\t-------\t-------\n")
+		fmt.Fprintf(tw, "  Total\t%d\t%d\t%d\t%d\t%d\t%d\n",
+			r.Activity.Totals.Claim, r.Activity.Totals.Success, r.Activity.Totals.Fail,
+			r.Activity.Totals.LostElection,
+			r.Activity.Totals.Promote, r.Activity.Totals.Distill)
+		tw.Flush()
+	}
+	fmt.Fprintln(w)
+
+	fmt.Fprintln(w, "Promotion latency (all-time)")
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "  Transition\tCount\tp50\tp95")
+	fmt.Fprintf(tw, "  short→mid\t%d\t%s\t%s\n",
+		r.Latency.ShortToMid.Count, formatDuration(r.Latency.ShortToMid.P50), formatDuration(r.Latency.ShortToMid.P95))
+	fmt.Fprintf(tw, "  mid→long\t%d\t%s\t%s\n",
+		r.Latency.MidToLong.Count, formatDuration(r.Latency.MidToLong.P50), formatDuration(r.Latency.MidToLong.P95))
+	tw.Flush()
+	fmt.Fprintln(w)
+
+	fmt.Fprintln(w, "1-source mid leak detector")
+	fmt.Fprintf(w, "  Current:           %d trace(s)\n", r.OneSourceMid.Current)
+	status := "✓ gate is holding"
+	if r.OneSourceMid.PromotedLast7d > 0 {
+		status = "⚠ recent leak — investigate"
+	}
+	fmt.Fprintf(w, "  Promoted last 7d:  %d  %s\n", r.OneSourceMid.PromotedLast7d, status)
+}
+
+// formatDuration renders a duration in days/hours/minutes/seconds for
+// operator-friendly text output. JSON output keeps the raw nanosecond
+// integer so scripts can do whatever bucketing they want.
+func formatDuration(d time.Duration) string {
+	if d == 0 {
+		return "-"
+	}
+	if d >= 24*time.Hour {
+		return fmt.Sprintf("%.1fd", float64(d)/float64(24*time.Hour))
+	}
+	if d >= time.Hour {
+		return fmt.Sprintf("%.1fh", d.Hours())
+	}
+	if d >= time.Minute {
+		return fmt.Sprintf("%.1fm", d.Minutes())
+	}
+	return fmt.Sprintf("%.1fs", d.Seconds())
 }
 
 // memoryPromoteCmd surfaces Cortex.Promote as an operator-facing CLI

--- a/internal/cli/cmd_memory_health_test.go
+++ b/internal/cli/cmd_memory_health_test.go
@@ -1,0 +1,136 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Fail-Safe/Noema/internal/cortex"
+	"github.com/Fail-Safe/Noema/internal/trace"
+)
+
+// newCortexForHealth builds an on-disk cortex with no traces. Used by
+// the health-command tests where the cortex methods do the real work
+// and we only care that the CLI dispatch / output formatting wires
+// them up correctly.
+func newCortexForHealth(t *testing.T, name string) *cortex.Cortex {
+	t.Helper()
+	parent := t.TempDir()
+	if _, err := cortex.Create(name, parent); err != nil {
+		t.Fatalf("cortex.Create: %v", err)
+	}
+	cx, err := cortex.Open(name, filepath.Join(parent, name))
+	if err != nil {
+		t.Fatalf("cortex.Open: %v", err)
+	}
+	t.Cleanup(func() { cx.Close() })
+	return cx
+}
+
+// TestRunMemoryHealth_JSONEnvelope locks in the wire contract: a
+// single top-level schema_version per the design doc, plus the three
+// expected sections. External tooling will pin to this shape, so
+// silently dropping schema_version or renaming a section is a
+// breaking change this test should fail on.
+func TestRunMemoryHealth_JSONEnvelope(t *testing.T) {
+	cx := newCortexForHealth(t, "envtest")
+	var buf bytes.Buffer
+	if err := runMemoryHealth(&buf, cx, "24h", "json"); err != nil {
+		t.Fatalf("runMemoryHealth: %v", err)
+	}
+	var got struct {
+		SchemaVersion int             `json:"schema_version"`
+		Activity      json.RawMessage `json:"activity"`
+		Latency       json.RawMessage `json:"latency"`
+		OneSourceMid  json.RawMessage `json:"one_source_mid"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal output: %v\n%s", err, buf.String())
+	}
+	if got.SchemaVersion != 1 {
+		t.Errorf("schema_version = %d, want 1", got.SchemaVersion)
+	}
+	if len(got.Activity) == 0 {
+		t.Error("activity section missing")
+	}
+	if len(got.Latency) == 0 {
+		t.Error("latency section missing")
+	}
+	if len(got.OneSourceMid) == 0 {
+		t.Error("one_source_mid section missing")
+	}
+}
+
+// TestRunMemoryHealth_TextRendersAllSections pins that every section
+// header appears in the text output even on an empty cortex — the
+// operator should always see the layout, with "(no events)" rather
+// than a missing block when there's nothing to show.
+func TestRunMemoryHealth_TextRendersAllSections(t *testing.T) {
+	cx := newCortexForHealth(t, "texttest")
+	var buf bytes.Buffer
+	if err := runMemoryHealth(&buf, cx, "24h", "text"); err != nil {
+		t.Fatalf("runMemoryHealth: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{
+		"Consolidation activity",
+		"(no events in window)",
+		"Promotion latency",
+		"1-source mid leak detector",
+		"gate is holding",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("text output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestRunMemoryHealth_LeakSignalFlipsWhenPromoteFires is the
+// load-bearing test for the leak detector's operator-facing message.
+// A clean cortex shows "gate is holding"; the moment a 1-source
+// trace is promoted to mid, the message must flip to the warn line.
+// If the threshold check ever inverts this would silently mask leaks.
+func TestRunMemoryHealth_LeakSignalFlipsWhenPromoteFires(t *testing.T) {
+	cx := newCortexForHealth(t, "leaktest")
+
+	src := trace.New("source", "note", "", nil, "body")
+	if err := cx.Add(src); err != nil {
+		t.Fatalf("Add src: %v", err)
+	}
+	leaker := trace.New("leaker", "note", "", nil, "body")
+	leaker.DerivedFrom = []string{src.ID}
+	if err := cx.Add(leaker); err != nil {
+		t.Fatalf("Add leaker: %v", err)
+	}
+	if err := cx.Promote(leaker.ID, trace.TierMid); err != nil {
+		t.Fatalf("Promote: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := runMemoryHealth(&buf, cx, "24h", "text"); err != nil {
+		t.Fatalf("runMemoryHealth: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "recent leak") {
+		t.Errorf("expected leak warning in output, got:\n%s", out)
+	}
+	if strings.Contains(out, "gate is holding") {
+		t.Errorf("'gate is holding' shouldn't appear when PromotedLast7d > 0:\n%s", out)
+	}
+}
+
+// TestRunMemoryHealth_InvalidOutput surfaces a typo in --output as a
+// clear error rather than silently falling through to text rendering.
+func TestRunMemoryHealth_InvalidOutput(t *testing.T) {
+	cx := newCortexForHealth(t, "errtest")
+	var buf bytes.Buffer
+	err := runMemoryHealth(&buf, cx, "24h", "yaml")
+	if err == nil {
+		t.Fatal("expected error for unsupported --output, got nil")
+	}
+	if !strings.Contains(err.Error(), "yaml") {
+		t.Errorf("error should name the bad value: %v", err)
+	}
+}

--- a/internal/cli/cmd_memory_popular_test.go
+++ b/internal/cli/cmd_memory_popular_test.go
@@ -1,0 +1,99 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Fail-Safe/Noema/internal/cortex"
+	"github.com/Fail-Safe/Noema/internal/trace"
+)
+
+func TestRunMemoryPopular_JSONEnvelope(t *testing.T) {
+	cx := newCortexForHealth(t, "poptest")
+	var buf bytes.Buffer
+	if err := runMemoryPopular(&buf, cx, 10, "json"); err != nil {
+		t.Fatalf("runMemoryPopular: %v", err)
+	}
+	var got struct {
+		SchemaVersion int             `json:"schema_version"`
+		Top           int             `json:"top"`
+		Traces        json.RawMessage `json:"traces"`
+		Tags          json.RawMessage `json:"tags"`
+	}
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("unmarshal: %v\n%s", err, buf.String())
+	}
+	if got.SchemaVersion != 1 {
+		t.Errorf("schema_version = %d, want 1", got.SchemaVersion)
+	}
+	if got.Top != 10 {
+		t.Errorf("top = %d, want 10", got.Top)
+	}
+}
+
+// TestRunMemoryPopular_RenderShowsRealData seeds a tagged trace,
+// generates a search hit, and asserts the trace title and tag both
+// appear in the text output. Locks the CLI rendering against drift
+// from the underlying cortex method's column order.
+func TestRunMemoryPopular_RenderShowsRealData(t *testing.T) {
+	cx := newCortexForHealth(t, "popdata")
+
+	tr := trace.New("findme", "note", "", []string{"sample-tag"}, "body")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if _, err := cx.SearchAs("findme", cortex.ListOptions{}, cortex.ActorAgent, cortex.DefaultSearchHitTopN); err != nil {
+		t.Fatalf("SearchAs: %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := runMemoryPopular(&buf, cx, 5, "text"); err != nil {
+		t.Fatalf("runMemoryPopular: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "findme") {
+		t.Errorf("text output missing trace title:\n%s", out)
+	}
+	if !strings.Contains(out, "sample-tag") {
+		t.Errorf("text output missing tag:\n%s", out)
+	}
+}
+
+// TestRunMemoryPopular_EmptyShowsBothPlaceholders pins that even on
+// an empty cortex, both leaderboard sections render with explicit
+// "no engagement yet" placeholders rather than blank space — keeps
+// the layout legible the first time an operator runs the command.
+func TestRunMemoryPopular_EmptyShowsBothPlaceholders(t *testing.T) {
+	cx := newCortexForHealth(t, "popempty")
+	var buf bytes.Buffer
+	if err := runMemoryPopular(&buf, cx, 10, "text"); err != nil {
+		t.Fatalf("runMemoryPopular: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Top 10 traces") {
+		t.Errorf("missing traces section header:\n%s", out)
+	}
+	if !strings.Contains(out, "Top 10 tags") {
+		t.Errorf("missing tags section header:\n%s", out)
+	}
+	if !strings.Contains(out, "no traces with engagement yet") {
+		t.Errorf("missing traces empty placeholder:\n%s", out)
+	}
+	if !strings.Contains(out, "no tagged traces with engagement yet") {
+		t.Errorf("missing tags empty placeholder:\n%s", out)
+	}
+}
+
+func TestRunMemoryPopular_InvalidOutput(t *testing.T) {
+	cx := newCortexForHealth(t, "poperr")
+	var buf bytes.Buffer
+	err := runMemoryPopular(&buf, cx, 10, "yaml")
+	if err == nil {
+		t.Fatal("expected error for unsupported --output, got nil")
+	}
+	if !strings.Contains(err.Error(), "yaml") {
+		t.Errorf("error should name the bad value: %v", err)
+	}
+}

--- a/internal/cli/cmd_serve.go
+++ b/internal/cli/cmd_serve.go
@@ -230,8 +230,15 @@ func serveCmd() *cobra.Command {
 			// background-work lock so the cron scheduler only fires
 			// once per cortex even when multiple processes are serving
 			// MCP traffic.
+			//
+			// The in-flight registry is shared with the watchdog so
+			// the sweeper can recognize the local runner's active
+			// claims and skip them (Pattern B in the consolidation
+			// race analysis). Built unconditionally — both startups
+			// are cheap and a nil registry is safe-but-race-prone.
+			inFlight := consolidation.NewInFlightRegistry()
 			if gotLock && manifestErr == nil && m.Consolidation != nil && m.Consolidation.Enabled {
-				consolidator = startConsolidator(cx, m.Consolidation, m.Federation)
+				consolidator = startConsolidator(cx, m.Consolidation, m.Federation, inFlight)
 			}
 
 			// Eligibility loop: advertises this cortex's consolidation
@@ -251,7 +258,7 @@ func serveCmd() *cobra.Command {
 			// need a parallel sweeper.
 			if gotLock && manifestErr == nil && m.Consolidation != nil && m.Consolidation.Enabled &&
 				m.Federation != nil && len(m.Federation.Peers) > 0 {
-				watchdog = startWatchdog(cx, m.Consolidation)
+				watchdog = startWatchdog(cx, m.Consolidation, m.Federation, inFlight)
 			}
 
 			switch transport {
@@ -468,7 +475,13 @@ func startWatcher(cx *cortex.Cortex, cfg *cortex.WatchConfig) *watch.Watcher {
 // actually runs a cycle. Single-node cortexes skip the wrapper — the
 // gate would work there too, but it would emit a Claim+Success pair on
 // every pass for a degenerate election with a single participant.
-func startConsolidator(cx *cortex.Cortex, cfg *cortex.ConsolidationConfig, fed *cortex.FederationConfig) *consolidation.Agent {
+//
+// registry is the process-local in-flight tracker shared with the
+// watchdog (built once in the caller). It is consulted by the watchdog
+// to skip windows the local runner is currently executing, eliminating
+// the same-peer race where a Sweep tick fires between the inner pass
+// completing and the Success event being emitted.
+func startConsolidator(cx *cortex.Cortex, cfg *cortex.ConsolidationConfig, fed *cortex.FederationConfig, registry *consolidation.InFlightRegistry) *consolidation.Agent {
 	if cfg == nil || !cfg.Enabled {
 		return nil
 	}
@@ -540,7 +553,7 @@ func startConsolidator(cx *cortex.Cortex, cfg *cortex.ConsolidationConfig, fed *
 			Emitter:     cx,
 			Log:         logger,
 		})
-		pass = consolidation.WithElection(pass, election, logger)
+		pass = consolidation.WithElection(pass, election, registry, logger)
 		fmt.Fprintf(os.Stderr, "[consolidation] election gate enabled (peers=%d quiet=%s)\n",
 			len(peerNames), 2*interval)
 	}
@@ -617,20 +630,41 @@ func startEligibility(cx *cortex.Cortex, cfg *cortex.ConsolidationConfig, fed *c
 // pass trips the watchdog before the local consolidator emits success.
 // Sweep cadence is still an internal default (1 minute) — promoting
 // that to manifest config can wait until someone needs it.
-func startWatchdog(cx *cortex.Cortex, cfg *cortex.ConsolidationConfig) *consolidation.Watchdog {
+func startWatchdog(cx *cortex.Cortex, cfg *cortex.ConsolidationConfig, fed *cortex.FederationConfig, registry *consolidation.InFlightRegistry) *consolidation.Watchdog {
 	logger := func(format string, args ...any) {
 		fmt.Fprintf(os.Stderr, format+"\n", args...)
 	}
 	timeout := cfg.EffectiveWatchdogTimeout()
+
+	// Remote claims need an extra grace period so federation sync has
+	// time to deliver the runner's Success before the observer's
+	// watchdog ticks. Without it, every long-running pass produces one
+	// spurious watchdog_expired fail per observer whose sync interval
+	// hadn't yet caught up. The 2 × interval default mirrors the
+	// election quiet-period and the syncer's worst-case staleness.
+	remoteGrace := time.Duration(0)
+	if fed != nil && len(fed.Peers) > 0 {
+		interval := 30 * time.Second
+		if fed.Interval != "" {
+			if parsed, err := time.ParseDuration(fed.Interval); err == nil && parsed > 0 {
+				interval = parsed
+			}
+		}
+		remoteGrace = 2 * interval
+	}
+
 	w := consolidation.NewWatchdog(consolidation.WatchdogConfig{
 		DB:            cx.DB.DB,
 		Emitter:       cx,
 		LocalCortexID: cx.ID,
 		Timeout:       timeout,
+		RemoteGrace:   remoteGrace,
+		Registry:      registry,
 		Log:           logger,
 	})
 	w.Start()
-	fmt.Fprintf(os.Stderr, "[consolidation] watchdog started (timeout=%s)\n", timeout)
+	fmt.Fprintf(os.Stderr, "[consolidation] watchdog started (timeout=%s remote_grace=%s)\n",
+		timeout, remoteGrace)
 	return w
 }
 

--- a/internal/cli/cmd_sync.go
+++ b/internal/cli/cmd_sync.go
@@ -33,14 +33,27 @@ left the index pointing at files that no longer exist.`,
 			}
 
 			if recover {
-				fmt.Printf("Added: %d  Updated: %d  Recovered: %d  Orphaned: %d\n",
-					result.Added, result.Updated, result.Recovered, result.Orphaned)
+				fmt.Printf("Added: %d  Updated: %d  Drifted: %d  Recovered: %d  Orphaned: %d\n",
+					result.Added, result.Updated, result.Drifted, result.Recovered, result.Orphaned)
 			} else {
-				fmt.Printf("Added: %d  Updated: %d  Orphaned: %d\n",
-					result.Added, result.Updated, result.Orphaned)
+				fmt.Printf("Added: %d  Updated: %d  Drifted: %d  Orphaned: %d\n",
+					result.Added, result.Updated, result.Drifted, result.Orphaned)
 			}
 			if result.Recovered > 0 {
 				fmt.Println("Note: recovered entries had missing files that were rebuilt from the local event log.")
+			}
+			if result.Drifted > 0 {
+				fmt.Println("Note: drifted entries are long-tier traces whose on-disk files differ from the DB.")
+				fmt.Println("      The DB row is left untouched (long-tier is immutable). Visibility was still reconciled.")
+				fmt.Println("      Most common cause: federation-inherited rows whose origin name matches this")
+				fmt.Println("      cortex but whose cortex_id was correctly captured from the originating peer.")
+				fmt.Println("      Use `noema get <id>` to inspect each trace's current file body. Drifted IDs:")
+				for _, id := range result.DriftedIDs {
+					fmt.Printf("        %s\n", id)
+				}
+				if result.Drifted > len(result.DriftedIDs) {
+					fmt.Printf("        … and %d more\n", result.Drifted-len(result.DriftedIDs))
+				}
 			}
 			if result.Orphaned > 0 {
 				fmt.Println("Note: orphaned entries are in the database but have no file on disk.")

--- a/internal/consolidation/inflight.go
+++ b/internal/consolidation/inflight.go
@@ -1,0 +1,68 @@
+package consolidation
+
+import "sync"
+
+// InFlightRegistry tracks consolidation windows the local pass-gate has
+// claimed but not yet emitted a terminal (success/fail) event for. The
+// watchdog consults it to skip the local runner's own active claims, so
+// a sweep that fires while the runner is mid-pass cannot race ahead of
+// the pending Success event and emit a spurious watchdog_expired fail.
+//
+// The registry is process-local and intentionally not persisted. A
+// crash mid-pass leaves the claim with no Success/Fail in the event
+// log; the next process boot starts with an empty registry, and the
+// watchdog correctly observes the orphan and closes it out (the very
+// situation the watchdog exists for). Persisting would defeat that.
+//
+// Safe for concurrent use; the pass-gate's Begin and the watchdog's
+// IsActive routinely race in production.
+type InFlightRegistry struct {
+	mu      sync.Mutex
+	windows map[string]struct{}
+}
+
+// NewInFlightRegistry returns a ready-to-use registry. The zero value
+// is also usable for tests that want to assert the watchdog tolerates a
+// nil registry (the production wiring always supplies one).
+func NewInFlightRegistry() *InFlightRegistry {
+	return &InFlightRegistry{windows: make(map[string]struct{})}
+}
+
+// Begin records that the local runner is about to invoke the inner
+// PassFn for windowID. Pair with End in a defer so a panic in the
+// inner function doesn't leave a stuck entry behind.
+func (r *InFlightRegistry) Begin(windowID string) {
+	if r == nil || windowID == "" {
+		return
+	}
+	r.mu.Lock()
+	if r.windows == nil {
+		r.windows = make(map[string]struct{})
+	}
+	r.windows[windowID] = struct{}{}
+	r.mu.Unlock()
+}
+
+// End clears the in-flight marker for windowID. Idempotent: calling
+// End on an unknown window is a no-op so defer chains stay simple.
+func (r *InFlightRegistry) End(windowID string) {
+	if r == nil || windowID == "" {
+		return
+	}
+	r.mu.Lock()
+	delete(r.windows, windowID)
+	r.mu.Unlock()
+}
+
+// IsActive reports whether the local runner is currently executing
+// windowID. The watchdog checks this before emitting a fail; a true
+// answer means "trust the runner, the Success event is on its way."
+func (r *InFlightRegistry) IsActive(windowID string) bool {
+	if r == nil || windowID == "" {
+		return false
+	}
+	r.mu.Lock()
+	_, ok := r.windows[windowID]
+	r.mu.Unlock()
+	return ok
+}

--- a/internal/consolidation/pass_gate.go
+++ b/internal/consolidation/pass_gate.go
@@ -39,7 +39,7 @@ import (
 // wrapper degenerates to "emit Claim, brief sleep, emit Success
 // around the pass" — correct but mildly wasteful. Phase 4 can add a
 // no-peers fast path if the overhead ever matters.
-func WithElection(inner PassFn, election *Election, log func(format string, args ...any)) PassFn {
+func WithElection(inner PassFn, election *Election, registry *InFlightRegistry, log func(format string, args ...any)) PassFn {
 	if log == nil {
 		log = func(string, ...any) {}
 	}
@@ -77,6 +77,13 @@ func WithElection(inner PassFn, election *Election, log func(format string, args
 			_ = election.Fail(windowID, reason)
 			return nil
 		}
+
+		// Mark the window in-flight before invoking inner() so the
+		// watchdog's Sweep can recognize this peer's own active pass
+		// and skip it. Cleared in a defer so a panic in inner() (or
+		// in Success/Fail emission) still releases the marker.
+		registry.Begin(windowID)
+		defer registry.End(windowID)
 
 		log("[consolidation] running as elected winner (trigger=%s window=%s)",
 			trigger, windowID)

--- a/internal/consolidation/pass_gate_test.go
+++ b/internal/consolidation/pass_gate_test.go
@@ -38,7 +38,7 @@ func TestWithElection_SkipsWhenNotElected(t *testing.T) {
 	})
 
 	inner := &callTracker{}
-	wrapped := consolidation.WithElection(inner.pass, e, nil)
+	wrapped := consolidation.WithElection(inner.pass, e, nil, nil)
 
 	if err := wrapped(context.Background(), "cron"); err != nil {
 		t.Fatalf("wrapped: %v", err)
@@ -70,7 +70,7 @@ func TestWithElection_RunsWhenElected(t *testing.T) {
 	})
 
 	inner := &callTracker{}
-	wrapped := consolidation.WithElection(inner.pass, e, nil)
+	wrapped := consolidation.WithElection(inner.pass, e, nil, nil)
 
 	if err := wrapped(context.Background(), "cron"); err != nil {
 		t.Fatalf("wrapped: %v", err)
@@ -105,7 +105,7 @@ func TestWithElection_EmitsFailOnPassError(t *testing.T) {
 
 	passErr := errors.New("LLM backend returned 500")
 	inner := &callTracker{err: passErr}
-	wrapped := consolidation.WithElection(inner.pass, e, nil)
+	wrapped := consolidation.WithElection(inner.pass, e, nil, nil)
 
 	err := wrapped(context.Background(), "cron")
 	if err == nil || !errors.Is(err, passErr) {
@@ -138,7 +138,7 @@ func TestWithElection_HonorsContextCancellationDuringQuietPeriod(t *testing.T) {
 	})
 
 	inner := &callTracker{}
-	wrapped := consolidation.WithElection(inner.pass, e, nil)
+	wrapped := consolidation.WithElection(inner.pass, e, nil, nil)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // pre-cancel so the sleep returns immediately
@@ -217,7 +217,7 @@ func TestWithElection_EmitsNoWinnerAtRecheck(t *testing.T) {
 	})
 
 	inner := &callTracker{}
-	wrapped := consolidation.WithElection(inner.pass, e, nil)
+	wrapped := consolidation.WithElection(inner.pass, e, nil, nil)
 
 	// Demote local rank to 0 partway through the quiet period so the
 	// recheck finds zero eligible peers.
@@ -260,7 +260,7 @@ func TestWithElection_EmitsPeerOutrankedAtRecheck(t *testing.T) {
 	})
 
 	inner := &callTracker{}
-	wrapped := consolidation.WithElection(inner.pass, e, nil)
+	wrapped := consolidation.WithElection(inner.pass, e, nil, nil)
 
 	// Higher-ranked peer surfaces during the quiet wait.
 	go func() {

--- a/internal/consolidation/watchdog.go
+++ b/internal/consolidation/watchdog.go
@@ -47,6 +47,29 @@ type WatchdogConfig struct {
 	// closed out. Zero defaults to defaultWatchdogInterval.
 	Interval time.Duration
 
+	// RemoteGrace is added to Timeout when evaluating claims emitted by
+	// a peer other than LocalCortexID. The motivation is the
+	// observer-side race in §14 of the consolidation plan: a peer's
+	// successful pass produces a Success event that takes one
+	// federation.interval to propagate. Without an extra grace, every
+	// observer's watchdog tick that falls between Timeout-elapsed and
+	// Success-arrived emits a spurious watchdog_expired fail, and
+	// `consolidation_health.totals.fail` ends up double-counting the
+	// completed pass by exactly the number of observers whose sync
+	// hadn't caught up. Recommend setting to ~2 × federation.interval;
+	// zero disables the grace (every claim, local or remote, gets the
+	// same Timeout).
+	RemoteGrace time.Duration
+
+	// Registry tracks windows the local pass-gate is currently
+	// executing. Sweep skips windows where IsActive(window) is true to
+	// kill the same-peer race: the runner is about to emit Success but
+	// the watchdog sweep saw the claim as orphaned because it ticked
+	// just before Success landed. A nil registry is permitted (tests
+	// and pre-wiring shims rely on it) and degrades to the previous
+	// race-prone behavior.
+	Registry *InFlightRegistry
+
 	// Now is injected for tests; zero defaults to time.Now.
 	Now func() time.Time
 
@@ -151,17 +174,47 @@ type orphanedClaim struct {
 // Not safe for concurrent invocation — the loop goroutine is the only
 // expected caller in production. The internal mutex serializes any
 // stray test calls against the loop.
+//
+// The SQL prefilter uses the LOCAL cutoff (now − Timeout) so it
+// returns every claim old enough for the local cortex to consider
+// closing. The Go filter then enforces the stricter remote cutoff
+// (now − (Timeout + RemoteGrace)) on claims attributed to a different
+// cortex, plus the in-flight registry check that protects this peer's
+// own active passes.
 func (w *Watchdog) Sweep() error {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 
-	cutoff := w.cfg.Now().Add(-w.cfg.Timeout).UTC().Format(time.RFC3339)
-	orphans, err := w.findOrphans(cutoff)
+	now := w.cfg.Now()
+	// "Older than X" reads as "timestamp earlier than now − X." The
+	// SQL filter uses the bound that lets the most rows through (the
+	// shorter age) so per-row policy can be applied in Go.
+	localCutoff := now.Add(-w.cfg.Timeout)
+	remoteCutoff := now.Add(-(w.cfg.Timeout + w.cfg.RemoteGrace))
+
+	orphans, err := w.findOrphans(localCutoff.UTC().Format(time.RFC3339))
 	if err != nil {
 		return fmt.Errorf("watchdog query: %w", err)
 	}
 
 	for _, o := range orphans {
+		if w.cfg.Registry.IsActive(o.WindowID) {
+			// Local runner is still executing this window; trust
+			// the runner. Pattern B (runner-Sweep race on the same
+			// peer) lives here.
+			continue
+		}
+		if w.cfg.RemoteGrace > 0 && o.WinnerID != w.cfg.LocalCortexID {
+			// Remote-emitted claim: defer until the federation-sync
+			// grace window has also elapsed. Pattern C (observer's
+			// watchdog firing before the runner's Success replicates)
+			// lives here.
+			claimedAt, perr := time.Parse(time.RFC3339, o.Timestamp)
+			if perr == nil && claimedAt.After(remoteCutoff) {
+				continue
+			}
+		}
+
 		// Each emission goes through the same EmitCoordinationEvent
 		// path used by Election, so the closing fail lands in the
 		// event log with the local cortex as the emitter and the

--- a/internal/consolidation/watchdog_test.go
+++ b/internal/consolidation/watchdog_test.go
@@ -269,3 +269,148 @@ func TestWatchdog_StopWithoutStartIsSafe(t *testing.T) {
 	})
 	w.Stop() // should be a no-op
 }
+
+// TestWatchdog_SkipsInFlightLocalClaim pins the Pattern B fix: when the
+// local pass-gate has registered a window as in-flight, the watchdog
+// must not close it out even if Timeout has elapsed. The runner is
+// about to emit Success; the watchdog beating it by milliseconds was
+// the actual production race we observed on 2026-05-15.
+func TestWatchdog_SkipsInFlightLocalClaim(t *testing.T) {
+	cx := buildWatchdogCortex(t)
+	// Emit the claim with cortex_id = local. EmitCoordinationEvent
+	// stamps cortex_id from the cortex itself, so the claim's
+	// WinnerID will match LocalCortexID below.
+	windowID := emitClaim(t, cx, cx.ID)
+
+	registry := consolidation.NewInFlightRegistry()
+	registry.Begin(windowID)
+	defer registry.End(windowID)
+
+	future := time.Now().Add(20 * time.Minute)
+	w := consolidation.NewWatchdog(consolidation.WatchdogConfig{
+		DB:            cx.DB.DB,
+		Emitter:       cx,
+		LocalCortexID: cx.ID,
+		Timeout:       10 * time.Minute,
+		Registry:      registry,
+		Now:           func() time.Time { return future },
+	})
+
+	if err := w.Sweep(); err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if got := countActions(t, cx, event.ActionConsolidationFail); got != 0 {
+		t.Errorf("fail events = %d, want 0 (registry says local runner is still executing)", got)
+	}
+}
+
+// TestWatchdog_RemoteGraceDefersClosure pins the Pattern C fix: a
+// remote-emitted claim must not be closed out until Timeout + RemoteGrace
+// has elapsed, giving federation sync time to deliver the runner's
+// Success event. Without this, every long-running pass produces one
+// spurious watchdog_expired fail per observer whose sync lagged.
+func TestWatchdog_RemoteGraceDefersClosure(t *testing.T) {
+	cx := buildWatchdogCortex(t)
+	// Different cortex_id than the local cortex so the row is treated
+	// as remote-emitted. emitClaim stamps the WinnerID into FailData,
+	// but EmitCoordinationEvent stamps the cortex_id column from the
+	// cortex's own ID — which for findOrphans IS the row's cortex_id.
+	// So this test exercises the local-cortex path; for the true
+	// remote case the row would have come through federation replay.
+	// We approximate by inserting a raw event with a foreign cortex_id.
+	otherCortexID := "01REMOTECORTEXIDXXXXXXXXXXX"
+	windowID := "01REMOTECLAIMWINDOWXXXXXXXX"
+	insertRawWatchdogEvent(t, cx, event.ActionConsolidationClaim, windowID,
+		time.Now().Add(-12*time.Minute), otherCortexID)
+
+	// Timeout has elapsed (12m > 10m) but Timeout+RemoteGrace has not
+	// (12m < 10m + 5m). The watchdog must hold off.
+	w := consolidation.NewWatchdog(consolidation.WatchdogConfig{
+		DB:            cx.DB.DB,
+		Emitter:       cx,
+		LocalCortexID: cx.ID,
+		Timeout:       10 * time.Minute,
+		RemoteGrace:   5 * time.Minute,
+	})
+	if err := w.Sweep(); err != nil {
+		t.Fatalf("Sweep within grace: %v", err)
+	}
+	if got := countActions(t, cx, event.ActionConsolidationFail); got != 0 {
+		t.Errorf("fail events within remote grace = %d, want 0", got)
+	}
+
+	// Past the grace window — now the watchdog should close it out.
+	future := time.Now().Add(20 * time.Minute)
+	w2 := consolidation.NewWatchdog(consolidation.WatchdogConfig{
+		DB:            cx.DB.DB,
+		Emitter:       cx,
+		LocalCortexID: cx.ID,
+		Timeout:       10 * time.Minute,
+		RemoteGrace:   5 * time.Minute,
+		Now:           func() time.Time { return future },
+	})
+	if err := w2.Sweep(); err != nil {
+		t.Fatalf("Sweep past grace: %v", err)
+	}
+	if got := countActions(t, cx, event.ActionConsolidationFail); got != 1 {
+		t.Errorf("fail events past remote grace = %d, want 1", got)
+	}
+}
+
+// TestWatchdog_LocalClaimUsesStrictTimeout pins that RemoteGrace does
+// NOT delay closure of the local cortex's own orphaned claims. Only
+// remote claims need the federation-sync buffer; local claims racing
+// the runner are handled by the InFlightRegistry instead.
+func TestWatchdog_LocalClaimUsesStrictTimeout(t *testing.T) {
+	cx := buildWatchdogCortex(t)
+	// Local-emitted claim that has exceeded Timeout but not yet
+	// Timeout+RemoteGrace. The registry is empty (no in-flight pass),
+	// so the watchdog should close it on the strict timeout despite
+	// the configured remote grace.
+	windowID := emitClaim(t, cx, cx.ID)
+
+	future := time.Now().Add(11 * time.Minute) // past 10m timeout, within 10+5m
+	w := consolidation.NewWatchdog(consolidation.WatchdogConfig{
+		DB:            cx.DB.DB,
+		Emitter:       cx,
+		LocalCortexID: cx.ID,
+		Timeout:       10 * time.Minute,
+		RemoteGrace:   5 * time.Minute,
+		Registry:      consolidation.NewInFlightRegistry(),
+		Now:           func() time.Time { return future },
+	})
+	if err := w.Sweep(); err != nil {
+		t.Fatalf("Sweep: %v", err)
+	}
+	if got := countActions(t, cx, event.ActionConsolidationFail); got != 1 {
+		t.Errorf("fail events = %d, want 1 (local claim past strict timeout, registry empty)", got)
+	}
+	// Sanity: the closed window should be the one we emitted.
+	if r := findFailReason(t, cx, windowID); r != consolidation.FailReasonWatchdogExpired {
+		t.Errorf("fail reason for %s = %q, want %q", windowID, r, consolidation.FailReasonWatchdogExpired)
+	}
+}
+
+// insertRawWatchdogEvent writes an events row with a foreign cortex_id
+// so tests can exercise the "claim emitted by a remote peer" code path
+// without standing up a federation syncer. EmitCoordinationEvent
+// always stamps the LOCAL cortex_id, so the production-path emitClaim
+// helper can't produce a remote-attributed row.
+func insertRawWatchdogEvent(t *testing.T, cx *consolidationCortex, action event.Action, windowID string, ts time.Time, cortexID string) {
+	t.Helper()
+	payload := `{"window_id":"` + windowID + `","cortex_id":"` + cortexID + `"}`
+	id := "test-" + windowID + "-" + string(action)
+	_, err := cx.DB.Exec(
+		`INSERT INTO events (id, action, trace_id, origin, timestamp, data, vclock, cortex_id)
+		 VALUES (?, ?, ?, ?, ?, ?, '{}', ?)`,
+		id, string(action), windowID, "remote-peer", ts.UTC().Format(time.RFC3339), payload, cortexID,
+	)
+	if err != nil {
+		t.Fatalf("insert raw event: %v", err)
+	}
+}
+
+// consolidationCortex is a narrow alias so insertRawWatchdogEvent can
+// accept the *cortex.Cortex from buildWatchdogCortex without dragging
+// the cortex package import into the helper signature.
+type consolidationCortex = cortex.Cortex

--- a/internal/cortex/cortex.go
+++ b/internal/cortex/cortex.go
@@ -1985,6 +1985,19 @@ type SyncResult struct {
 	Updated   int // files found on disk and already in DB (re-synced)
 	Recovered int // orphaned DB rows whose files were rebuilt from the event log
 	Orphaned  int // IDs in DB with no corresponding file on disk (after recovery)
+	// Drifted counts long-tier traces whose on-disk file differs from the DB
+	// row in an immutable field (title, type, body hash, etc.). Sync refuses
+	// to reconcile such drift — the long-tier immutability trigger would
+	// abort, and even if it didn't, the right surface for "long-tier file
+	// drifted" is `noema verify drift`, not silent overwrite in either
+	// direction. Drifted rows still get archive/trash visibility reconciled.
+	// Surface them in the CLI so users know to investigate.
+	Drifted int
+	// DriftedIDs lists the IDs of drifted long-tier traces, in walk order.
+	// Capped at 10 to keep terminal output manageable on a cortex with a
+	// pathological number of drifted rows; the full set is recoverable via
+	// `noema verify drift` if needed.
+	DriftedIDs []string
 }
 
 // SyncOptions controls optional Sync behaviors.
@@ -1993,6 +2006,41 @@ type SyncOptions struct {
 	// rows from the local event log. Off by default so manual `rm` of a trace
 	// file remains a valid way to mark it for cleanup.
 	Recover bool
+}
+
+// longTierDrifted reports whether the on-disk trace's immutable fields
+// disagree with the DB row. Mirrors the WHEN clause of
+// trg_long_term_immutable (migration 013) so the function returns true
+// in exactly the same cases that would trip the trigger. Kept in lockstep
+// with the migration: a new locked field added to the trigger MUST also
+// be added here, otherwise the Drifted counter under-reports.
+//
+// existingCortexID is the DB's current cortex_id for the row (not on the
+// Row struct, so the caller queries it separately). The most common
+// real-world drift is federation-inherited rows where the file's origin
+// name matches the local cortex's display name but the DB's cortex_id
+// was correctly captured from the originating peer — Sync's resolver
+// would otherwise overwrite that ID, which the trigger blocks.
+//
+// Tags and lineage aren't on this list: they live in separate tables
+// (trace_tags, trace_lineage) that the trigger doesn't guard. Sync
+// still won't reconcile them when this function returns true — see the
+// callsite for why ("their content would point at a drifted-but-not-
+// applied state").
+func longTierDrifted(existing *Row, existingCortexID string, t *trace.Trace, contentHash, computedCortexID string) bool {
+	if existing == nil {
+		return false
+	}
+	return existing.Title != t.Title ||
+		existing.Type != t.Type ||
+		existing.Author != t.Author ||
+		existing.Origin != t.Origin ||
+		existingCortexID != computedCortexID ||
+		existing.ContentHash != contentHash ||
+		existing.UpdatedAt != t.Updated ||
+		existing.CreatedAt != t.Created ||
+		existing.SourceLocked != t.SourceLocked ||
+		existing.SourceHash != t.SourceHash
 }
 
 // Sync reconciles the database with the current state of the markdown files on
@@ -2082,7 +2130,14 @@ func (c *Cortex) SyncWithOptions(opts SyncOptions) (SyncResult, error) {
 		}
 
 		contentHash := trace.ContentHash(t.Body)
-		if t.ContentHash != contentHash {
+		// Long-tier traces are DB-level immutable: refuse to rewrite the
+		// file's content_hash frontmatter here. The hash-heal step is
+		// fine for short/mid traces (it self-repairs a metadata row that
+		// fell out of sync with the body) but for long-tier files even a
+		// frontmatter touch counts as mutation. Leave drift for the
+		// drift checker to surface.
+		isLongTier := dbErr == nil && existing != nil && existing.Tier == trace.TierLong
+		if t.ContentHash != contentHash && !isLongTier {
 			t.ContentHash = contentHash
 			if err := t.Write(e.path); err != nil {
 				return result, fmt.Errorf("updating content hash for %s: %w", t.ID, err)
@@ -2099,6 +2154,56 @@ func (c *Cortex) SyncWithOptions(opts SyncOptions) (SyncResult, error) {
 				return result, fmt.Errorf("inserting %s: %w", t.ID, err)
 			}
 			result.Added++
+		} else if isLongTier {
+			// Long-tier rows are immutable by trigger. ALWAYS use the
+			// narrow UPDATE that touches only the columns the trigger
+			// permits (archived_at, trashed_at). The blanket UPDATE
+			// path below is never safe here: even an apparently-no-op
+			// SET on a locked column trips trg_long_term_immutable
+			// when the OLD and NEW values disagree on a column we
+			// didn't think to check (the live regression was
+			// federation-inherited rows where the file's origin name
+			// matches the local cortex but the DB's cortex_id was
+			// correctly captured from the originating peer — Sync's
+			// resolver would overwrite that, the trigger aborts, and
+			// the entire run dies).
+			//
+			// Detect drift separately so the Drifted counter is right.
+			// The narrow UPDATE runs the same way either way; drift
+			// detection only affects the reported counter and the
+			// decision to skip tag/lineage/FTS reconciliation (which
+			// would point at a drifted-but-not-applied state).
+			var existingCortexID string
+			if err := tx.QueryRow(
+				`SELECT COALESCE(cortex_id, '') FROM traces WHERE id = ?`, t.ID,
+			).Scan(&existingCortexID); err != nil {
+				// Empty string is a fine fallback; the drift comparison
+				// still works (an empty existing vs. a non-empty computed
+				// reads as drift, which is the right answer when the row
+				// is mid-migration).
+				existingCortexID = ""
+			}
+			drifted := longTierDrifted(existing, existingCortexID, t, contentHash, cortexID)
+
+			_, err = tx.Exec(
+				`UPDATE traces SET archived_at=?, trashed_at=? WHERE id=?`,
+				archivedAt, trashedAt, t.ID,
+			)
+			if err != nil {
+				tx.Rollback()
+				return result, fmt.Errorf("reconciling visibility for long-tier %s: %w", t.ID, err)
+			}
+			if drifted {
+				result.Drifted++
+				if len(result.DriftedIDs) < 10 {
+					result.DriftedIDs = append(result.DriftedIDs, t.ID)
+				}
+				if err := tx.Commit(); err != nil {
+					return result, err
+				}
+				continue
+			}
+			result.Updated++
 		} else {
 			// Already in DB — update metadata and reconcile state.
 			_, err = tx.Exec(

--- a/internal/cortex/cortex_test.go
+++ b/internal/cortex/cortex_test.go
@@ -1084,6 +1084,169 @@ func TestSync_PreservesExistingTimestamps(t *testing.T) {
 	}
 }
 
+// TestSync_LongTierDriftIsReportedNotAborted pins the fix for the
+// constraint-failure regression: a long-tier trace whose on-disk file
+// drifted from its DB row (because Obsidian re-saved it, federation
+// replayed a snapshot, an agent appended, …) used to crash the entire
+// Sync transaction with `constraint failed: long-term trace is immutable`.
+// Now Sync should count it in Drifted, leave the DB row untouched on the
+// locked columns, still reconcile visibility, and continue processing
+// the other files.
+func TestSync_LongTierDriftIsReportedNotAborted(t *testing.T) {
+	cx := setup(t)
+
+	// Long-tier trace, created directly at the long tier so we don't
+	// need to drive it through the promotion path.
+	tr := trace.New("Long-tier trace", "note", "agent-1", []string{"a"}, "Original body.")
+	tr.Tier = trace.TierLong
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	// And a short-tier trace that should still get processed even
+	// though the long-tier one drifts. If Sync aborts on the first
+	// drift, this row never reconciles and the test catches it.
+	tr2 := trace.New("Short-tier sibling", "note", "", nil, "Sibling body.")
+	if err := cx.Add(tr2); err != nil {
+		t.Fatalf("Add tr2: %v", err)
+	}
+	path2 := cx.TraceFile(tr2.ID, false)
+	parsed2, err := trace.ParseFile(path2)
+	if err != nil {
+		t.Fatalf("ParseFile tr2: %v", err)
+	}
+	parsed2.Title = "Short-tier sibling (renamed)"
+	if err := parsed2.Write(path2); err != nil {
+		t.Fatalf("Write tr2: %v", err)
+	}
+
+	// Edit the long-tier trace's file directly — simulates Obsidian /
+	// agent / external tool drift. Title change is enough to trip the
+	// immutability trigger via the old code path.
+	path := cx.TraceFile(tr.ID, false)
+	parsed, err := trace.ParseFile(path)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	parsed.Title = "Long-tier trace (drifted)"
+	parsed.Body = "Body rewritten by external tool."
+	if err := parsed.Write(path); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	result, err := cx.Sync()
+	if err != nil {
+		t.Fatalf("Sync must not error on long-tier drift: %v", err)
+	}
+	if result.Drifted != 1 {
+		t.Errorf("Drifted = %d, want 1", result.Drifted)
+	}
+	if len(result.DriftedIDs) != 1 || result.DriftedIDs[0] != tr.ID {
+		t.Errorf("DriftedIDs = %v, want [%s]", result.DriftedIDs, tr.ID)
+	}
+	if result.Updated != 1 {
+		t.Errorf("Updated = %d, want 1 (the short-tier sibling)", result.Updated)
+	}
+
+	// DB row for the long-tier trace must NOT carry the drifted title.
+	row, err := cx.Get(tr.ID)
+	if err != nil {
+		t.Fatalf("Get long-tier: %v", err)
+	}
+	if row.Title != "Long-tier trace" {
+		t.Errorf("Long-tier title was overwritten: got %q, want %q", row.Title, "Long-tier trace")
+	}
+
+	// Short-tier sibling MUST have been reconciled despite the drift.
+	row2, err := cx.Get(tr2.ID)
+	if err != nil {
+		t.Fatalf("Get short-tier: %v", err)
+	}
+	if row2.Title != "Short-tier sibling (renamed)" {
+		t.Errorf("Short-tier sibling was not reconciled: got %q, want %q",
+			row2.Title, "Short-tier sibling (renamed)")
+	}
+}
+
+// TestSync_LongTierWithoutDriftStillUpdatesVisibility pins that a
+// long-tier trace whose file matches the DB exactly is treated as a
+// normal Updated row (one cheap visibility reconciliation, no drift
+// noise). The previous behavior was the same; this test prevents a
+// future "always skip long-tier" overreaction to the drift fix.
+func TestSync_LongTierWithoutDriftStillUpdatesVisibility(t *testing.T) {
+	cx := setup(t)
+
+	tr := trace.New("Long-tier clean", "note", "", nil, "Body.")
+	tr.Tier = trace.TierLong
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	result, err := cx.Sync()
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if result.Drifted != 0 {
+		t.Errorf("Drifted = %d, want 0 (file matches DB)", result.Drifted)
+	}
+	if result.Updated != 1 {
+		t.Errorf("Updated = %d, want 1", result.Updated)
+	}
+}
+
+// TestSync_LongTierForeignCortexIDDoesNotAbort pins the live regression
+// from 2026-05-19: a long-tier trace whose DB row carries a foreign
+// cortex_id (federated in from a peer whose display name matches the
+// local cortex's display name) used to crash Sync because the resolver
+// computes cortex_id = local-ID from `origin == c.Name`, but the
+// trigger blocks any cortex_id change on long-tier rows. The first
+// version of the fix missed cortex_id in its drift check, so this case
+// fell through to the blanket UPDATE and re-tripped the trigger.
+//
+// Real-world setup: file frontmatter says `origin: agentbrain` (matches
+// local cortex name); DB row's cortex_id is a foreign ULID. Sync must
+// report drift, leave cortex_id alone, and not abort.
+func TestSync_LongTierForeignCortexIDDoesNotAbort(t *testing.T) {
+	cx := setup(t)
+
+	// Create the row as short-tier first so we can inject the foreign
+	// cortex_id without tripping the immutability trigger (it only
+	// fires when OLD.tier='long' AND NEW.tier='long'). Then flip tier
+	// to long in a single UPDATE that sets both columns at once.
+	tr := trace.New("Federation-inherited long-tier", "context", "hermes/paige", []string{"hermes-session"}, "Body.")
+	tr.Origin = cx.Name // mirrors the live bug: name matches, ID won't.
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	foreignCortexID := "01KNJX4991ASW6NNKS9BQHNCGB" // ai-1's ULID in the live report
+	if _, err := cx.DB.Exec(
+		`UPDATE traces SET cortex_id = ?, tier = 'long' WHERE id = ?`,
+		foreignCortexID, tr.ID,
+	); err != nil {
+		t.Fatalf("seeding foreign cortex_id at long tier: %v", err)
+	}
+
+	result, err := cx.Sync()
+	if err != nil {
+		t.Fatalf("Sync must not error on foreign cortex_id: %v", err)
+	}
+	if result.Drifted != 1 {
+		t.Errorf("Drifted = %d, want 1 (cortex_id mismatch is drift)", result.Drifted)
+	}
+
+	// cortex_id must remain the foreign value — that's the whole point
+	// of long-tier immutability.
+	var got string
+	if err := cx.DB.QueryRow(
+		`SELECT cortex_id FROM traces WHERE id = ?`, tr.ID,
+	).Scan(&got); err != nil {
+		t.Fatalf("reading cortex_id back: %v", err)
+	}
+	if got != foreignCortexID {
+		t.Errorf("cortex_id = %q, want %q (must not be overwritten)", got, foreignCortexID)
+	}
+}
+
 func TestUpdate(t *testing.T) {
 	cx := setup(t)
 

--- a/internal/cortex/observability.go
+++ b/internal/cortex/observability.go
@@ -1,0 +1,520 @@
+package cortex
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Fail-Safe/Noema/internal/event"
+	"github.com/Fail-Safe/Noema/internal/trace"
+)
+
+// ParseSince parses the standard observability lookback flag. Accepts
+// any duration string time.ParseDuration handles ("90m", "24h"), plus
+// "d" (days) and "w" (weeks) which the stdlib doesn't recognise. Used
+// by every CLI / MCP surface that takes a --since argument so a user
+// who types "7d" once finds it works everywhere — the design doc's
+// "--since <dur> universally" decision (§3).
+//
+// An empty string returns zero — interpreted by callers as "no window
+// / all time."
+func ParseSince(s string) (time.Duration, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, nil
+	}
+	// Strip a trailing "d" or "w" and multiply. We don't try to be
+	// clever about combined units like "1d12h" — if a user wants that
+	// they can pass "36h", which time.ParseDuration handles natively.
+	if n := len(s); n > 0 {
+		switch s[n-1] {
+		case 'd':
+			days, err := strconv.Atoi(s[:n-1])
+			if err == nil {
+				return time.Duration(days) * 24 * time.Hour, nil
+			}
+		case 'w':
+			weeks, err := strconv.Atoi(s[:n-1])
+			if err == nil {
+				return time.Duration(weeks) * 7 * 24 * time.Hour, nil
+			}
+		}
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid duration %q: use Go duration syntax (e.g. 24h, 90m) or days/weeks (7d, 2w)", s)
+	}
+	return d, nil
+}
+
+// ConsolidationActivity reports the consolidation pipeline's recent
+// behavior — election outcomes, promotions, and real distillation events
+// — bucketed by UTC day and totaled over the window. Lets an operator
+// answer "did consolidation actually do anything overnight, and was
+// any of it the LLM path?" without hand-writing SQL against the events
+// table.
+type ConsolidationActivity struct {
+	// Since is the lookback window. JSON-skipped so the wire format
+	// can use a human-readable string in SinceLabel instead of the
+	// default time.Duration encoding (nanoseconds as int64), which
+	// would silently mislead anyone treating the field name as a
+	// hint about its unit.
+	Since      time.Duration       `json:"-"`
+	SinceLabel string              `json:"since"` // "24h0m0s" — parseable via time.ParseDuration
+	SinceStart time.Time           `json:"since_start"`
+	Daily      []ConsolidationDay  `json:"daily"`
+	Totals     ConsolidationTotals `json:"totals"`
+}
+
+// ConsolidationDay buckets one UTC date's event counts. Days with zero
+// activity are omitted to keep the JSON compact — consumers should
+// treat a missing date as "no events that day" rather than "missing
+// data."
+//
+// LostElection splits the three "preempted" fail reasons (peer_outranked,
+// no_winner_at_recheck, context_canceled) out of Fail. The election gate
+// emits those when the local peer claimed but a higher-ranked peer was
+// going to run anyway — that's the gate working as designed, not a
+// pipeline error. Operators reading the surface needed a way to tell
+// "the LLM endpoint is flapping" apart from "two peers raced and the
+// other one won."
+type ConsolidationDay struct {
+	Date         string `json:"date"` // YYYY-MM-DD (UTC)
+	Success      int    `json:"success"`
+	Fail         int    `json:"fail"`
+	LostElection int    `json:"lost_election"`
+	Claim        int    `json:"claim"`
+	Promote      int    `json:"promote"`
+	Distill      int    `json:"distill"`
+}
+
+// ConsolidationTotals sums each action over the entire window.
+type ConsolidationTotals struct {
+	Success      int `json:"success"`
+	Fail         int `json:"fail"`
+	LostElection int `json:"lost_election"`
+	Claim        int `json:"claim"`
+	Promote      int `json:"promote"`
+	Distill      int `json:"distill"`
+}
+
+// preemptionReasons is the set of consolidation_fail reasons that
+// represent the election gate refusing to run (a peer outranked us, no
+// peer qualified at the recheck, or context cancellation) rather than
+// an actual pipeline error. Keeping the set in one place means a new
+// preemption reason added in election.go only needs to be mirrored
+// here; nothing else cares.
+var preemptionReasons = map[string]struct{}{
+	"peer_outranked":       {},
+	"no_winner_at_recheck": {},
+	"context_canceled":     {},
+}
+
+// PromotionLatency reports the distribution of time-to-promotion for
+// short→mid and mid→long transitions. Latency is computed in Go from
+// the event log rather than in SQL because mid→long requires walking
+// each trace's tier history to find the timestamp when it entered the
+// mid tier (a previous promote event, or created_at if it was born
+// there).
+type PromotionLatency struct {
+	ShortToMid PromotionStats `json:"short_to_mid"`
+	MidToLong  PromotionStats `json:"mid_to_long"`
+}
+
+// PromotionStats is the per-transition rollup. Durations serialize as
+// nanoseconds (Go's time.Duration default); the CLI text renderer
+// formats them as human-readable spans for terminal output.
+type PromotionStats struct {
+	Count int `json:"count"`
+	// Duration fields skip JSON serialization (would emit raw
+	// nanoseconds); the *Label sibling carries the same value as a
+	// parseable string ("129h36m12s"). Callers doing math use the
+	// time.Duration; JSON consumers parse the string with
+	// time.ParseDuration.
+	P50      time.Duration `json:"-"`
+	P50Label string        `json:"p50"`
+	P95      time.Duration `json:"-"`
+	P95Label string        `json:"p95"`
+}
+
+// PopularTrace is one row in the top-N-by-search-popularity table.
+// SearchHits and ReadCount are federation-wide aggregates (sum across
+// every peer's trace_usage row for this trace), matching the
+// convention EngagementStats already uses.
+type PopularTrace struct {
+	ID         string `json:"id"`
+	Title      string `json:"title"`
+	Type       string `json:"type"`
+	Tier       string `json:"tier"`
+	SearchHits int    `json:"search_hits"`
+	ReadCount  int    `json:"read_count"`
+}
+
+// TagSummary is one row in the per-tag activity table. TraceCount is
+// the number of distinct active traces carrying the tag; the
+// SearchHits / ReadCount / ModifyCount sums attribute the trace's
+// total signal to each of its tags, so a trace with three tags
+// contributes its 10 reads three times across the table (once per
+// tag). That's the right semantic for "which tags are accumulating
+// engagement" — a multi-tagged trace IS engagement for all of its
+// tags. Comparing two tag rows is fair because both columns use the
+// same attribution rule.
+type TagSummary struct {
+	Tag         string `json:"tag"`
+	TraceCount  int    `json:"trace_count"`
+	SearchHits  int    `json:"search_hits"`
+	ReadCount   int    `json:"read_count"`
+	ModifyCount int    `json:"modify_count"`
+}
+
+// TopSearchedTraces returns the top-N active traces ranked by
+// search_hit_count (primary) and read_count (tiebreaker). Cumulative
+// counters across all-time — a since-window filter doesn't apply
+// because the counter rows don't carry timestamps. If the question is
+// "what's hot lately" rather than "what's been hot all-time," the
+// answer needs a different table (per-day usage snapshots), which is
+// deferred to a future iteration.
+func (c *Cortex) TopSearchedTraces(n int) ([]PopularTrace, error) {
+	if n <= 0 {
+		n = 10
+	}
+	q := `
+		SELECT t.id, t.title, t.type, t.tier,
+		       COALESCE(SUM(u.search_hit_count), 0) AS hits,
+		       COALESCE(SUM(u.read_count), 0)       AS reads
+		FROM traces t
+		LEFT JOIN trace_usage u ON u.trace_id = t.id
+		WHERE t.archived_at IS NULL
+		  AND t.trashed_at IS NULL
+		  AND t.purged_at IS NULL
+		GROUP BY t.id
+		HAVING hits > 0 OR reads > 0
+		ORDER BY hits DESC, reads DESC, t.id ASC
+		LIMIT ?`
+	rows, err := c.DB.Query(q, n)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []PopularTrace
+	for rows.Next() {
+		var p PopularTrace
+		if err := rows.Scan(&p.ID, &p.Title, &p.Type, &p.Tier, &p.SearchHits, &p.ReadCount); err != nil {
+			return nil, err
+		}
+		out = append(out, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// TagActivity returns the top-N tags ranked by total engagement
+// (search hits primary, reads secondary). Empty cortex returns an
+// empty slice (not nil) so JSON serializes as `[]` rather than `null`
+// — JSON consumers shouldn't have to special-case absence.
+func (c *Cortex) TagActivity(n int) ([]TagSummary, error) {
+	if n <= 0 {
+		n = 20
+	}
+	q := `
+		SELECT tt.tag,
+		       COUNT(DISTINCT t.id)                AS trace_count,
+		       COALESCE(SUM(u.search_hit_count), 0) AS hits,
+		       COALESCE(SUM(u.read_count), 0)       AS reads,
+		       COALESCE(SUM(u.modify_count), 0)     AS mods
+		FROM trace_tags tt
+		JOIN traces t ON t.id = tt.trace_id
+		LEFT JOIN trace_usage u ON u.trace_id = t.id
+		WHERE t.archived_at IS NULL
+		  AND t.trashed_at IS NULL
+		  AND t.purged_at IS NULL
+		GROUP BY tt.tag
+		ORDER BY hits DESC, reads DESC, mods DESC, tt.tag ASC
+		LIMIT ?`
+	rows, err := c.DB.Query(q, n)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	out := []TagSummary{}
+	for rows.Next() {
+		var s TagSummary
+		if err := rows.Scan(&s.Tag, &s.TraceCount, &s.SearchHits, &s.ReadCount, &s.ModifyCount); err != nil {
+			return nil, err
+		}
+		out = append(out, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// OneSourceMidCount is the leak detector for the 1-source mid bucket.
+// PRs #86 and #90 closed two distinct paths that were promoting
+// single-derived-from traces past the heuristic; this surface lets us
+// see at a glance whether either gate ever leaks again. Current is
+// the live count; PromotedLast7d is the count of distinct traces that
+// landed in the mid tier with derived_from_count=1 within the last 7
+// days (the operationally useful signal — Current can grow only via
+// recent promotions, so a healthy gate keeps PromotedLast7d at zero).
+type OneSourceMidCount struct {
+	Current        int `json:"current"`
+	PromotedLast7d int `json:"promoted_last_7d"`
+}
+
+// ConsolidationActivity queries the events table for the consolidation
+// pipeline's recent actions, bucketed by UTC day. since is the
+// look-back window; a zero or negative duration is treated as "since
+// the beginning of the event log." Active traces only — purged
+// tombstones and archived rows are unaffected because their promote
+// events remain in the log as part of the immutable audit trail.
+func (c *Cortex) ConsolidationActivity(since time.Duration) (ConsolidationActivity, error) {
+	out := ConsolidationActivity{Since: since, SinceLabel: since.String(), Daily: []ConsolidationDay{}}
+
+	var args []any
+	where := `WHERE action IN (?, ?, ?, ?, ?)`
+	args = append(args,
+		string(event.ActionConsolidationSuccess),
+		string(event.ActionConsolidationFail),
+		string(event.ActionConsolidationClaim),
+		string(event.ActionPromote),
+		string(event.ActionConsolidate),
+	)
+	if since > 0 {
+		cutoff := time.Now().UTC().Add(-since)
+		out.SinceStart = cutoff
+		where += ` AND timestamp >= ?`
+		args = append(args, cutoff.Format(time.RFC3339))
+	}
+
+	// The reason column is only meaningful for ActionConsolidationFail
+	// rows; the COALESCE keeps the grouping stable for every other
+	// action (they all share an empty-string reason bucket). The cost
+	// of the extra GROUP BY column is a few more rows per day on a
+	// noisy cortex — well below any meaningful threshold.
+	q := `
+		SELECT substr(timestamp, 1, 10)                  AS date,
+		       action,
+		       COALESCE(json_extract(data, '$.reason'), '') AS reason,
+		       COUNT(*)
+		FROM events ` + where + `
+		GROUP BY date, action, reason
+		ORDER BY date`
+	rows, err := c.DB.Query(q, args...)
+	if err != nil {
+		return out, err
+	}
+	defer rows.Close()
+
+	byDate := map[string]*ConsolidationDay{}
+	for rows.Next() {
+		var date, action, reason string
+		var n int
+		if err := rows.Scan(&date, &action, &reason, &n); err != nil {
+			return out, err
+		}
+		d, ok := byDate[date]
+		if !ok {
+			d = &ConsolidationDay{Date: date}
+			byDate[date] = d
+		}
+		switch event.Action(action) {
+		case event.ActionConsolidationSuccess:
+			d.Success += n
+			out.Totals.Success += n
+		case event.ActionConsolidationFail:
+			if _, preempted := preemptionReasons[reason]; preempted {
+				d.LostElection += n
+				out.Totals.LostElection += n
+			} else {
+				d.Fail += n
+				out.Totals.Fail += n
+			}
+		case event.ActionConsolidationClaim:
+			d.Claim += n
+			out.Totals.Claim += n
+		case event.ActionPromote:
+			d.Promote += n
+			out.Totals.Promote += n
+		case event.ActionConsolidate:
+			d.Distill += n
+			out.Totals.Distill += n
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return out, err
+	}
+
+	dates := make([]string, 0, len(byDate))
+	for d := range byDate {
+		dates = append(dates, d)
+	}
+	sort.Strings(dates)
+	for _, d := range dates {
+		out.Daily = append(out.Daily, *byDate[d])
+	}
+	return out, nil
+}
+
+// PromotionLatency walks every promote event in the log and computes
+// the elapsed time since the trace entered the prior tier. short→mid
+// uses traces.created_at as the start (the vast majority of traces
+// are born at short). mid→long uses the most recent promote-to-mid
+// event for that trace, falling back to created_at for traces created
+// directly at mid (manual promotion). The result is sorted in Go to
+// derive p50/p95.
+func (c *Cortex) PromotionLatency() (PromotionLatency, error) {
+	var out PromotionLatency
+
+	q := `
+		SELECT
+			e.trace_id,
+			e.timestamp,
+			COALESCE(json_extract(e.data, '$.from'), '') AS from_tier,
+			COALESCE(json_extract(e.data, '$.to'), '')   AS to_tier,
+			t.created_at
+		FROM events e
+		JOIN traces t ON t.id = e.trace_id
+		WHERE e.action = ?
+		ORDER BY e.trace_id, e.timestamp`
+	rows, err := c.DB.Query(q, string(event.ActionPromote))
+	if err != nil {
+		return out, err
+	}
+	defer rows.Close()
+
+	type promote struct {
+		ts            time.Time
+		from, to      string
+		traceCreated  time.Time
+	}
+	byTrace := map[string][]promote{}
+	for rows.Next() {
+		var id, tsStr, from, to, createdStr string
+		if err := rows.Scan(&id, &tsStr, &from, &to, &createdStr); err != nil {
+			return out, err
+		}
+		ts, err := time.Parse(time.RFC3339, tsStr)
+		if err != nil {
+			continue
+		}
+		created, err := time.Parse(time.RFC3339, createdStr)
+		if err != nil {
+			continue
+		}
+		byTrace[id] = append(byTrace[id], promote{ts: ts, from: from, to: to, traceCreated: created})
+	}
+	if err := rows.Err(); err != nil {
+		return out, err
+	}
+
+	var shortToMid, midToLong []time.Duration
+	for _, events := range byTrace {
+		// In-order already (SQL ORDER BY trace_id, timestamp). Walk each
+		// trace's promotes, tracking the timestamp at which it entered
+		// the mid tier so we can measure mid→long against that.
+		midEntry := time.Time{}
+		for _, p := range events {
+			if p.to == trace.TierMid && p.from == trace.TierShort {
+				shortToMid = append(shortToMid, p.ts.Sub(p.traceCreated))
+				midEntry = p.ts
+			}
+			if p.to == trace.TierLong && p.from == trace.TierMid {
+				start := midEntry
+				if start.IsZero() {
+					// Trace was created at mid (no prior promote event);
+					// best available start is created_at.
+					start = p.traceCreated
+				}
+				midToLong = append(midToLong, p.ts.Sub(start))
+			}
+		}
+	}
+
+	out.ShortToMid = summarize(shortToMid)
+	out.MidToLong = summarize(midToLong)
+	return out, nil
+}
+
+// summarize computes count + p50 + p95 from an unsorted slice of
+// durations. Empty input returns the zero struct. Percentile uses the
+// nearest-rank method (ceil(p × N)) since linear interpolation buys
+// nothing on operator-facing latency reports and complicates tests.
+func summarize(ds []time.Duration) PromotionStats {
+	if len(ds) == 0 {
+		return PromotionStats{}
+	}
+	sort.Slice(ds, func(i, j int) bool { return ds[i] < ds[j] })
+	pick := func(p float64) time.Duration {
+		idx := int(float64(len(ds))*p + 0.999999) - 1
+		if idx < 0 {
+			idx = 0
+		}
+		if idx >= len(ds) {
+			idx = len(ds) - 1
+		}
+		return ds[idx]
+	}
+	p50 := pick(0.50)
+	p95 := pick(0.95)
+	return PromotionStats{
+		Count:    len(ds),
+		P50:      p50,
+		P50Label: p50.String(),
+		P95:      p95,
+		P95Label: p95.String(),
+	}
+}
+
+// OneSourceMidCount returns the current count of active mid-tier
+// traces with derived_from_count == 1 (the bucket PR #86 narrowed but
+// can't fully eliminate) and the count of distinct traces promoted
+// into that bucket within the last 7 days. A healthy gate keeps
+// PromotedLast7d at zero; a non-zero value names the operationally
+// useful signal "the 1-source leak path is open again, go investigate."
+func (c *Cortex) OneSourceMidCount() (OneSourceMidCount, error) {
+	var out OneSourceMidCount
+
+	q1 := `
+		SELECT COUNT(*)
+		FROM traces t
+		JOIN (
+			SELECT trace_id, COUNT(*) AS n
+			FROM trace_lineage
+			GROUP BY trace_id
+		) l ON l.trace_id = t.id
+		WHERE t.tier = ?
+		  AND t.archived_at IS NULL
+		  AND t.trashed_at IS NULL
+		  AND t.purged_at IS NULL
+		  AND l.n = 1`
+	if err := c.DB.QueryRow(q1, trace.TierMid).Scan(&out.Current); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return out, fmt.Errorf("current count: %w", err)
+	}
+
+	cutoff := time.Now().UTC().Add(-7 * 24 * time.Hour).Format(time.RFC3339)
+	q2 := `
+		SELECT COUNT(DISTINCT e.trace_id)
+		FROM events e
+		JOIN (
+			SELECT trace_id, COUNT(*) AS n
+			FROM trace_lineage
+			GROUP BY trace_id
+		) l ON l.trace_id = e.trace_id
+		WHERE e.action = ?
+		  AND COALESCE(json_extract(e.data, '$.to'), '') = ?
+		  AND e.timestamp >= ?
+		  AND l.n = 1`
+	if err := c.DB.QueryRow(q2, string(event.ActionPromote), trace.TierMid, cutoff).Scan(&out.PromotedLast7d); err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return out, fmt.Errorf("recent promotes: %w", err)
+	}
+
+	return out, nil
+}

--- a/internal/cortex/observability_test.go
+++ b/internal/cortex/observability_test.go
@@ -1,0 +1,540 @@
+package cortex_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Fail-Safe/Noema/internal/cortex"
+	"github.com/Fail-Safe/Noema/internal/event"
+	"github.com/Fail-Safe/Noema/internal/trace"
+)
+
+// insertRawEvent writes an event row directly so tests can backdate
+// timestamps and exercise the time-window filters. Uses the same
+// columns the production emitter writes via internal/cortex/cortex.go
+// emitEvent (id, action, trace_id, origin, timestamp, data, vclock,
+// cortex_id). Production callers go through emitEvent inside a
+// transaction; tests are the only legitimate direct-insert path.
+func insertRawEvent(t *testing.T, cx *cortex.Cortex, action event.Action, traceID string, ts time.Time, data map[string]any) {
+	t.Helper()
+	payload := []byte("{}")
+	if data != nil {
+		b, err := json.Marshal(data)
+		if err != nil {
+			t.Fatalf("marshal event data: %v", err)
+		}
+		payload = b
+	}
+	// Synthesize a unique id so we can insert many events in one test.
+	id := fmt.Sprintf("test-%d-%s-%s", ts.UnixNano(), action, traceID)
+	_, err := cx.DB.Exec(
+		`INSERT INTO events (id, action, trace_id, origin, timestamp, data, vclock, cortex_id)
+		 VALUES (?, ?, ?, ?, ?, ?, '{}', ?)`,
+		id, string(action), traceID, cx.Name, ts.UTC().Format(time.RFC3339), string(payload), cx.ID,
+	)
+	if err != nil {
+		t.Fatalf("insert raw event: %v", err)
+	}
+}
+
+// TestParseSince pins the duration syntax accepted by every --since
+// surface. Go's time.ParseDuration handles "24h" / "90m" natively;
+// the "d" (days) and "w" (weeks) suffixes are added by ParseSince so
+// operators don't have to compute hours for week-scale lookbacks.
+func TestParseSince(t *testing.T) {
+	cases := []struct {
+		in   string
+		want time.Duration
+		err  bool
+	}{
+		{"", 0, false},
+		{"24h", 24 * time.Hour, false},
+		{"90m", 90 * time.Minute, false},
+		{"7d", 7 * 24 * time.Hour, false},
+		{"2w", 2 * 7 * 24 * time.Hour, false},
+		{"1d", 24 * time.Hour, false},
+		{"garbage", 0, true},
+		{"5x", 0, true},
+	}
+	for _, tc := range cases {
+		got, err := cortex.ParseSince(tc.in)
+		if tc.err && err == nil {
+			t.Errorf("ParseSince(%q): want error, got %v", tc.in, got)
+			continue
+		}
+		if !tc.err && err != nil {
+			t.Errorf("ParseSince(%q): unexpected error %v", tc.in, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("ParseSince(%q) = %v, want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestConsolidationActivity_EmptyLog(t *testing.T) {
+	cx := setup(t)
+	got, err := cx.ConsolidationActivity(0)
+	if err != nil {
+		t.Fatalf("ConsolidationActivity: %v", err)
+	}
+	if len(got.Daily) != 0 {
+		t.Errorf("Daily = %v, want empty", got.Daily)
+	}
+	if (got.Totals != cortex.ConsolidationTotals{}) {
+		t.Errorf("Totals = %+v, want zero", got.Totals)
+	}
+}
+
+// TestConsolidationActivity_BucketsAndTotals pins that the day-bucket
+// keying is UTC-date (substr of RFC3339 timestamp) and that every
+// observed action increments both its day bucket and the rollup total.
+// Inserts a mix of action types across two days so a regression that
+// swaps action keys or off-by-ones a date boundary is visible.
+func TestConsolidationActivity_BucketsAndTotals(t *testing.T) {
+	cx := setup(t)
+	tr := trace.New("seed", "note", "", nil, "body")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	day1 := time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)
+	day2 := time.Date(2026, 5, 2, 12, 0, 0, 0, time.UTC)
+	insertRawEvent(t, cx, event.ActionConsolidationClaim, tr.ID, day1, nil)
+	insertRawEvent(t, cx, event.ActionConsolidationSuccess, tr.ID, day1, nil)
+	insertRawEvent(t, cx, event.ActionConsolidationSuccess, tr.ID, day2, nil)
+	// One genuine failure (no reason field, or a non-preemption reason)…
+	insertRawEvent(t, cx, event.ActionConsolidationFail, tr.ID, day2.Add(1*time.Second),
+		map[string]any{"reason": "llm_error"})
+	// …and one preempted-by-peer fail that must NOT inflate the Fail bucket.
+	insertRawEvent(t, cx, event.ActionConsolidationFail, tr.ID, day2.Add(2*time.Second),
+		map[string]any{"reason": "peer_outranked"})
+	insertRawEvent(t, cx, event.ActionPromote, tr.ID, day2, map[string]any{"from": "short", "to": "mid"})
+	insertRawEvent(t, cx, event.ActionConsolidate, tr.ID, day2, nil)
+
+	got, err := cx.ConsolidationActivity(0)
+	if err != nil {
+		t.Fatalf("ConsolidationActivity: %v", err)
+	}
+	if len(got.Daily) != 2 {
+		t.Fatalf("Daily entries = %d, want 2: %+v", len(got.Daily), got.Daily)
+	}
+	if got.Daily[0].Date != "2026-05-01" || got.Daily[0].Claim != 1 || got.Daily[0].Success != 1 {
+		t.Errorf("Day 1 = %+v, want date=2026-05-01 claim=1 success=1", got.Daily[0])
+	}
+	if d := got.Daily[1]; d.Date != "2026-05-02" || d.Success != 1 || d.Fail != 1 || d.LostElection != 1 || d.Promote != 1 || d.Distill != 1 {
+		t.Errorf("Day 2 = %+v, want date=2026-05-02 success=1 fail=1 lost_election=1 promote=1 distill=1", d)
+	}
+	want := cortex.ConsolidationTotals{Success: 2, Fail: 1, LostElection: 1, Claim: 1, Promote: 1, Distill: 1}
+	if got.Totals != want {
+		t.Errorf("Totals = %+v, want %+v", got.Totals, want)
+	}
+}
+
+// TestConsolidationActivity_AllPreemptionReasons pins that every reason
+// the election gate emits as a "preempted" fail (peer_outranked,
+// no_winner_at_recheck, context_canceled) routes to the LostElection
+// bucket. A new preemption reason added in election.go must also be
+// mirrored in preemptionReasons in observability.go, and this test is
+// the trip wire for that.
+func TestConsolidationActivity_AllPreemptionReasons(t *testing.T) {
+	cx := setup(t)
+	tr := trace.New("seed", "note", "", nil, "body")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	day := time.Date(2026, 5, 3, 12, 0, 0, 0, time.UTC)
+	for i, reason := range []string{"peer_outranked", "no_winner_at_recheck", "context_canceled"} {
+		insertRawEvent(t, cx, event.ActionConsolidationFail, tr.ID,
+			day.Add(time.Duration(i)*time.Second),
+			map[string]any{"reason": reason})
+	}
+	// One genuine failure to make sure the Fail bucket isn't being
+	// swallowed wholesale.
+	insertRawEvent(t, cx, event.ActionConsolidationFail, tr.ID, day.Add(10*time.Second),
+		map[string]any{"reason": "watchdog_expired"})
+
+	got, err := cx.ConsolidationActivity(0)
+	if err != nil {
+		t.Fatalf("ConsolidationActivity: %v", err)
+	}
+	if got.Totals.LostElection != 3 {
+		t.Errorf("LostElection total = %d, want 3 (one per preemption reason)", got.Totals.LostElection)
+	}
+	if got.Totals.Fail != 1 {
+		t.Errorf("Fail total = %d, want 1 (watchdog_expired is a real failure)", got.Totals.Fail)
+	}
+}
+
+// TestConsolidationActivity_SinceFilter pins that the time window
+// drops events older than the cutoff. Without this filter the
+// `noema memory health --since 24h` command would always show
+// all-time totals, defeating the point.
+func TestConsolidationActivity_SinceFilter(t *testing.T) {
+	cx := setup(t)
+	tr := trace.New("seed", "note", "", nil, "body")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	old := time.Now().UTC().Add(-72 * time.Hour)
+	recent := time.Now().UTC().Add(-1 * time.Hour)
+	insertRawEvent(t, cx, event.ActionConsolidationSuccess, tr.ID, old, nil)
+	insertRawEvent(t, cx, event.ActionConsolidationSuccess, tr.ID, recent, nil)
+
+	got, err := cx.ConsolidationActivity(24 * time.Hour)
+	if err != nil {
+		t.Fatalf("ConsolidationActivity: %v", err)
+	}
+	if got.Totals.Success != 1 {
+		t.Errorf("Totals.Success = %d, want 1 (since-window should drop the 72h-old event)", got.Totals.Success)
+	}
+}
+
+func TestPromotionLatency_EmptyLog(t *testing.T) {
+	cx := setup(t)
+	got, err := cx.PromotionLatency()
+	if err != nil {
+		t.Fatalf("PromotionLatency: %v", err)
+	}
+	if got.ShortToMid.Count != 0 || got.MidToLong.Count != 0 {
+		t.Errorf("expected zero counts, got %+v", got)
+	}
+}
+
+// TestPromotionLatency_ShortToMid_FromCreated pins that short→mid
+// measures elapsed time from the trace's created_at to the first
+// short→mid promote event. Uses a real Promote call so the event
+// payload (`from`/`to` fields) matches what production emits — a
+// regression that drops those JSON fields would silently break the
+// latency calculation here.
+func TestPromotionLatency_ShortToMid_FromCreated(t *testing.T) {
+	cx := setup(t)
+	tr := trace.New("subject", "note", "", nil, "body")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := cx.Promote(tr.ID, trace.TierMid); err != nil {
+		t.Fatalf("Promote: %v", err)
+	}
+	got, err := cx.PromotionLatency()
+	if err != nil {
+		t.Fatalf("PromotionLatency: %v", err)
+	}
+	if got.ShortToMid.Count != 1 {
+		t.Errorf("ShortToMid.Count = %d, want 1", got.ShortToMid.Count)
+	}
+	if got.ShortToMid.P50 < 0 {
+		t.Errorf("ShortToMid.P50 = %v, want >= 0", got.ShortToMid.P50)
+	}
+}
+
+// TestPromotionLatency_MidToLong_UsesMidEntry is the load-bearing test
+// for the two-stage promotion case. A trace created at short, promoted
+// to mid 10 days later, then promoted to long 5 days after that should
+// report mid→long latency as 5 days, not 15. If the code mistakenly
+// used created_at as the start for the mid→long bucket, this test
+// would catch it.
+func TestPromotionLatency_MidToLong_UsesMidEntry(t *testing.T) {
+	cx := setup(t)
+	tr := trace.New("two-stage", "note", "", nil, "body")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	// Backdate created_at so the elapsed deltas are meaningful.
+	created := time.Now().UTC().Add(-20 * 24 * time.Hour)
+	if _, err := cx.DB.Exec(`UPDATE traces SET created_at = ? WHERE id = ?`, created.Format(time.RFC3339), tr.ID); err != nil {
+		t.Fatalf("backdate created_at: %v", err)
+	}
+	midEntry := created.Add(10 * 24 * time.Hour)
+	longEntry := midEntry.Add(5 * 24 * time.Hour)
+	insertRawEvent(t, cx, event.ActionPromote, tr.ID, midEntry, map[string]any{"from": "short", "to": "mid"})
+	insertRawEvent(t, cx, event.ActionPromote, tr.ID, longEntry, map[string]any{"from": "mid", "to": "long"})
+
+	got, err := cx.PromotionLatency()
+	if err != nil {
+		t.Fatalf("PromotionLatency: %v", err)
+	}
+	if got.MidToLong.Count != 1 {
+		t.Fatalf("MidToLong.Count = %d, want 1", got.MidToLong.Count)
+	}
+	wantApprox := 5 * 24 * time.Hour
+	diff := got.MidToLong.P50 - wantApprox
+	if diff < -time.Hour || diff > time.Hour {
+		t.Errorf("MidToLong.P50 = %v, want ~%v (mid→long should measure from mid entry, not created_at)", got.MidToLong.P50, wantApprox)
+	}
+}
+
+// TestTopSearchedTraces_RanksByHitsThenReads pins the primary/secondary
+// sort: search_hit_count first, then read_count as tiebreaker. A trace
+// with more reads but fewer search hits should still rank below a trace
+// with more search hits, because the surface is named "popular by
+// search" — the search counter dominates intentionally.
+func TestTopSearchedTraces_RanksByHitsThenReads(t *testing.T) {
+	cx := setup(t)
+	a := trace.New("alpha", "note", "", nil, "body")
+	if err := cx.Add(a); err != nil {
+		t.Fatalf("Add a: %v", err)
+	}
+	b := trace.New("beta", "note", "", nil, "body")
+	if err := cx.Add(b); err != nil {
+		t.Fatalf("Add b: %v", err)
+	}
+	// alpha: 1 search hit, no reads. beta: 0 search hits, many reads.
+	if _, err := cx.SearchAs("alpha", cortex.ListOptions{}, cortex.ActorAgent, cortex.DefaultSearchHitTopN); err != nil {
+		t.Fatalf("SearchAs: %v", err)
+	}
+	for range 5 {
+		if _, err := cx.GetAs(b.ID, cortex.ActorAgent); err != nil {
+			t.Fatalf("GetAs b: %v", err)
+		}
+	}
+	got, err := cx.TopSearchedTraces(10)
+	if err != nil {
+		t.Fatalf("TopSearchedTraces: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d rows, want 2: %+v", len(got), got)
+	}
+	if got[0].ID != a.ID {
+		t.Errorf("rank 1 = %q, want alpha (search hits dominate over reads)", got[0].ID)
+	}
+	if got[1].ID != b.ID {
+		t.Errorf("rank 2 = %q, want beta", got[1].ID)
+	}
+}
+
+// TestTopSearchedTraces_LimitAndZeroFilter pins two things in one test:
+// the LIMIT cap is honored, and traces with zero engagement on both
+// counters drop out entirely (HAVING clause). Otherwise a fresh cortex
+// would return a long list of just-created untouched traces, drowning
+// out the few actually-searched ones.
+func TestTopSearchedTraces_LimitAndZeroFilter(t *testing.T) {
+	cx := setup(t)
+	for i := range 5 {
+		tr := trace.New(fmt.Sprintf("t%d", i), "note", "", nil, "body")
+		if err := cx.Add(tr); err != nil {
+			t.Fatalf("Add: %v", err)
+		}
+	}
+	// Add one searched trace.
+	hot := trace.New("hot", "note", "", nil, "body")
+	if err := cx.Add(hot); err != nil {
+		t.Fatalf("Add hot: %v", err)
+	}
+	if _, err := cx.SearchAs("hot", cortex.ListOptions{}, cortex.ActorAgent, cortex.DefaultSearchHitTopN); err != nil {
+		t.Fatalf("SearchAs: %v", err)
+	}
+
+	got, err := cx.TopSearchedTraces(3)
+	if err != nil {
+		t.Fatalf("TopSearchedTraces: %v", err)
+	}
+	if len(got) != 1 {
+		t.Errorf("got %d rows, want 1 (zero-engagement traces should be filtered):\n%+v", len(got), got)
+	}
+}
+
+func TestTopSearchedTraces_EmptyCortex(t *testing.T) {
+	cx := setup(t)
+	got, err := cx.TopSearchedTraces(10)
+	if err != nil {
+		t.Fatalf("TopSearchedTraces: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty result on empty cortex, got %+v", got)
+	}
+}
+
+// TestTagActivity_AggregatesAcrossTags pins that a trace with multiple
+// tags contributes its engagement to each tag — a trace tagged
+// [go, language] with 10 reads adds 10 reads to BOTH tag rows. That's
+// the intended semantic: each tag's row answers "what's this tag's
+// total engagement footprint," not "what's exclusively this tag's."
+func TestTagActivity_AggregatesAcrossTags(t *testing.T) {
+	cx := setup(t)
+	dual := trace.New("dual", "note", "", []string{"go", "language"}, "body")
+	if err := cx.Add(dual); err != nil {
+		t.Fatalf("Add dual: %v", err)
+	}
+	if _, err := cx.GetAs(dual.ID, cortex.ActorAgent); err != nil {
+		t.Fatalf("GetAs: %v", err)
+	}
+
+	got, err := cx.TagActivity(10)
+	if err != nil {
+		t.Fatalf("TagActivity: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d tags, want 2: %+v", len(got), got)
+	}
+	for _, ts := range got {
+		if ts.TraceCount != 1 {
+			t.Errorf("tag %q TraceCount = %d, want 1", ts.Tag, ts.TraceCount)
+		}
+		if ts.ReadCount != 1 {
+			t.Errorf("tag %q ReadCount = %d, want 1 (each tag gets full attribution of its trace's reads)", ts.Tag, ts.ReadCount)
+		}
+	}
+}
+
+// TestTagActivity_ExcludesArchived pins the active-only convention:
+// a tag whose only carrier is archived should not appear in the
+// output. Otherwise an operator browsing "what's hot" sees ghost
+// tags from traces they explicitly demoted to archive.
+func TestTagActivity_ExcludesArchived(t *testing.T) {
+	cx := setup(t)
+	tr := trace.New("ghosted", "note", "", []string{"obsolete-tag"}, "body")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if _, err := cx.GetAs(tr.ID, cortex.ActorAgent); err != nil {
+		t.Fatalf("GetAs: %v", err)
+	}
+	if err := cx.Archive(tr.ID); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+
+	got, err := cx.TagActivity(10)
+	if err != nil {
+		t.Fatalf("TagActivity: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected empty (archived trace's tag should be excluded), got %+v", got)
+	}
+}
+
+func TestTagActivity_EmptyReturnsEmptySlice(t *testing.T) {
+	cx := setup(t)
+	got, err := cx.TagActivity(10)
+	if err != nil {
+		t.Fatalf("TagActivity: %v", err)
+	}
+	if got == nil {
+		t.Error("got nil, want non-nil empty slice (JSON should serialize as [] not null)")
+	}
+	if len(got) != 0 {
+		t.Errorf("got %+v, want empty", got)
+	}
+}
+
+func TestOneSourceMidCount_Empty(t *testing.T) {
+	cx := setup(t)
+	got, err := cx.OneSourceMidCount()
+	if err != nil {
+		t.Fatalf("OneSourceMidCount: %v", err)
+	}
+	if got.Current != 0 || got.PromotedLast7d != 0 {
+		t.Errorf("expected zero, got %+v", got)
+	}
+}
+
+// TestOneSourceMidCount_CountsActive1Source pins that the current
+// count includes only ACTIVE mid traces with exactly one derived_from
+// — archived/trashed are excluded (matches the engagement-stats
+// convention) and traces with 0 or 2+ sources don't count.
+func TestOneSourceMidCount_CountsActive1Source(t *testing.T) {
+	cx := setup(t)
+	src := trace.New("source", "note", "", nil, "body")
+	if err := cx.Add(src); err != nil {
+		t.Fatalf("Add src: %v", err)
+	}
+	// 1-source mid (counts).
+	single := trace.New("single", "note", "", nil, "body")
+	single.Tier = trace.TierMid
+	single.DerivedFrom = []string{src.ID}
+	if err := cx.Add(single); err != nil {
+		t.Fatalf("Add single: %v", err)
+	}
+	// 0-source mid (doesn't count).
+	zero := trace.New("zero", "note", "", nil, "body")
+	zero.Tier = trace.TierMid
+	if err := cx.Add(zero); err != nil {
+		t.Fatalf("Add zero: %v", err)
+	}
+	// Archived 1-source mid (doesn't count).
+	src2 := trace.New("source2", "note", "", nil, "body")
+	if err := cx.Add(src2); err != nil {
+		t.Fatalf("Add src2: %v", err)
+	}
+	hidden := trace.New("hidden", "note", "", nil, "body")
+	hidden.Tier = trace.TierMid
+	hidden.DerivedFrom = []string{src2.ID}
+	if err := cx.Add(hidden); err != nil {
+		t.Fatalf("Add hidden: %v", err)
+	}
+	if err := cx.Archive(hidden.ID); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+
+	got, err := cx.OneSourceMidCount()
+	if err != nil {
+		t.Fatalf("OneSourceMidCount: %v", err)
+	}
+	if got.Current != 1 {
+		t.Errorf("Current = %d, want 1 (only the active 1-source mid)", got.Current)
+	}
+}
+
+// TestOneSourceMidCount_PromotedLast7d pins the leak-detection
+// signal — a 1-source trace promoted to mid within the last 7 days
+// should appear in PromotedLast7d. This is the metric that should be
+// zero if PRs #86 and #90's gates are holding.
+func TestOneSourceMidCount_PromotedLast7d(t *testing.T) {
+	cx := setup(t)
+	src := trace.New("source", "note", "", nil, "body")
+	if err := cx.Add(src); err != nil {
+		t.Fatalf("Add src: %v", err)
+	}
+	leaker := trace.New("leaker", "note", "", nil, "body")
+	leaker.DerivedFrom = []string{src.ID}
+	if err := cx.Add(leaker); err != nil {
+		t.Fatalf("Add leaker: %v", err)
+	}
+	// Use a real Promote so the event payload shape matches production.
+	if err := cx.Promote(leaker.ID, trace.TierMid); err != nil {
+		t.Fatalf("Promote: %v", err)
+	}
+
+	got, err := cx.OneSourceMidCount()
+	if err != nil {
+		t.Fatalf("OneSourceMidCount: %v", err)
+	}
+	if got.PromotedLast7d != 1 {
+		t.Errorf("PromotedLast7d = %d, want 1", got.PromotedLast7d)
+	}
+	if got.Current != 1 {
+		t.Errorf("Current = %d, want 1", got.Current)
+	}
+}
+
+// TestOneSourceMidCount_OldPromoteExcluded pins that promotes older
+// than the 7-day window don't inflate PromotedLast7d — otherwise the
+// leak signal stays "on" forever once it fires once.
+func TestOneSourceMidCount_OldPromoteExcluded(t *testing.T) {
+	cx := setup(t)
+	src := trace.New("source", "note", "", nil, "body")
+	if err := cx.Add(src); err != nil {
+		t.Fatalf("Add src: %v", err)
+	}
+	old := trace.New("old", "note", "", nil, "body")
+	old.Tier = trace.TierMid
+	old.DerivedFrom = []string{src.ID}
+	if err := cx.Add(old); err != nil {
+		t.Fatalf("Add old: %v", err)
+	}
+	insertRawEvent(t, cx, event.ActionPromote, old.ID,
+		time.Now().UTC().Add(-30*24*time.Hour),
+		map[string]any{"from": "short", "to": "mid"})
+
+	got, err := cx.OneSourceMidCount()
+	if err != nil {
+		t.Fatalf("OneSourceMidCount: %v", err)
+	}
+	if got.PromotedLast7d != 0 {
+		t.Errorf("PromotedLast7d = %d, want 0 (30d-old promote should be outside the 7d window)", got.PromotedLast7d)
+	}
+	if got.Current != 1 {
+		t.Errorf("Current = %d, want 1", got.Current)
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -419,6 +419,75 @@ func NewServer(cx *cortex.Cortex, noemaVersion string, federationMode string) *s
 		return mcp.NewToolResultText(string(buf)), nil
 	})
 
+	s.AddTool(mcp.NewTool("consolidation_health",
+		mcp.WithDescription("Recent consolidation pipeline health: daily success/fail/promote/distill counts within the lookback window, short→mid and mid→long promotion-latency percentiles, and the 1-source mid leak detector. Lets an agent or operator answer 'is consolidation actually happening, and is anything leaking?' without raw SQL against the events table."),
+		mcp.WithString("since", mcp.Description("Lookback window for the activity buckets, e.g. \"24h\", \"7d\". Default 24h. Latency percentiles and the leak detector ignore this — they are all-time / fixed-window respectively.")),
+	), func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		since, err := cortex.ParseSince(req.GetString("since", "24h"))
+		if err != nil {
+			return mcp.NewToolResultError(err.Error()), nil
+		}
+		activity, err := cx.ConsolidationActivity(since)
+		if err != nil {
+			return nil, fmt.Errorf("consolidation activity: %w", err)
+		}
+		latency, err := cx.PromotionLatency()
+		if err != nil {
+			return nil, fmt.Errorf("promotion latency: %w", err)
+		}
+		leak, err := cx.OneSourceMidCount()
+		if err != nil {
+			return nil, fmt.Errorf("one-source mid count: %w", err)
+		}
+		out := struct {
+			SchemaVersion int                          `json:"schema_version"`
+			Activity      cortex.ConsolidationActivity `json:"activity"`
+			Latency       cortex.PromotionLatency      `json:"latency"`
+			OneSourceMid  cortex.OneSourceMidCount     `json:"one_source_mid"`
+		}{
+			SchemaVersion: 1,
+			Activity:      activity,
+			Latency:       latency,
+			OneSourceMid:  leak,
+		}
+		buf, _ := json.MarshalIndent(out, "", "  ")
+		return mcp.NewToolResultText(string(buf)), nil
+	})
+
+	s.AddTool(mcp.NewTool("search_activity",
+		mcp.WithDescription("Top-N traces by federation-wide search popularity (search_hit_count then read_count) plus top-N tags by aggregate engagement. Lets an agent answer 'what's worth reading?' or 'which topics are hot?' without scanning every trace. Active traces only; archived/trashed are excluded."),
+		mcp.WithNumber("top", mcp.Description("How many top traces and top tags to return. Default 10. Capped at 100.")),
+	), func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		top := int(req.GetFloat("top", 10))
+		if top <= 0 {
+			top = 10
+		}
+		if top > 100 {
+			top = 100
+		}
+		traces, err := cx.TopSearchedTraces(top)
+		if err != nil {
+			return nil, fmt.Errorf("top searched traces: %w", err)
+		}
+		tags, err := cx.TagActivity(top)
+		if err != nil {
+			return nil, fmt.Errorf("tag activity: %w", err)
+		}
+		out := struct {
+			SchemaVersion int                   `json:"schema_version"`
+			Top           int                   `json:"top"`
+			Traces        []cortex.PopularTrace `json:"traces"`
+			Tags          []cortex.TagSummary   `json:"tags"`
+		}{
+			SchemaVersion: 1,
+			Top:           top,
+			Traces:        traces,
+			Tags:          tags,
+		}
+		buf, _ := json.MarshalIndent(out, "", "  ")
+		return mcp.NewToolResultText(string(buf)), nil
+	})
+
 	s.AddTool(mcp.NewTool("record_consolidation_result",
 		mcp.WithDescription("Internal tool. Materialises a distilled mid-tier trace from a set of short-term sources. Validates the source IDs exist (>=2 required), creates the new trace with derived_from lineage pointing at the sources, and emits an ActionConsolidate event carrying model/profile/confidence telemetry for the quality dashboard."),
 		mcp.WithString("title", mcp.Description("Title for the distilled trace"), mcp.Required()),
@@ -937,6 +1006,18 @@ Choose the type that best reflects the intent of the memory:
   cortex_identity                → return this cortex's stable ULID + name +
                                    manifest version (used by federation peers
                                    to verify identity on every sync)
+  consolidation_health [since]   → daily consolidation activity (success/fail/
+                                   promote/distill) over the window, plus
+                                   short→mid and mid→long latency percentiles
+                                   and the 1-source mid leak detector. since
+                                   accepts Go duration syntax plus d/w (e.g.
+                                   24h, 7d). Defaults to 24h.
+  search_activity [top]          → top-N traces by federation-wide search
+                                   popularity, plus top-N tags by aggregate
+                                   engagement (hits + reads + modifies). Use
+                                   this to surface what's worth reading or to
+                                   discover which topics are hot. top defaults
+                                   to 10, capped at 100.
   sync_events [since] [limit]    → pull events for federation (JSON array)
   federation_status              → MCP access posture, federation config,
                                    peer states, vector clock

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -340,6 +340,7 @@ const (
 	stateList    viewState = iota
 	stateSearch
 	stateConfirm
+	stateHelp
 )
 
 // focusPane tracks which pane (list or detail) receives navigation keys.
@@ -620,6 +621,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.updateSearch(msg)
 		case stateConfirm:
 			return m.updateConfirm(msg)
+		case stateHelp:
+			return m.updateHelp(msg)
 		}
 	}
 	return m, nil
@@ -808,6 +811,10 @@ func (m model) updateList(msg tea.KeyMsg) (model, tea.Cmd) {
 		m.cursor = 0
 		return m, m.reload()
 
+	case "?":
+		m.state = stateHelp
+		return m, nil
+
 	case "+", "=":
 		// Accept "=" too so users on layouts where "+" requires Shift
 		// can upvote without the modifier. "-" is unambiguous.
@@ -925,6 +932,16 @@ func (m model) updateConfirm(msg tea.KeyMsg) (model, tea.Cmd) {
 	case "n", "N", "esc":
 		m.state = stateList
 		m.confirm = confirmAction{}
+	}
+	return m, nil
+}
+
+func (m model) updateHelp(msg tea.KeyMsg) (model, tea.Cmd) {
+	switch msg.String() {
+	case "q", "ctrl+c":
+		return m, tea.Quit
+	case "?", "esc", "enter", " ":
+		m.state = stateList
 	}
 	return m, nil
 }
@@ -1276,20 +1293,25 @@ func (m model) View() string {
 		return "Loading…\n"
 	}
 
-	listW, detailW := m.paneWidths()
 	bodyH := m.bodyHeight()
 
-	list := m.renderList(listW, bodyH)
-	detail := m.renderDetail(detailW, bodyH)
+	var body string
+	if m.state == stateHelp {
+		body = m.renderHelp(m.width, bodyH)
+	} else {
+		listW, detailW := m.paneWidths()
+		list := m.renderList(listW, bodyH)
+		detail := m.renderDetail(detailW, bodyH)
 
-	// Single-column divider
-	divLines := make([]string, bodyH)
-	for i := range divLines {
-		divLines[i] = styleDivider.Render("│")
+		// Single-column divider
+		divLines := make([]string, bodyH)
+		for i := range divLines {
+			divLines[i] = styleDivider.Render("│")
+		}
+		divider := strings.Join(divLines, "\n")
+
+		body = lipgloss.JoinHorizontal(lipgloss.Top, list, divider, detail)
 	}
-	divider := strings.Join(divLines, "\n")
-
-	body := lipgloss.JoinHorizontal(lipgloss.Top, list, divider, detail)
 
 	// Header and footer are single-row strings that only stretch as
 	// far as their content goes; right-pad them with surface cells so
@@ -1597,6 +1619,73 @@ func (m model) renderDetail(width, height int) string {
 	return styleSurface.Width(width).Height(height).Render(content)
 }
 
+// renderHelp draws the keybinding overlay shown when state == stateHelp.
+// It replaces the list+detail body so every binding fits without
+// fighting for space against the row list. Grouped by purpose; tier
+// toggles get their own group because they were previously invisible
+// to anyone who hadn't read the source.
+func (m model) renderHelp(width, height int) string {
+	groups := []struct {
+		title string
+		keys  [][2]string
+	}{
+		{"Navigation", [][2]string{
+			{"j / k or ↓ / ↑", "move cursor"},
+			{"g / G", "top / bottom"},
+			{"PgUp / PgDn", "half-page (detail pane)"},
+			{"→ or tab", "focus detail pane"},
+			{"← or tab", "focus list pane"},
+			{"esc", "clear search / back"},
+		}},
+		{"Trace actions", [][2]string{
+			{"n", "new trace"},
+			{"e", "edit current trace"},
+			{"+ / =", "upvote (cycles +1 → 0)"},
+			{"-", "downvote (cycles -1 → 0)"},
+			{"d", "archive"},
+			{"u", "unarchive"},
+			{"D", "trash (or purge from trash view)"},
+			{"r", "recover from trash"},
+		}},
+		{"Views & filters", [][2]string{
+			{"1", "toggle short-tier visibility"},
+			{"2", "toggle mid-tier visibility"},
+			{"3", "toggle long-tier visibility"},
+			{"0", "show all tiers"},
+			{"a", "toggle archived (active + archived)"},
+			{"t", "toggle trash view"},
+			{"/", "search"},
+			{"f", "live follow (auto-refresh)"},
+			{"R", "manual refresh"},
+		}},
+		{"Other", [][2]string{
+			{"?", "this help (esc / enter / space to dismiss)"},
+			{"q or ctrl+c", "quit"},
+		}},
+	}
+
+	var lines []string
+	lines = append(lines, "")
+	lines = append(lines, "  "+styleHeader.Render("Noema")+styleHeaderAccent.Render(".")+styleDim.Render("  keybindings"))
+	lines = append(lines, "")
+	for _, g := range groups {
+		lines = append(lines, "  "+styleHeaderAccent.Render(g.title))
+		for _, kv := range g.keys {
+			lines = append(lines, fmt.Sprintf("    %-18s  %s", kv[0], styleDim.Render(kv[1])))
+		}
+		lines = append(lines, "")
+	}
+
+	// Pad or truncate to body height so the footer stays pinned.
+	for len(lines) < height {
+		lines = append(lines, "")
+	}
+	if len(lines) > height {
+		lines = lines[:height]
+	}
+	return styleSurface.Width(width).Height(height).Render(strings.Join(lines, "\n"))
+}
+
 func (m model) renderFooter() string {
 	switch m.state {
 	case stateSearch:
@@ -1605,6 +1694,9 @@ func (m model) renderFooter() string {
 	case stateConfirm:
 		prompt := fmt.Sprintf("  %s %q? [y/N] ", m.confirm.action, m.confirm.id)
 		return styleError.Render(prompt)
+
+	case stateHelp:
+		return surfacePad(2) + styleFooter.Render("?/esc/enter:back  q:quit")
 
 	default:
 		if m.err != nil {
@@ -1618,11 +1710,11 @@ func (m model) renderFooter() string {
 		case m.focus == focusDetail:
 			// Detail-pane focus: arrow keys scroll the body, everything
 			// else is either reach-through (quit) or tab back to list.
-			hint = "j/k:scroll  g/G:top/bot  PgUp/PgDn:half  ←/tab:list  esc:list  q:quit"
+			hint = "j/k:scroll  g/G:top/bot  PgUp/PgDn:half  ←/tab:list  esc:list  ?:help  q:quit"
 		case m.showTrashed:
-			hint = "j/k:nav  r:recover  D:purge  t:back  /:search  →/tab:body  f:live  R:refresh  q:quit"
+			hint = "j/k:nav  r:recover  D:purge  t:back  /:search  →/tab:body  f:live  R:refresh  ?:help  q:quit"
 		default:
-			hint = "j/k:nav  n:new  e:edit  +/-:vote  d:archive  u:unarchive  D:trash  t:trash-view  a:all  /:search  →/tab:body  f:live  R:refresh  q:quit"
+			hint = "j/k:nav  n:new  e:edit  d:archive  D:trash  1/2/3:tier  0:all-tiers  /:search  →/tab:body  ?:help  q:quit"
 		}
 		if m.focus == focusList && m.searchQuery != "" {
 			hint = "esc:clear  " + hint

--- a/internal/tui/tui_tier_test.go
+++ b/internal/tui/tui_tier_test.go
@@ -77,6 +77,43 @@ func TestTUI_TierToggleResetsCursor(t *testing.T) {
 	}
 }
 
+// TestTUI_HelpToggle pins the discoverability fix: '?' from the list
+// enters the help overlay; '?' or 'esc' exits back to the list. The
+// gap this closes is that tier-toggle keys (1/2/3/0) had been
+// undocumented in any UI surface, so users couldn't find the long-tier
+// rows hidden behind the default filter.
+func TestTUI_HelpToggle(t *testing.T) {
+	m := initialModel(nil)
+	if m.state != stateList {
+		t.Fatalf("starting state = %v, want stateList", m.state)
+	}
+	m = keyPress(m, "?")
+	if m.state != stateHelp {
+		t.Errorf("'?' from list did not enter stateHelp, got %v", m.state)
+	}
+	next, _ := m.updateHelp(tea.KeyMsg{Type: tea.KeyEsc})
+	if next.state != stateList {
+		t.Errorf("'esc' from help did not return to stateList, got %v", next.state)
+	}
+}
+
+// TestFooter_AdvertisesTierKeys locks in that the previously-hidden
+// tier toggle keys and the help overlay are advertised in the default-
+// mode footer hint. The whole point of this work is that these keys
+// are no longer invisible to a user who hasn't read the source.
+func TestFooter_AdvertisesTierKeys(t *testing.T) {
+	cx := setupCortex(t)
+	addTrace(t, cx, "first", "note")
+	m := loadedModel(t, cx)
+
+	hint := m.renderFooter()
+	for _, want := range []string{"1/2/3:tier", "0:all-tiers", "?:help"} {
+		if !strings.Contains(hint, want) {
+			t.Errorf("footer missing %q hint:\n%s", want, hint)
+		}
+	}
+}
+
 func TestTierBadge(t *testing.T) {
 	cases := map[string]string{
 		trace.TierShort: "s",

--- a/scripts/deploy-hermes-plugin.sh
+++ b/scripts/deploy-hermes-plugin.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Deploy the Hermes Noema memory provider plugin to one or more remote hosts.
+#
+# Usage:
+#   scripts/deploy-hermes-plugin.sh <host> [<host> ...]
+#
+# Each host must be SSH-reachable. The script rsyncs plugins/hermes/ to
+# <hermes-home>/plugins/memory/noema/ on each host (default hermes-home is
+# ~/.hermes/hermes-agent — override with HERMES_HOME on the remote env).
+# Then it restarts every hermes-gateway-*.service systemd --user unit so the
+# new code is picked up.
+#
+# Idempotent. Safe to re-run. No-ops on hosts that don't have Hermes installed.
+#
+# Until `noema hermes install` (Tier 2) lands, this is the pull-mechanism
+# replacement for the manual `cp -r` step in plugins/hermes/README.md.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "usage: $0 <host> [<host> ...]" >&2
+    exit 64
+fi
+
+repo_root=$(cd "$(dirname "$0")/.." && pwd)
+src="$repo_root/plugins/hermes/"
+
+if [[ ! -f "$src/__init__.py" ]]; then
+    echo "error: plugin source not found at $src" >&2
+    exit 1
+fi
+
+for host in "$@"; do
+    echo "==> $host"
+
+    remote_home=$(ssh "$host" 'echo "${HERMES_HOME:-$HOME/.hermes/hermes-agent}"')
+    remote_dest="$remote_home/plugins/memory/noema"
+
+    if ! ssh "$host" "test -d $remote_home"; then
+        echo "    Hermes not installed at $remote_home — skipping"
+        continue
+    fi
+
+    ssh "$host" "mkdir -p $remote_dest"
+
+    # --delete removes stale files (e.g. an old transport_legacy.py); excludes
+    # __pycache__ so we don't ship local bytecode.
+    rsync -az --delete \
+        --exclude='__pycache__' \
+        --exclude='.pytest_cache' \
+        --exclude='.ruff_cache' \
+        "$src" "$host:$remote_dest/"
+
+    echo "    plugin synced to $remote_dest"
+
+    # Restart every Hermes gateway profile so the new code loads. Prefer
+    # the host's `hermes-profiles` utility if present — it owns the
+    # canonical restart convention (sequencing, profile discovery, etc.)
+    # and we should not re-implement it. Fall back to a direct systemctl
+    # glob restart on hosts that don't have the utility installed.
+    if ssh -n "$host" 'command -v hermes-profiles >/dev/null 2>&1'; then
+        echo "    restarting via hermes-profiles gateways restart"
+        ssh -n "$host" 'hermes-profiles gateways restart'
+        continue
+    fi
+
+    units=$(ssh -n "$host" "systemctl --user list-unit-files 'hermes-gateway*.service' --no-legend 2>/dev/null | awk '{print \$1}'" || true)
+    if [[ -z "$units" ]]; then
+        echo "    no hermes-gateway-*.service units found — skipping restart"
+        continue
+    fi
+    while IFS= read -r unit; do
+        [[ -z "$unit" ]] && continue
+        echo "    restarting $unit"
+        ssh -n "$host" "systemctl --user restart $unit"
+    done <<<"$units"
+done
+
+echo
+echo "deploy complete."


### PR DESCRIPTION
Seven changes squashed onto next since v0.10.4:

- #94 feat(tui): help overlay + advertise tier-toggle keys in footer.
       New `?` key opens a Bubble Tea overlay listing every keybind grouped
       by section; the existing footer now advertises the `[shift+]m`
       short→mid → mid→long tier-toggle chord so it's discoverable
       without reading the source.

- #95 feat(memory): consolidation health surface (CLI + MCP). New
       `noema memory health [--since 24h]` CLI and `consolidation_health`
       MCP tool answer "how did consolidation fare overnight, and is
       anything leaking?" in one round-trip: daily success/fail/claim/
       promote/distill counts, short→mid and mid→long p50/p95 latency,
       and the 1-source mid leak detector. New ParseSince() takes "7d" /
       "2w" alongside Go duration syntax everywhere --since is accepted.

- #96 feat(memory): engagement surface — popular traces + tag activity.
       New `noema memory popular` CLI and `search_activity` MCP tool
       rank active traces by federation-wide search_hit_count primary
       and read_count tiebreaker, plus top-N tags by aggregate
       engagement. The auto-injection-friendly signal pattern from #84
       finally gets a query surface — Hermes-style providers that fold
       results into context without ever calling get_trace now show up
       in the rankings instead of being invisible.

- #97 feat(memory): split election-loss from real failures in
       consolidation_health. `ConsolidationDay` and totals gain a
       `LostElection` field. The activity SQL groups by
       (date, action, reason) and routes the three preempted reasons
       (peer_outranked, no_winner_at_recheck, context_canceled) into
       the new bucket so "the LLM endpoint is flapping" reads
       differently from "ai-2 outranked us at the gate." The
       preemption-reason set lives in one place with a trip-wire test
       in case a fourth reason is added to election.go.

- #98 fix(consolidation): kill watchdog races on same-peer +
       remote-peer claims. The 2026-05-14/15 watchdog cluster
       surfaced two patterns: (B) a peer's own watchdog Sweep emits
       Fail at T+10:00 one second before the runner emits Success at
       T+10:01 (same-peer race); (C) a remote peer's local watchdog
       fires before federation sync delivers the runner's Success
       (cross-peer race producing N-1 spurious fails per long pass).
       Fix is a process-local InFlightRegistry consulted by Sweep
       (kills B) plus a RemoteGrace defaulting to
       2 × federation.interval that defers closure of remote-emitted
       claims (kills C). WithElection registers Begin/End around
       inner() so panics still release the marker.

- #99 fix(sync): report long-tier file drift instead of aborting
       the run. `noema sync` was aborting the entire reconciliation
       run on the first long-tier trace whose on-disk file had
       drifted from the DB, with `constraint failed: long-term trace
       is immutable`. The blanket UPDATE was sending all locked
       columns back to the row regardless of tier; for long-tier
       rows the immutability trigger correctly aborts. Sync now
       detects long-tier rows up front, runs a narrow UPDATE
       touching only archived_at and trashed_at, reports drift via
       a new Drifted counter on SyncResult, and continues
       processing. Covers cortex_id drift specifically (the most
       common federation-inherited case where the file's origin
       name matches the local cortex but the DB's cortex_id was
       captured from the originating peer).

- (chore) add deploy-hermes-plugin.sh for fleet plugin sync. One-shot
       script that rsyncs the Hermes Noema plugin to ai-1/2/3 under
       the right path and prompts each host's service to reload.
       Internal-use; not part of the public release surface.

Verified pre-release: full `go test ./...` and `go vet ./...` clean on
the merged tree. Live `noema sync` against agentbrain successfully
reports 6 drifted long-tier traces (5 with cortex_id-only drift from
federation inheritance, 1 with multi-field drift on a user-preference
trace) where the previous binary aborted on the first one.

The two new observability commands (`noema memory health` and
`noema memory popular`) plus the LostElection split graduate
observability from "scrape the events table by hand" to first-class
CLI / MCP surfaces, which is why this lands as a minor bump rather
than v0.10.5.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>