### PR TITLE
fix(consolidation): make quiet-period recheck tests deterministic

### DIFF
--- a/internal/consolidation/election.go
+++ b/internal/consolidation/election.go
@@ -1,6 +1,7 @@
 package consolidation
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -65,6 +66,14 @@ type Outcome struct {
 // lives in federation_state rather than in the struct.
 type Election struct {
 	cfg ElectionConfig
+
+	// quietWait blocks for the quiet period between Claim and the
+	// recheck Decide, returning the ctx error if cancelled mid-wait.
+	// Defaults to a real-time, ctx-aware sleep; tests override it (via
+	// SetQuietWaitHook in export_test.go) to drive the recheck
+	// deterministically instead of racing a real sleep from a separate
+	// goroutine.
+	quietWait func(ctx context.Context, d time.Duration) error
 }
 
 // NewElection constructs an evaluator with defaults filled in.
@@ -75,7 +84,30 @@ func NewElection(cfg ElectionConfig) *Election {
 	if cfg.Log == nil {
 		cfg.Log = func(string, ...any) {}
 	}
-	return &Election{cfg: cfg}
+	return &Election{cfg: cfg, quietWait: realQuietWait}
+}
+
+// realQuietWait is the production quiet-period waiter: a ctx-aware sleep
+// of d. A non-positive d returns immediately (tests pass zero to skip
+// the wait). Cancellation returns ctx.Err so the pass gate can classify
+// it as context_canceled.
+func realQuietWait(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(d):
+		return nil
+	}
+}
+
+// waitQuietPeriod blocks for the configured quiet period (or until ctx
+// is cancelled) between the Claim and the recheck Decide. Returns
+// ctx.Err on cancellation, nil otherwise.
+func (e *Election) waitQuietPeriod(ctx context.Context) error {
+	return e.quietWait(ctx, e.cfg.QuietPeriod)
 }
 
 // CortexID returns the configured local cortex ID. Exposed so callers

--- a/internal/consolidation/export_test.go
+++ b/internal/consolidation/export_test.go
@@ -1,0 +1,16 @@
+package consolidation
+
+import (
+	"context"
+	"time"
+)
+
+// SetQuietWaitHook overrides the quiet-period waiter so tests can drive
+// the gap between the initial Decide and the post-quiet recheck
+// deterministically — mutating rank state synchronously inside the hook
+// instead of racing a real-time sleep from a separate goroutine. The hook
+// receives the context and configured duration; returning a non-nil error
+// is treated by the pass gate as a context cancellation.
+func (e *Election) SetQuietWaitHook(fn func(ctx context.Context, d time.Duration) error) {
+	e.quietWait = fn
+}

--- a/internal/consolidation/pass_gate.go
+++ b/internal/consolidation/pass_gate.go
@@ -3,7 +3,6 @@ package consolidation
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/Fail-Safe/Noema/internal/event"
 )
@@ -57,13 +56,9 @@ func WithElection(inner PassFn, election *Election, registry *InFlightRegistry, 
 
 		// Quiet-period wait for conflicting claims. Respect ctx so
 		// Agent.Stop() doesn't block on a multi-second sleep.
-		if election.QuietPeriod() > 0 {
-			select {
-			case <-ctx.Done():
-				_ = election.Fail(windowID, FailReasonContextCanceled)
-				return ctx.Err()
-			case <-time.After(election.QuietPeriod()):
-			}
+		if err := election.waitQuietPeriod(ctx); err != nil {
+			_ = election.Fail(windowID, FailReasonContextCanceled)
+			return err
 		}
 
 		recheck := election.Decide()

--- a/internal/consolidation/pass_gate_test.go
+++ b/internal/consolidation/pass_gate_test.go
@@ -185,24 +185,11 @@ func TestWithElection_EmitsNoWinnerAtRecheck(t *testing.T) {
 	// peer-outranked reason. Operationally this signals "everyone
 	// dropped out", not "someone else won" — different debugging path.
 	//
-	// Reproduce by handing Decide() a now-time that makes the local
-	// rank fresh enough to count at t=0 but stale enough to be
-	// filtered when the recheck advances the clock past the entry's
-	// validity window. We do this by writing a rank with ObservedAt
-	// well in the past and using a non-zero QuietPeriod such that
-	// recheck filters it out — except the existing minAge check
-	// requires entries to be at least minAge old, not at most.
-	//
-	// Simpler approach: install a hook that flips local rank to 0
-	// between Decide and recheck. We do that by writing the initial
-	// rank, letting the wrapper take its first Decide (we won), then
-	// the test's clock function returns a "now" that drives the
-	// recheck. To make recheck see no eligible peers, overwrite the
-	// rank entry with Rank=0 just before the wrapper resleeps.
-	//
-	// Because the wrapper sleeps real time when QuietPeriod > 0 and
-	// we want no flake, use QuietPeriod = 50ms and overwrite the
-	// rank from the test goroutine after a brief wait.
+	// At t=0 the local rank wins. The quiet-wait hook then demotes it
+	// to RankIneligible (0) so the recheck finds no eligible peer. The
+	// hook runs synchronously between the two Decide calls — no
+	// goroutine, no real sleep — so the demotion can't lose a race
+	// against the wait under CI load. See SetQuietWaitHook.
 	state := newElectionState(t)
 	now := time.Date(2026, 4, 21, 12, 0, 0, 0, time.UTC)
 	must(t, state.SetLocalRank(federation.RankEntry{CortexID: "01LOCAL", Rank: 50, ObservedAt: stale(now)}))
@@ -215,16 +202,12 @@ func TestWithElection_EmitsNoWinnerAtRecheck(t *testing.T) {
 		State:       state,
 		Emitter:     emitter,
 	})
+	e.SetQuietWaitHook(func(context.Context, time.Duration) error {
+		return state.SetLocalRank(federation.RankEntry{CortexID: "01LOCAL", Rank: 0, ObservedAt: stale(now)})
+	})
 
 	inner := &callTracker{}
 	wrapped := consolidation.WithElection(inner.pass, e, nil, nil)
-
-	// Demote local rank to 0 partway through the quiet period so the
-	// recheck finds zero eligible peers.
-	go func() {
-		time.Sleep(10 * time.Millisecond)
-		_ = state.SetLocalRank(federation.RankEntry{CortexID: "01LOCAL", Rank: 0, ObservedAt: stale(now)})
-	}()
 
 	if err := wrapped(context.Background(), "cron"); err != nil {
 		t.Fatalf("wrapped: %v", err)
@@ -244,7 +227,9 @@ func TestWithElection_EmitsPeerOutrankedAtRecheck(t *testing.T) {
 	// Peer-outranked-at-recheck guard: a peer that wasn't visible at
 	// initial Decide arrives during the quiet period and outranks
 	// us. The wrapper must surface FailReasonPeerOutranked, not the
-	// no-winner reason.
+	// no-winner reason. The higher-ranked peer is published synchronously
+	// from the quiet-wait hook (between the two Decide calls) so the
+	// arrival can't race the wait under CI load. See SetQuietWaitHook.
 	state := newElectionState(t)
 	now := time.Date(2026, 4, 21, 12, 0, 0, 0, time.UTC)
 	must(t, state.SetLocalRank(federation.RankEntry{CortexID: "01LOCAL", Rank: 30, ObservedAt: stale(now)}))
@@ -258,15 +243,12 @@ func TestWithElection_EmitsPeerOutrankedAtRecheck(t *testing.T) {
 		State:       state,
 		Emitter:     emitter,
 	})
+	e.SetQuietWaitHook(func(context.Context, time.Duration) error {
+		return state.SetPeerRank("ai-2", federation.RankEntry{CortexID: "01PEER", Rank: 90, ObservedAt: stale(now)})
+	})
 
 	inner := &callTracker{}
 	wrapped := consolidation.WithElection(inner.pass, e, nil, nil)
-
-	// Higher-ranked peer surfaces during the quiet wait.
-	go func() {
-		time.Sleep(10 * time.Millisecond)
-		_ = state.SetPeerRank("ai-2", federation.RankEntry{CortexID: "01PEER", Rank: 90, ObservedAt: stale(now)})
-	}()
 
 	if err := wrapped(context.Background(), "cron"); err != nil {
 		t.Fatalf("wrapped: %v", err)


### PR DESCRIPTION
## Problem
`TestWithElection_EmitsNoWinnerAtRecheck` and `TestWithElection_EmitsPeerOutrankedAtRecheck` were flaky in CI (failed under parallel `-race` load, passed locally). Both drove the gap between the gate's two `Decide()` calls by mutating rank state from a **goroutine timed to land inside a real 50ms `time.After` sleep**. Under load the goroutine was starved past the recheck, the mutation missed its window, and the gate saw the original winning rank — surfacing as `pass calls = 1, want 0` / `fail events = 0`.

## Fix
Replace the only seam between the two `Decide()` calls — the real-time sleep — with an injectable waiter:
- `Election.quietWait` defaults to a ctx-aware real sleep (`realQuietWait`); the pass gate calls it via `waitQuietPeriod`.
- Tests override it through `SetQuietWaitHook` (`export_test.go`) to mutate rank **synchronously between the two Decide calls**, removing the goroutine and the wall-clock dependency.

Production behavior is unchanged: identical ctx-cancellation semantics, zero-duration still skips the wait.

## Verification
- Both tests **50× uncached under `-race`** — green.
- Full `internal/consolidation` package **5× under `-race`** — green.
- Full suite `go test -race ./...` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)