### PR TITLE
release: v0.13.0

### DIFF
--- a/plugins/hermes/__init__.py
+++ b/plugins/hermes/__init__.py
@@ -699,11 +699,22 @@ class NoemaMemoryProvider(MemoryProvider):
     def _create_session_trace(self) -> None:
         """Create the session log trace on initialize.
 
-        If the trace already exists (same session re-initialized on the same
-        day), look it up and reuse it instead of failing.
+        The session id is suffixed onto the title so the derived trace id
+        (``YYYYMMDD-hermes-session-<label>-<sid>``) stays unique per session
+        while still grouping under the ``hermes-session-`` prefix. If the same
+        session re-initializes on the same day the id collides
+        deterministically; we detect the collision envelope and reuse the
+        existing trace instead of failing.
         """
-        title_label = self._session_title or self._session_id[:12]
-        session_tag = f"session-{self._session_id[:12]}"
+        sid = self._session_id[:12]
+        label = self._session_title or sid
+        # sid trails the human label so session traces still group under the
+        # `hermes-session-` prefix while staying unique per session.
+        title = (
+            f"hermes-session: {label} ({sid})" if label != sid
+            else f"hermes-session: {sid}"
+        )
+        session_tag = f"session-{sid}"
         body = (
             f"Session ID: {self._session_id}\n"
             f"Agent: {self._agent_identity}\n"
@@ -712,26 +723,50 @@ class NoemaMemoryProvider(MemoryProvider):
         )
         try:
             result = self._transport.call_tool("create_trace", {
-                "title": f"hermes-session: {title_label}",
+                "title": title,
                 "type": "context",
                 "author": self._author,
                 "tags": f"hermes-session, {session_tag}",
                 "body": body,
             })
-            # Extract trace ID from "Trace created: <id>" response.
-            if result and result.startswith("Trace created: "):
-                self._session_trace_id = result.split("Trace created: ", 1)[1].strip()
-            else:
-                logger.warning("Unexpected create_trace response: %s", result)
-        except RuntimeError as e:
-            if "UNIQUE constraint" in str(e):
-                # Session re-initialized — find and reuse the existing trace.
-                logger.info("Session trace already exists, reusing")
-                self._recover_session_trace(session_tag)
-            else:
-                logger.warning("Failed to create session trace: %s", e)
         except Exception as e:
             logger.warning("Failed to create session trace: %s", e)
+            return
+
+        # Success: "Trace created: <id>".
+        if result and result.startswith("Trace created: "):
+            self._session_trace_id = result.split("Trace created: ", 1)[1].strip()
+            return
+        # create_trace surfaces a failure as an isError text body, not an
+        # exception. A deterministic-id collision means this session was
+        # already initialized today — reuse the existing trace.
+        collision = self._parse_collision(result)
+        if collision and collision.get("id"):
+            self._session_trace_id = collision["id"]
+            logger.info("Session trace already exists, reusing %s", collision["id"])
+        elif collision:
+            # Malformed envelope (no id) — fall back to a tag lookup.
+            self._recover_session_trace(session_tag)
+        else:
+            logger.warning("Unexpected create_trace response: %s", result)
+
+    @staticmethod
+    def _parse_collision(text: Optional[str]) -> Optional[Dict[str, Any]]:
+        """Return the trace_id_collision envelope if `text` is one, else None.
+
+        create_trace reports a duplicate id as an isError result whose text
+        body is a JSON envelope with ``kind == "trace_id_collision"`` and the
+        existing trace's id under ``id``.
+        """
+        if not text:
+            return None
+        try:
+            payload = json.loads(text)
+        except (ValueError, TypeError):
+            return None
+        if isinstance(payload, dict) and payload.get("kind") == "trace_id_collision":
+            return payload
+        return None
 
     def _recover_session_trace(self, session_tag: str) -> None:
         """Find an existing session trace by tag and reuse it."""

--- a/plugins/hermes/tests/test_unit.py
+++ b/plugins/hermes/tests/test_unit.py
@@ -316,6 +316,85 @@ class TestHelpers:
 
 
 # ---------------------------------------------------------------------------
+# __init__.py — session trace creation
+# ---------------------------------------------------------------------------
+
+class TestSessionTrace:
+    def _provider(self):
+        p = NoemaMemoryProvider()
+        p._transport = MagicMock()
+        p._author = "hermes/tester"
+        p._session_id = "abcdef123456789"
+        p._session_title = "hey max"
+        p._agent_identity = "max"
+        p._platform = "test"
+        return p
+
+    def test_title_suffixes_session_id(self):
+        p = self._provider()
+        p._transport.call_tool.return_value = (
+            "Trace created: 20260531-hermes-session-hey-max-abcdef123456"
+        )
+        p._create_session_trace()
+        args = p._transport.call_tool.call_args[0][1]
+        # sid trails the human label so the derived id is unique per session
+        # while still grouping under the `hermes-session-` prefix.
+        assert args["title"] == "hermes-session: hey max (abcdef123456)"
+        assert args["type"] == "context"
+        assert args["author"] == "hermes/tester"
+        assert args["tags"] == "hermes-session, session-abcdef123456"
+        assert p._session_trace_id == "20260531-hermes-session-hey-max-abcdef123456"
+
+    def test_title_omits_redundant_sid_when_no_session_title(self):
+        p = self._provider()
+        p._session_title = ""
+        p._transport.call_tool.return_value = "Trace created: 20260531-x"
+        p._create_session_trace()
+        args = p._transport.call_tool.call_args[0][1]
+        assert args["title"] == "hermes-session: abcdef123456"
+
+    def test_collision_envelope_reuses_existing_id(self):
+        p = self._provider()
+        p._transport.call_tool.return_value = json.dumps({
+            "kind": "trace_id_collision",
+            "id": "20260531-hermes-session-hey-max-abcdef123456",
+            "existing_state": "active",
+            "summary": "trace id ... already exists",
+        })
+        p._create_session_trace()
+        # No tag-search fallback needed — the envelope carries the id.
+        assert p._session_trace_id == "20260531-hermes-session-hey-max-abcdef123456"
+        assert p._transport.call_tool.call_count == 1
+
+    def test_collision_without_id_falls_back_to_tag_search(self):
+        p = self._provider()
+        p._transport.call_tool.side_effect = [
+            json.dumps({"kind": "trace_id_collision"}),
+            "[context] 20260531-hermes-session-hey-max-abcdef123456 (2026-05-31) — max [hermes-session]",
+        ]
+        p._create_session_trace()
+        assert p._session_trace_id == "20260531-hermes-session-hey-max-abcdef123456"
+        assert p._transport.call_tool.call_count == 2
+
+    def test_unexpected_response_leaves_trace_id_unset(self):
+        p = self._provider()
+        p._transport.call_tool.return_value = "something weird"
+        p._create_session_trace()
+        assert p._session_trace_id == ""
+
+    def test_parse_collision(self):
+        env = json.dumps({"kind": "trace_id_collision", "id": "20260531-x"})
+        assert NoemaMemoryProvider._parse_collision(env) == {
+            "kind": "trace_id_collision", "id": "20260531-x",
+        }
+        assert NoemaMemoryProvider._parse_collision("Trace created: 20260531-x") is None
+        assert NoemaMemoryProvider._parse_collision('{"kind":"other"}') is None
+        assert NoemaMemoryProvider._parse_collision("not json") is None
+        assert NoemaMemoryProvider._parse_collision("") is None
+        assert NoemaMemoryProvider._parse_collision(None) is None
+
+
+# ---------------------------------------------------------------------------
 # __init__.py — config loading
 # ---------------------------------------------------------------------------
 
@@ -559,44 +638,6 @@ class TestPrefetch:
 # ---------------------------------------------------------------------------
 # __init__.py — session trace creation (mocked transport)
 # ---------------------------------------------------------------------------
-
-class TestSessionTrace:
-    def test_session_trace_created(self):
-        p = NoemaMemoryProvider()
-        p._transport = MagicMock()
-        p._transport.call_tool.return_value = "Trace created: 20260412-hermes-session-abc"
-        p._session_id = "session-abc123"
-        p._agent_identity = "researcher"
-        p._author = "hermes/researcher"
-        p._session_title = "Research session"
-        p._platform = "cli"
-
-        p._create_session_trace()
-
-        call_args = p._transport.call_tool.call_args
-        assert call_args[0][0] == "create_trace"
-        args = call_args[0][1]
-        assert args["title"] == "hermes-session: Research session"
-        assert args["type"] == "context"
-        assert args["author"] == "hermes/researcher"
-        assert "hermes-session" in args["tags"]
-        assert p._session_trace_id == "20260412-hermes-session-abc"
-
-    def test_session_trace_uses_id_fallback(self):
-        p = NoemaMemoryProvider()
-        p._transport = MagicMock()
-        p._transport.call_tool.return_value = "Trace created: 20260412-hermes-session-x"
-        p._session_id = "abcdefghijklmnop"
-        p._session_title = ""
-        p._author = "hermes/unknown"
-        p._platform = "cli"
-        p._agent_identity = "unknown"
-
-        p._create_session_trace()
-
-        call_args = p._transport.call_tool.call_args
-        assert "abcdefghijkl" in call_args[0][1]["title"]
-
 
 # ---------------------------------------------------------------------------
 # Session-summary body builder


### PR DESCRIPTION
Lands the v0.13.0 content (the full next backlog + Hermes session-trace fix) onto main as a single linear commit, per the Protect Main ruleset (linear history, squash/rebase only). Tree is identical to the already-built v0.13.0 release; tag will be repointed here. Supersedes #106.