### PR TITLE
release: v0.13.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ MCP clients talking to a keyed endpoint must send `Authorization: Bearer <key>`.
 For ad-hoc use, backgrounding with `nohup` works fine:
 
 ```bash
-nohup noema serve --cortex agentbrain --transport http --host 127.0.0.1 \
+nohup noema serve --cortex mycortex --transport http --host 127.0.0.1 \
   > ~/noema.log 2>&1 &
 disown
 ```
@@ -460,18 +460,18 @@ For a real federation host you probably want a process supervisor — restart on
 **Linux (systemd)**
 
 ```bash
-noema serve --cortex agentbrain --transport http --host 192.168.1.10 --print-systemd-unit | sudo tee /etc/systemd/system/noema-agentbrain.service
+noema serve --cortex mycortex --transport http --host 192.168.1.10 --print-systemd-unit | sudo tee /etc/systemd/system/noema-mycortex.service
 sudo systemctl daemon-reload
-sudo systemctl enable --now noema-agentbrain
-sudo journalctl -u noema-agentbrain -f
+sudo systemctl enable --now noema-mycortex
+sudo journalctl -u noema-mycortex -f
 ```
 
 **macOS (launchd)**
 
 ```bash
-noema serve --cortex agentbrain --transport http --host 127.0.0.1 --print-launchd-plist > ~/Library/LaunchAgents/com.fail-safe.noema.agentbrain.plist
-launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.fail-safe.noema.agentbrain.plist
-tail -f ~/Library/Logs/noema-agentbrain.log
+noema serve --cortex mycortex --transport http --host 127.0.0.1 --print-launchd-plist > ~/Library/LaunchAgents/com.fail-safe.noema.mycortex.plist
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.fail-safe.noema.mycortex.plist
+tail -f ~/Library/Logs/noema-mycortex.log
 ```
 
 Both flags require `--transport http` (stdio has no endpoint to supervise) and an explicit `--cortex` (the unit/plist pins exactly one cortex — NOEMA_CORTEX and the config default aren't carried into the service environment). All the usual HTTP flag invariants (`--host` not `0.0.0.0`, TLS pair symmetry) are validated at preview time, so you catch misconfigurations before installing.

--- a/internal/cli/cmd_cortex_test.go
+++ b/internal/cli/cmd_cortex_test.go
@@ -92,7 +92,7 @@ func TestCortexList_NoDefaultSingleCortex(t *testing.T) {
 	cfg := &config.Config{
 		Default: "",
 		Cortexes: map[string]config.CortexEntry{
-			"agentbrain": {Path: "/home/mark/.noema/agentbrain"},
+			"mycortex": {Path: "/home/user/.noema/mycortex"},
 		},
 	}
 	var out bytes.Buffer
@@ -100,7 +100,7 @@ func TestCortexList_NoDefaultSingleCortex(t *testing.T) {
 		t.Fatalf("runCortexList: %v", err)
 	}
 	s := out.String()
-	if !strings.Contains(s, "noema use agentbrain") {
+	if !strings.Contains(s, "noema use mycortex") {
 		t.Errorf("hint does not name the specific use command: %s", s)
 	}
 	if !strings.Contains(s, "auto-promoted on next use") {

--- a/internal/cli/cmd_federation.go
+++ b/internal/cli/cmd_federation.go
@@ -243,7 +243,7 @@ the peer's event log so no events are silently skipped.
 
 This is the supported way to clear stale federation state — never edit
 the federation_state SQLite table by hand.`,
-		Example: "  noema federation reset-peer ai-2\n  noema federation reset-peer ai-2 ai-3 --yes",
+		Example: "  noema federation reset-peer peer-b\n  noema federation reset-peer peer-b peer-c --yes",
 		Args:    cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cx, err := resolveCortex()
@@ -472,7 +472,7 @@ func federationPausePeerCmd() *cobra.Command {
 		Use:     "pause-peer <name>",
 		Short:   "Pause syncing with a federation peer",
 		Long:    "Sets a peer's mode to \"paused\" in cortex.md. The syncer will skip this peer\nuntil it is resumed. No state is lost — the cursor and pinned identity are preserved.",
-		Example: "  noema federation pause-peer ai-2",
+		Example: "  noema federation pause-peer peer-b",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return setPeerMode(cmd, args[0], cortex.PeerModePaused)
@@ -485,7 +485,7 @@ func federationResumePeerCmd() *cobra.Command {
 		Use:     "resume-peer <name>",
 		Short:   "Resume syncing with a paused federation peer",
 		Long:    "Clears a peer's mode back to \"sync\" in cortex.md. The syncer will resume\npulling from this peer on the next poll.",
-		Example: "  noema federation resume-peer ai-2",
+		Example: "  noema federation resume-peer peer-b",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return setPeerMode(cmd, args[0], cortex.PeerModeSync)

--- a/internal/cli/cmd_federation_test.go
+++ b/internal/cli/cmd_federation_test.go
@@ -94,7 +94,7 @@ func endpointMap(cx *cortex.Cortex, t *testing.T) map[string]string {
 // TestFederationResetPeer_ClearsAllState pins the headline behavior: a peer
 // with full state present (pin + cursor + last_seen + a vector-clock bucket
 // keyed on the pinned id) loses all four after a successful reset. This is
-// the exact scenario in the recent ai-1/ai-2/ai-3 incident — without this
+// the exact scenario in the recent peer-a/peer-b/peer-c incident — without this
 // test the next refactor could quietly skip clearing the vclock bucket and
 // nobody would notice until federation started reporting ghost dominance.
 func TestFederationResetPeer_ClearsAllState(t *testing.T) {

--- a/internal/cli/cmd_migrate_test.go
+++ b/internal/cli/cmd_migrate_test.go
@@ -235,8 +235,8 @@ func TestMigrateCortexID_ClearsStalePeerState(t *testing.T) {
 	}
 	m.Federation = &cortex.FederationConfig{
 		Peers: []cortex.PeerEntry{
-			{Name: "ai-2", Endpoint: "https://ai-2.example:3000"},
-			{Name: "ai-3", Endpoint: "https://ai-3.example:3000"},
+			{Name: "peer-b", Endpoint: "https://peer-b.example:3000"},
+			{Name: "peer-c", Endpoint: "https://peer-c.example:3000"},
 		},
 	}
 	if err := cortex.WriteManifest(dir, m); err != nil {
@@ -254,7 +254,7 @@ func TestMigrateCortexID_ClearsStalePeerState(t *testing.T) {
 	}
 	defer conn.Close()
 
-	staleClock := map[string]uint64{name: 1, "ai-2": 5, "ai-3": 7}
+	staleClock := map[string]uint64{name: 1, "peer-b": 5, "peer-c": 7}
 	clockJSON, _ := json.Marshal(staleClock)
 	if _, err := conn.Exec(
 		`INSERT INTO federation_state (key, value) VALUES ('vclock', ?)
@@ -267,8 +267,8 @@ func TestMigrateCortexID_ClearsStalePeerState(t *testing.T) {
 		name string
 		id   string
 	}{
-		{"ai-2", "01JOLD000000000000000AI200"},
-		{"ai-3", "01JOLD000000000000000AI300"},
+		{"peer-b", "01JOLD000000000000000PRB00"},
+		{"peer-c", "01JOLD000000000000000PRC00"},
 	} {
 		if _, err := conn.Exec(
 			`INSERT INTO federation_state (key, value) VALUES (?, ?)`,
@@ -286,10 +286,10 @@ func TestMigrateCortexID_ClearsStalePeerState(t *testing.T) {
 	for _, row := range []struct {
 		key, value string
 	}{
-		{"peer:ai-2:last_event", "01EVENT00000000000000AI201"},
-		{"peer:ai-2:last_seen", "2026-04-07T12:00:00Z"},
-		{"peer:ai-3:last_event", "01EVENT00000000000000AI301"},
-		{"peer:ai-3:last_seen", "2026-04-07T12:00:00Z"},
+		{"peer:peer-b:last_event", "01EVENT00000000000000PRB01"},
+		{"peer:peer-b:last_seen", "2026-04-07T12:00:00Z"},
+		{"peer:peer-c:last_event", "01EVENT00000000000000PRC01"},
+		{"peer:peer-c:last_seen", "2026-04-07T12:00:00Z"},
 	} {
 		if _, err := conn.Exec(
 			`INSERT INTO federation_state (key, value) VALUES (?, ?)`,
@@ -338,11 +338,11 @@ func TestMigrateCortexID_ClearsStalePeerState(t *testing.T) {
 	if err := json.Unmarshal([]byte(clockRaw), &vc); err != nil {
 		t.Fatalf("parse vclock: %v", err)
 	}
-	if _, lingering := vc["ai-2"]; lingering {
-		t.Errorf("vclock still has ai-2 bucket: %v", vc)
+	if _, lingering := vc["peer-b"]; lingering {
+		t.Errorf("vclock still has peer-b bucket: %v", vc)
 	}
-	if _, lingering := vc["ai-3"]; lingering {
-		t.Errorf("vclock still has ai-3 bucket: %v", vc)
+	if _, lingering := vc["peer-c"]; lingering {
+		t.Errorf("vclock still has peer-c bucket: %v", vc)
 	}
 	if vc[newID] == 0 {
 		t.Errorf("vclock missing entry under new id %q: %v", newID, vc)
@@ -384,8 +384,8 @@ func TestMigrateCortexID_ClearsStalePeerState(t *testing.T) {
 // TestMigrateCortexID_ResetClearsCursors pins the new --reset side effect:
 // cursors and last_seen rows are wiped so the post-migration syncer
 // re-pulls each peer's event log from the start. This is the fix for the
-// incident where ai-2/ai-3 migrated with --reset, kept their pre-incident
-// cursors for ai-1, and then only saw the handful of events ai-1 emitted
+// incident where peer-b/peer-c migrated with --reset, kept their pre-incident
+// cursors for peer-a, and then only saw the handful of events peer-a emitted
 // after the chaos — silently skipping everything written during the
 // period of broken federation that motivated the reset in the first place.
 //
@@ -405,8 +405,8 @@ func TestMigrateCortexID_ResetClearsCursors(t *testing.T) {
 	}
 	m.Federation = &cortex.FederationConfig{
 		Peers: []cortex.PeerEntry{
-			{Name: "ai-1", Endpoint: "https://ai-1.example:3000"},
-			{Name: "ai-3", Endpoint: "https://ai-3.example:3000"},
+			{Name: "peer-a", Endpoint: "https://peer-a.example:3000"},
+			{Name: "peer-c", Endpoint: "https://peer-c.example:3000"},
 		},
 	}
 	if err := cortex.WriteManifest(dir, m); err != nil {
@@ -423,10 +423,10 @@ func TestMigrateCortexID_ResetClearsCursors(t *testing.T) {
 	for _, row := range []struct {
 		key, value string
 	}{
-		{"peer:ai-1:last_event", "01EVENT0000000000000000AI1"},
-		{"peer:ai-1:last_seen", "2026-04-07T12:00:00Z"},
-		{"peer:ai-3:last_event", "01EVENT0000000000000000AI3"},
-		{"peer:ai-3:last_seen", "2026-04-07T12:00:00Z"},
+		{"peer:peer-a:last_event", "01EVENT0000000000000000PRA"},
+		{"peer:peer-a:last_seen", "2026-04-07T12:00:00Z"},
+		{"peer:peer-c:last_event", "01EVENT0000000000000000PRC"},
+		{"peer:peer-c:last_seen", "2026-04-07T12:00:00Z"},
 	} {
 		if _, err := conn.Exec(
 			`INSERT INTO federation_state (key, value) VALUES (?, ?)`,

--- a/internal/cli/cmd_resolve.go
+++ b/internal/cli/cmd_resolve.go
@@ -19,7 +19,7 @@ func resolveCmd() *cobra.Command {
 versions (by origin name) or supplying a custom merged body.
 
 Examples:
-  noema resolve 20260406-divergence-... --accept ai-1
+  noema resolve 20260406-divergence-... --accept peer-a
   noema resolve 20260406-divergence-... --custom "merged content here"
 
 Use 'noema get <divergence-id>' to see the available origins listed under

--- a/internal/cli/cmd_serve.go
+++ b/internal/cli/cmd_serve.go
@@ -1032,7 +1032,7 @@ func runPrintLaunchdPlist(out io.Writer, transport string, hosts []string, port 
 // as a plain struct (vs. positional args) makes tests self-documenting
 // and leaves room for future fields without breaking the call sites.
 type systemdUnitParams struct {
-	Cortex    string   // e.g. "agentbrain" — pinned into Description and filename suggestion
+	Cortex    string   // e.g. "mycortex" — pinned into Description and filename suggestion
 	User      string   // Linux username the service runs as (from os/user.Current)
 	Exe       string   // absolute path to the noema binary (from os.Executable)
 	ServeArgs []string // argv after the binary path, starting with "serve"
@@ -1102,7 +1102,7 @@ func buildSystemdUnit(p systemdUnitParams) string {
 // used only for the log path (~/Library/Logs/noema-<cortex>.log); the
 // agent itself runs as the user who loads the plist.
 type launchdPlistParams struct {
-	Cortex    string   // e.g. "agentbrain" — pinned into Label and filename
+	Cortex    string   // e.g. "mycortex" — pinned into Label and filename
 	Exe       string   // absolute path to the noema binary
 	HomeDir   string   // user home dir (from os.UserHomeDir) for log path
 	ServeArgs []string // argv after the binary path, starting with "serve"

--- a/internal/cli/cmd_serve_test.go
+++ b/internal/cli/cmd_serve_test.go
@@ -17,7 +17,7 @@ import (
 // weakens the check (e.g. re-adding a "but only if peers are configured"
 // condition).
 func TestValidateHTTPServe(t *testing.T) {
-	const cortexName = "ai-1"
+	const cortexName = "peer-a"
 
 	cases := []struct {
 		name           string
@@ -34,7 +34,7 @@ func TestValidateHTTPServe(t *testing.T) {
 		},
 		{
 			name:           "happy path with TLS",
-			hosts:          []string{"ai-1.example.com"},
+			hosts:          []string{"peer-a.example.com"},
 			tlsCert:        "/etc/ssl/cert.pem",
 			tlsKey:         "/etc/ssl/key.pem",
 			cortexExplicit: true,
@@ -72,27 +72,27 @@ func TestValidateHTTPServe(t *testing.T) {
 			wantErrSubstr:  "--tls-cert and --tls-key must be provided together",
 		},
 		{
-			// The regression case: a cortex is bound (here "ai-1") but
+			// The regression case: a cortex is bound (here "peer-a") but
 			// --cortex was not on the command line. Even though host and
 			// TLS look fine, the implicit binding is a federation
 			// footgun and must be rejected.
 			name:           "implicit cortex on HTTP",
-			hosts:          []string{"ai-1.example.com"},
+			hosts:          []string{"peer-a.example.com"},
 			tlsCert:        "/etc/ssl/cert.pem",
 			tlsKey:         "/etc/ssl/key.pem",
 			cortexExplicit: false,
 			wantErrSubstr:  "without an explicit --cortex flag",
 		},
 		{
-			// Specifically the agentbrain-on-ai-1 case from the field:
+			// Specifically the mycortex-on-peer-a case from the field:
 			// the bound cortex has no peers of its own, but is being
 			// served on a host where another cortex's peers expect to
 			// find a different identity. The guard must fire regardless
 			// of the bound cortex's federation config.
 			name:           "implicit cortex on HTTP includes cortex name in error",
-			hosts:          []string{"ai-1-tb.home-dns.com"},
+			hosts:          []string{"peer-a-tb.example.com"},
 			cortexExplicit: false,
-			wantErrSubstr:  "\"ai-1\"",
+			wantErrSubstr:  "\"peer-a\"",
 		},
 		{
 			// Multi-host: all hosts must be valid. The second host is
@@ -220,16 +220,16 @@ func TestBuildServeArgs_OmitsEmptyOptionals(t *testing.T) {
 	// should NOT appear; callers using the real serve command always
 	// have port=3000 by default, but the print functions can be called
 	// with arbitrary values and must not emit --port 0.
-	got := buildServeArgs("agentbrain", "http", nil, 0, "", "")
-	want := []string{"serve", "--cortex", "agentbrain", "--transport", "http"}
+	got := buildServeArgs("mycortex", "http", nil, 0, "", "")
+	want := []string{"serve", "--cortex", "mycortex", "--transport", "http"}
 	if !equalSlices(got, want) {
 		t.Errorf("minimal args: got %v, want %v", got, want)
 	}
 
 	// Full: every optional flag set, single host.
-	got = buildServeArgs("agentbrain", "http", []string{"10.0.0.5"}, 3000, "/etc/ssl/cert.pem", "/etc/ssl/key.pem")
+	got = buildServeArgs("mycortex", "http", []string{"10.0.0.5"}, 3000, "/etc/ssl/cert.pem", "/etc/ssl/key.pem")
 	want = []string{
-		"serve", "--cortex", "agentbrain", "--transport", "http",
+		"serve", "--cortex", "mycortex", "--transport", "http",
 		"--host", "10.0.0.5",
 		"--port", "3000",
 		"--tls-cert", "/etc/ssl/cert.pem",
@@ -240,9 +240,9 @@ func TestBuildServeArgs_OmitsEmptyOptionals(t *testing.T) {
 	}
 
 	// Multi-host: each host gets its own --host flag.
-	got = buildServeArgs("agentbrain", "http", []string{"10.0.0.5", "192.168.45.3"}, 3000, "", "")
+	got = buildServeArgs("mycortex", "http", []string{"10.0.0.5", "192.168.45.3"}, 3000, "", "")
 	want = []string{
-		"serve", "--cortex", "agentbrain", "--transport", "http",
+		"serve", "--cortex", "mycortex", "--transport", "http",
 		"--host", "10.0.0.5",
 		"--host", "192.168.45.3",
 		"--port", "3000",
@@ -273,11 +273,11 @@ func equalSlices(a, b []string) bool {
 // rejected by systemd or would silently start the wrong process.
 func TestBuildSystemdUnit_RendersRequiredSections(t *testing.T) {
 	out := buildSystemdUnit(systemdUnitParams{
-		Cortex: "agentbrain",
+		Cortex: "mycortex",
 		User:   "mark",
-		Exe:    "/home/mark/bin/noema",
+		Exe:    "/home/user/bin/noema",
 		ServeArgs: []string{
-			"serve", "--cortex", "agentbrain",
+			"serve", "--cortex", "mycortex",
 			"--transport", "http",
 			"--host", "192.168.1.10",
 			"--port", "3000",
@@ -289,9 +289,9 @@ func TestBuildSystemdUnit_RendersRequiredSections(t *testing.T) {
 		"[Unit]",
 		"[Service]",
 		"[Install]",
-		"Description=Noema memory server (agentbrain)",
+		"Description=Noema memory server (mycortex)",
 		"User=mark",
-		"ExecStart=/home/mark/bin/noema serve --cortex agentbrain --transport http --host 192.168.1.10 --port 3000",
+		"ExecStart=/home/user/bin/noema serve --cortex mycortex --transport http --host 192.168.1.10 --port 3000",
 		"Restart=on-failure",
 		"WantedBy=multi-user.target",
 		"After=network-online.target",
@@ -354,11 +354,11 @@ func TestBuildSystemdUnit_ReflectsTLSFlags(t *testing.T) {
 // on a developer's Mac.
 func TestBuildLaunchdPlist_IsValidXML(t *testing.T) {
 	out := buildLaunchdPlist(launchdPlistParams{
-		Cortex:  "agentbrain",
+		Cortex:  "mycortex",
 		Exe:     "/usr/local/bin/noema",
-		HomeDir: "/Users/mark",
+		HomeDir: "/Users/user",
 		ServeArgs: []string{
-			"serve", "--cortex", "agentbrain",
+			"serve", "--cortex", "mycortex",
 			"--transport", "http", "--host", "127.0.0.1",
 		},
 	})
@@ -383,27 +383,27 @@ func TestBuildLaunchdPlist_IsValidXML(t *testing.T) {
 // won't start, won't restart on crash, or silently swallows its output.
 func TestBuildLaunchdPlist_RendersRequiredKeys(t *testing.T) {
 	out := buildLaunchdPlist(launchdPlistParams{
-		Cortex:  "agentbrain",
+		Cortex:  "mycortex",
 		Exe:     "/usr/local/bin/noema",
-		HomeDir: "/Users/mark",
+		HomeDir: "/Users/user",
 		ServeArgs: []string{
-			"serve", "--cortex", "agentbrain",
+			"serve", "--cortex", "mycortex",
 			"--transport", "http", "--host", "127.0.0.1",
 			"--port", "3000",
 		},
 	})
 	for _, want := range []string{
 		"<key>Label</key>",
-		"<string>com.fail-safe.noema.agentbrain</string>",
+		"<string>com.fail-safe.noema.mycortex</string>",
 		"<key>ProgramArguments</key>",
 		"<string>/usr/local/bin/noema</string>",
 		"<string>serve</string>",
 		"<string>--cortex</string>",
-		"<string>agentbrain</string>",
+		"<string>mycortex</string>",
 		"<key>RunAtLoad</key>",
 		"<key>KeepAlive</key>",
 		"<key>StandardOutPath</key>",
-		"<string>/Users/mark/Library/Logs/noema-agentbrain.log</string>",
+		"<string>/Users/user/Library/Logs/noema-mycortex.log</string>",
 		"<key>StandardErrorPath</key>",
 	} {
 		if !strings.Contains(out, want) {
@@ -478,7 +478,7 @@ func TestRunPrintSystemdUnit_RejectsMissingCortex(t *testing.T) {
 // wrapping it in systemd is meaningless and would just mask bugs.
 func TestRunPrintSystemdUnit_RejectsStdioTransport(t *testing.T) {
 	prev := cortexFlag
-	cortexFlag = "agentbrain"
+	cortexFlag = "mycortex"
 	t.Cleanup(func() { cortexFlag = prev })
 
 	var out bytes.Buffer
@@ -497,7 +497,7 @@ func TestRunPrintSystemdUnit_RejectsStdioTransport(t *testing.T) {
 // would install a unit file that fails only on first start.
 func TestRunPrintSystemdUnit_PropagatesHTTPValidationErrors(t *testing.T) {
 	prev := cortexFlag
-	cortexFlag = "agentbrain"
+	cortexFlag = "mycortex"
 	t.Cleanup(func() { cortexFlag = prev })
 
 	var out bytes.Buffer
@@ -518,7 +518,7 @@ func TestRunPrintSystemdUnit_PropagatesHTTPValidationErrors(t *testing.T) {
 // together.
 func TestRunPrintSystemdUnit_HappyPath(t *testing.T) {
 	prev := cortexFlag
-	cortexFlag = "agentbrain"
+	cortexFlag = "mycortex"
 	t.Cleanup(func() { cortexFlag = prev })
 
 	var out bytes.Buffer
@@ -526,8 +526,8 @@ func TestRunPrintSystemdUnit_HappyPath(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	s := out.String()
-	if !strings.Contains(s, "--cortex agentbrain") {
-		t.Errorf("output does not include --cortex agentbrain:\n%s", s)
+	if !strings.Contains(s, "--cortex mycortex") {
+		t.Errorf("output does not include --cortex mycortex:\n%s", s)
 	}
 	if !strings.Contains(s, "[Unit]") {
 		t.Errorf("output is not a systemd unit:\n%s", s)
@@ -555,7 +555,7 @@ func TestRunPrintLaunchdPlist_RejectsMissingCortex(t *testing.T) {
 // stdio rejection for launchd.
 func TestRunPrintLaunchdPlist_RejectsStdioTransport(t *testing.T) {
 	prev := cortexFlag
-	cortexFlag = "agentbrain"
+	cortexFlag = "mycortex"
 	t.Cleanup(func() { cortexFlag = prev })
 
 	var out bytes.Buffer
@@ -573,7 +573,7 @@ func TestRunPrintLaunchdPlist_RejectsStdioTransport(t *testing.T) {
 // ProgramArguments.
 func TestRunPrintLaunchdPlist_HappyPath(t *testing.T) {
 	prev := cortexFlag
-	cortexFlag = "agentbrain"
+	cortexFlag = "mycortex"
 	t.Cleanup(func() { cortexFlag = prev })
 
 	var out bytes.Buffer
@@ -581,10 +581,10 @@ func TestRunPrintLaunchdPlist_HappyPath(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	s := out.String()
-	if !strings.Contains(s, "<string>agentbrain</string>") {
+	if !strings.Contains(s, "<string>mycortex</string>") {
 		t.Errorf("plist does not pin cortex name:\n%s", s)
 	}
-	if !strings.Contains(s, "com.fail-safe.noema.agentbrain") {
+	if !strings.Contains(s, "com.fail-safe.noema.mycortex") {
 		t.Errorf("plist label does not include cortex name:\n%s", s)
 	}
 }
@@ -671,10 +671,10 @@ func TestRequireTLSForKeyedMode(t *testing.T) {
 // that looks fine but never injects NOEMA_MCP_KEY.
 func TestBuildSystemdUnit_EmitsOptionalEnvironmentFile(t *testing.T) {
 	out := buildSystemdUnit(systemdUnitParams{
-		Cortex:    "agentbrain",
+		Cortex:    "mycortex",
 		User:      "mark",
 		Exe:       "/usr/local/bin/noema",
-		ServeArgs: []string{"serve", "--cortex", "agentbrain", "--transport", "http", "--host", "127.0.0.1"},
+		ServeArgs: []string{"serve", "--cortex", "mycortex", "--transport", "http", "--host", "127.0.0.1"},
 	})
 
 	// The "-" prefix is load-bearing: without it, systemd refuses to
@@ -682,7 +682,7 @@ func TestBuildSystemdUnit_EmitsOptionalEnvironmentFile(t *testing.T) {
 	// default state for open-mode cortexes. The test pins the exact
 	// path form so a refactor that changes ~/.config to /etc (or
 	// drops the "-") is caught here.
-	const wantLine = "EnvironmentFile=-%h/.config/noema/agentbrain.env"
+	const wantLine = "EnvironmentFile=-%h/.config/noema/mycortex.env"
 	if !strings.Contains(out, wantLine) {
 		t.Errorf("unit missing optional EnvironmentFile line %q\nfull:\n%s", wantLine, out)
 	}
@@ -709,10 +709,10 @@ func TestBuildSystemdUnit_EmitsOptionalEnvironmentFile(t *testing.T) {
 // sync instead of getting the env file checklist up front.
 func TestBuildSystemdUnit_IncludesKeyedModeInstallInstructions(t *testing.T) {
 	out := buildSystemdUnit(systemdUnitParams{
-		Cortex:    "agentbrain",
+		Cortex:    "mycortex",
 		User:      "mark",
 		Exe:       "/usr/local/bin/noema",
-		ServeArgs: []string{"serve", "--cortex", "agentbrain", "--transport", "http", "--host", "127.0.0.1"},
+		ServeArgs: []string{"serve", "--cortex", "mycortex", "--transport", "http", "--host", "127.0.0.1"},
 	})
 	for _, want := range []string{
 		"keyed-mode MCP auth",
@@ -735,10 +735,10 @@ func TestBuildSystemdUnit_IncludesKeyedModeInstallInstructions(t *testing.T) {
 // the dict (which would downgrade every keyed-mode Mac to open mode).
 func TestBuildLaunchdPlist_EmitsEnvironmentVariablesBlock(t *testing.T) {
 	out := buildLaunchdPlist(launchdPlistParams{
-		Cortex:    "agentbrain",
+		Cortex:    "mycortex",
 		Exe:       "/usr/local/bin/noema",
-		HomeDir:   "/Users/mark",
-		ServeArgs: []string{"serve", "--cortex", "agentbrain", "--transport", "http", "--host", "127.0.0.1"},
+		HomeDir:   "/Users/user",
+		ServeArgs: []string{"serve", "--cortex", "mycortex", "--transport", "http", "--host", "127.0.0.1"},
 	})
 	for _, want := range []string{
 		"<key>EnvironmentVariables</key>",
@@ -785,7 +785,7 @@ func TestBuildLaunchdPlist_EmitsEnvironmentVariablesBlock(t *testing.T) {
 // local-only workflows.
 func TestRunPrintMCPConfig_StdioShape(t *testing.T) {
 	prev := cortexFlag
-	cortexFlag = "agentbrain"
+	cortexFlag = "mycortex"
 	t.Cleanup(func() { cortexFlag = prev })
 
 	var buf bytes.Buffer
@@ -821,13 +821,13 @@ func TestRunPrintMCPConfig_StdioShape(t *testing.T) {
 	// pins exactly the cortex the operator was viewing at print time.
 	found := false
 	for _, a := range entry.Args {
-		if a == "agentbrain" {
+		if a == "mycortex" {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Errorf("stdio entry args do not pin --cortex agentbrain: %v", entry.Args)
+		t.Errorf("stdio entry args do not pin --cortex mycortex: %v", entry.Args)
 	}
 }
 
@@ -938,16 +938,16 @@ func TestRunPrintMCPConfig_HTTPIPv6Brackets(t *testing.T) {
 // --cortex" error would be technically correct but would put the operator
 // right back in the same diagnostic loop the guard exists to short-circuit.
 func TestValidateHTTPServe_ImplicitCortexErrorMessage(t *testing.T) {
-	err := validateHTTPServe([]string{"ai-1.example.com"}, "", "", "ai-1", false)
+	err := validateHTTPServe([]string{"peer-a.example.com"}, "", "", "peer-a", false)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
 	msg := err.Error()
 	for _, want := range []string{
-		`"ai-1"`,                             // names the bound cortex
-		"--cortex ai-1",                      // suggests the exact fix
+		`"peer-a"`,                             // names the bound cortex
+		"--cortex peer-a",                      // suggests the exact fix
 		"--transport http",                   // includes the transport flag
-		"--host ai-1.example.com",            // includes the host
+		"--host peer-a.example.com",            // includes the host
 		"silent failures on the peer side",   // explains *why*
 		"NOEMA_CORTEX or the config default", // names the implicit paths
 	} {

--- a/internal/cli/serve_logging_test.go
+++ b/internal/cli/serve_logging_test.go
@@ -41,11 +41,11 @@ func TestSetupServeLogging_StdioDefault(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_STATE_HOME", tmp)
 
-	got, err := setupServeLogging("agentbrain", "stdio", "", false)
+	got, err := setupServeLogging("mycortex", "stdio", "", false)
 	if err != nil {
 		t.Fatalf("setupServeLogging: %v", err)
 	}
-	want := filepath.Join(tmp, "noema", "agentbrain.log")
+	want := filepath.Join(tmp, "noema", "mycortex.log")
 	if got != want {
 		t.Errorf("path = %q, want %q", got, want)
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -42,8 +42,8 @@ func TestConfigMarshalRoundTrip(t *testing.T) {
 
 // TestSave_RejectsDuplicatePaths pins the guardrail in validatePaths: two
 // cortex entries cannot share the same on-disk directory. The motivating
-// failure mode was a stray `noema serve --cortex agentbrain` process
-// federating agentbrain's events under the "ai-1" alias because both
+// failure mode was a stray `noema serve --cortex mycortex` process
+// federating mycortex's events under the "peer-a" alias because both
 // entries had been pointed (via copy/paste) at the same directory.
 //
 // HOME is redirected so a passing run can't accidentally stomp on the

--- a/internal/consolidation/election.go
+++ b/internal/consolidation/election.go
@@ -1,6 +1,7 @@
 package consolidation
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -65,6 +66,14 @@ type Outcome struct {
 // lives in federation_state rather than in the struct.
 type Election struct {
 	cfg ElectionConfig
+
+	// quietWait blocks for the quiet period between Claim and the
+	// recheck Decide, returning the ctx error if cancelled mid-wait.
+	// Defaults to a real-time, ctx-aware sleep; tests override it (via
+	// SetQuietWaitHook in export_test.go) to drive the recheck
+	// deterministically instead of racing a real sleep from a separate
+	// goroutine.
+	quietWait func(ctx context.Context, d time.Duration) error
 }
 
 // NewElection constructs an evaluator with defaults filled in.
@@ -75,7 +84,30 @@ func NewElection(cfg ElectionConfig) *Election {
 	if cfg.Log == nil {
 		cfg.Log = func(string, ...any) {}
 	}
-	return &Election{cfg: cfg}
+	return &Election{cfg: cfg, quietWait: realQuietWait}
+}
+
+// realQuietWait is the production quiet-period waiter: a ctx-aware sleep
+// of d. A non-positive d returns immediately (tests pass zero to skip
+// the wait). Cancellation returns ctx.Err so the pass gate can classify
+// it as context_canceled.
+func realQuietWait(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(d):
+		return nil
+	}
+}
+
+// waitQuietPeriod blocks for the configured quiet period (or until ctx
+// is cancelled) between the Claim and the recheck Decide. Returns
+// ctx.Err on cancellation, nil otherwise.
+func (e *Election) waitQuietPeriod(ctx context.Context) error {
+	return e.quietWait(ctx, e.cfg.QuietPeriod)
 }
 
 // CortexID returns the configured local cortex ID. Exposed so callers
@@ -159,7 +191,7 @@ type FailData struct {
 // The three "preempted" reasons (PeerOutranked, NoWinnerAtRecheck,
 // ContextCanceled) replace the older catch-all "aborted_by_peer_conflict"
 // reason that was emitted by all three quiet-period exit paths. Telling
-// them apart in the event log lets operators distinguish "ai-3 outranked
+// them apart in the event log lets operators distinguish "peer-c outranked
 // us during the wait" from "everyone's rank entry expired" from
 // "agent.Stop() interrupted us" — same outcome (no pass), wildly
 // different operational meaning.

--- a/internal/consolidation/election_test.go
+++ b/internal/consolidation/election_test.go
@@ -74,11 +74,11 @@ func TestDecide_NoEligiblePeers(t *testing.T) {
 	state := newElectionState(t)
 	now := time.Date(2026, 4, 21, 12, 0, 0, 0, time.UTC)
 	must(t, state.SetLocalRank(federation.RankEntry{CortexID: "01LOCAL", Rank: 0, ObservedAt: stale(now)}))
-	must(t, state.SetPeerRank("ai-2", federation.RankEntry{CortexID: "01PEER", Rank: 0, ObservedAt: stale(now)}))
+	must(t, state.SetPeerRank("peer-b", federation.RankEntry{CortexID: "01PEER", Rank: 0, ObservedAt: stale(now)}))
 
 	e := consolidation.NewElection(consolidation.ElectionConfig{
 		CortexID:  "01LOCAL",
-		PeerNames: []string{"ai-2"},
+		PeerNames: []string{"peer-b"},
 		Now:       func() time.Time { return now },
 		State:     state,
 		Emitter:   &fakeEmitter{},
@@ -121,11 +121,11 @@ func TestDecide_HigherRankedPeerWins(t *testing.T) {
 	state := newElectionState(t)
 	now := time.Date(2026, 4, 21, 12, 0, 0, 0, time.UTC)
 	must(t, state.SetLocalRank(federation.RankEntry{CortexID: "01LOCAL", Rank: 30, ObservedAt: stale(now)}))
-	must(t, state.SetPeerRank("ai-2", federation.RankEntry{CortexID: "01PEER", Rank: 80, ObservedAt: stale(now)}))
+	must(t, state.SetPeerRank("peer-b", federation.RankEntry{CortexID: "01PEER", Rank: 80, ObservedAt: stale(now)}))
 
 	e := consolidation.NewElection(consolidation.ElectionConfig{
 		CortexID:  "01LOCAL",
-		PeerNames: []string{"ai-2"},
+		PeerNames: []string{"peer-b"},
 		Now:       func() time.Time { return now },
 		State:     state,
 		Emitter:   &fakeEmitter{},
@@ -145,11 +145,11 @@ func TestDecide_LocalWinsOnTiebreak(t *testing.T) {
 	state := newElectionState(t)
 	now := time.Date(2026, 4, 21, 12, 0, 0, 0, time.UTC)
 	must(t, state.SetLocalRank(federation.RankEntry{CortexID: "01ZZZ", Rank: 50, ObservedAt: stale(now)}))
-	must(t, state.SetPeerRank("ai-2", federation.RankEntry{CortexID: "01AAA", Rank: 50, ObservedAt: stale(now)}))
+	must(t, state.SetPeerRank("peer-b", federation.RankEntry{CortexID: "01AAA", Rank: 50, ObservedAt: stale(now)}))
 
 	e := consolidation.NewElection(consolidation.ElectionConfig{
 		CortexID:  "01ZZZ",
-		PeerNames: []string{"ai-2"},
+		PeerNames: []string{"peer-b"},
 		Now:       func() time.Time { return now },
 		State:     state,
 		Emitter:   &fakeEmitter{},
@@ -174,7 +174,7 @@ func TestDecide_QuietPeriodExcludesFreshEntries(t *testing.T) {
 		Rank:       99,
 		ObservedAt: now.Add(-5 * time.Second).UTC().Format(time.RFC3339), // fresh
 	}))
-	must(t, state.SetPeerRank("ai-2", federation.RankEntry{
+	must(t, state.SetPeerRank("peer-b", federation.RankEntry{
 		CortexID:   "01PEER",
 		Rank:       30,
 		ObservedAt: now.Add(-time.Hour).UTC().Format(time.RFC3339), // stale
@@ -182,7 +182,7 @@ func TestDecide_QuietPeriodExcludesFreshEntries(t *testing.T) {
 
 	e := consolidation.NewElection(consolidation.ElectionConfig{
 		CortexID:    "01LOCAL",
-		PeerNames:   []string{"ai-2"},
+		PeerNames:   []string{"peer-b"},
 		QuietPeriod: time.Minute,
 		Now:         func() time.Time { return now },
 		State:       state,

--- a/internal/consolidation/export_test.go
+++ b/internal/consolidation/export_test.go
@@ -1,0 +1,16 @@
+package consolidation
+
+import (
+	"context"
+	"time"
+)
+
+// SetQuietWaitHook overrides the quiet-period waiter so tests can drive
+// the gap between the initial Decide and the post-quiet recheck
+// deterministically — mutating rank state synchronously inside the hook
+// instead of racing a real-time sleep from a separate goroutine. The hook
+// receives the context and configured duration; returning a non-nil error
+// is treated by the pass gate as a context cancellation.
+func (e *Election) SetQuietWaitHook(fn func(ctx context.Context, d time.Duration) error) {
+	e.quietWait = fn
+}

--- a/internal/consolidation/pass_gate.go
+++ b/internal/consolidation/pass_gate.go
@@ -3,7 +3,6 @@ package consolidation
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/Fail-Safe/Noema/internal/event"
 )
@@ -57,13 +56,9 @@ func WithElection(inner PassFn, election *Election, registry *InFlightRegistry, 
 
 		// Quiet-period wait for conflicting claims. Respect ctx so
 		// Agent.Stop() doesn't block on a multi-second sleep.
-		if election.QuietPeriod() > 0 {
-			select {
-			case <-ctx.Done():
-				_ = election.Fail(windowID, FailReasonContextCanceled)
-				return ctx.Err()
-			case <-time.After(election.QuietPeriod()):
-			}
+		if err := election.waitQuietPeriod(ctx); err != nil {
+			_ = election.Fail(windowID, FailReasonContextCanceled)
+			return err
 		}
 
 		recheck := election.Decide()

--- a/internal/consolidation/pass_gate_test.go
+++ b/internal/consolidation/pass_gate_test.go
@@ -26,12 +26,12 @@ func TestWithElection_SkipsWhenNotElected(t *testing.T) {
 	state := newElectionState(t)
 	now := time.Date(2026, 4, 21, 12, 0, 0, 0, time.UTC)
 	must(t, state.SetLocalRank(federation.RankEntry{CortexID: "01LOCAL", Rank: 20, ObservedAt: stale(now)}))
-	must(t, state.SetPeerRank("ai-2", federation.RankEntry{CortexID: "01PEER", Rank: 80, ObservedAt: stale(now)}))
+	must(t, state.SetPeerRank("peer-b", federation.RankEntry{CortexID: "01PEER", Rank: 80, ObservedAt: stale(now)}))
 
 	emitter := &fakeEmitter{}
 	e := consolidation.NewElection(consolidation.ElectionConfig{
 		CortexID:  "01LOCAL",
-		PeerNames: []string{"ai-2"},
+		PeerNames: []string{"peer-b"},
 		Now:       func() time.Time { return now },
 		State:     state,
 		Emitter:   emitter,
@@ -57,12 +57,12 @@ func TestWithElection_RunsWhenElected(t *testing.T) {
 	state := newElectionState(t)
 	now := time.Date(2026, 4, 21, 12, 0, 0, 0, time.UTC)
 	must(t, state.SetLocalRank(federation.RankEntry{CortexID: "01LOCAL", Rank: 99, ObservedAt: stale(now)}))
-	must(t, state.SetPeerRank("ai-2", federation.RankEntry{CortexID: "01PEER", Rank: 10, ObservedAt: stale(now)}))
+	must(t, state.SetPeerRank("peer-b", federation.RankEntry{CortexID: "01PEER", Rank: 10, ObservedAt: stale(now)}))
 
 	emitter := &fakeEmitter{}
 	e := consolidation.NewElection(consolidation.ElectionConfig{
 		CortexID:    "01LOCAL",
-		PeerNames:   []string{"ai-2"},
+		PeerNames:   []string{"peer-b"},
 		QuietPeriod: 0, // zero = skip the sleep for fast tests
 		Now:         func() time.Time { return now },
 		State:       state,
@@ -185,24 +185,11 @@ func TestWithElection_EmitsNoWinnerAtRecheck(t *testing.T) {
 	// peer-outranked reason. Operationally this signals "everyone
 	// dropped out", not "someone else won" — different debugging path.
 	//
-	// Reproduce by handing Decide() a now-time that makes the local
-	// rank fresh enough to count at t=0 but stale enough to be
-	// filtered when the recheck advances the clock past the entry's
-	// validity window. We do this by writing a rank with ObservedAt
-	// well in the past and using a non-zero QuietPeriod such that
-	// recheck filters it out — except the existing minAge check
-	// requires entries to be at least minAge old, not at most.
-	//
-	// Simpler approach: install a hook that flips local rank to 0
-	// between Decide and recheck. We do that by writing the initial
-	// rank, letting the wrapper take its first Decide (we won), then
-	// the test's clock function returns a "now" that drives the
-	// recheck. To make recheck see no eligible peers, overwrite the
-	// rank entry with Rank=0 just before the wrapper resleeps.
-	//
-	// Because the wrapper sleeps real time when QuietPeriod > 0 and
-	// we want no flake, use QuietPeriod = 50ms and overwrite the
-	// rank from the test goroutine after a brief wait.
+	// At t=0 the local rank wins. The quiet-wait hook then demotes it
+	// to RankIneligible (0) so the recheck finds no eligible peer. The
+	// hook runs synchronously between the two Decide calls — no
+	// goroutine, no real sleep — so the demotion can't lose a race
+	// against the wait under CI load. See SetQuietWaitHook.
 	state := newElectionState(t)
 	now := time.Date(2026, 4, 21, 12, 0, 0, 0, time.UTC)
 	must(t, state.SetLocalRank(federation.RankEntry{CortexID: "01LOCAL", Rank: 50, ObservedAt: stale(now)}))
@@ -215,16 +202,12 @@ func TestWithElection_EmitsNoWinnerAtRecheck(t *testing.T) {
 		State:       state,
 		Emitter:     emitter,
 	})
+	e.SetQuietWaitHook(func(context.Context, time.Duration) error {
+		return state.SetLocalRank(federation.RankEntry{CortexID: "01LOCAL", Rank: 0, ObservedAt: stale(now)})
+	})
 
 	inner := &callTracker{}
 	wrapped := consolidation.WithElection(inner.pass, e, nil, nil)
-
-	// Demote local rank to 0 partway through the quiet period so the
-	// recheck finds zero eligible peers.
-	go func() {
-		time.Sleep(10 * time.Millisecond)
-		_ = state.SetLocalRank(federation.RankEntry{CortexID: "01LOCAL", Rank: 0, ObservedAt: stale(now)})
-	}()
 
 	if err := wrapped(context.Background(), "cron"); err != nil {
 		t.Fatalf("wrapped: %v", err)
@@ -244,7 +227,9 @@ func TestWithElection_EmitsPeerOutrankedAtRecheck(t *testing.T) {
 	// Peer-outranked-at-recheck guard: a peer that wasn't visible at
 	// initial Decide arrives during the quiet period and outranks
 	// us. The wrapper must surface FailReasonPeerOutranked, not the
-	// no-winner reason.
+	// no-winner reason. The higher-ranked peer is published synchronously
+	// from the quiet-wait hook (between the two Decide calls) so the
+	// arrival can't race the wait under CI load. See SetQuietWaitHook.
 	state := newElectionState(t)
 	now := time.Date(2026, 4, 21, 12, 0, 0, 0, time.UTC)
 	must(t, state.SetLocalRank(federation.RankEntry{CortexID: "01LOCAL", Rank: 30, ObservedAt: stale(now)}))
@@ -252,21 +237,18 @@ func TestWithElection_EmitsPeerOutrankedAtRecheck(t *testing.T) {
 	emitter := &fakeEmitter{}
 	e := consolidation.NewElection(consolidation.ElectionConfig{
 		CortexID:    "01LOCAL",
-		PeerNames:   []string{"ai-2"},
+		PeerNames:   []string{"peer-b"},
 		QuietPeriod: 50 * time.Millisecond,
 		Now:         func() time.Time { return now },
 		State:       state,
 		Emitter:     emitter,
 	})
+	e.SetQuietWaitHook(func(context.Context, time.Duration) error {
+		return state.SetPeerRank("peer-b", federation.RankEntry{CortexID: "01PEER", Rank: 90, ObservedAt: stale(now)})
+	})
 
 	inner := &callTracker{}
 	wrapped := consolidation.WithElection(inner.pass, e, nil, nil)
-
-	// Higher-ranked peer surfaces during the quiet wait.
-	go func() {
-		time.Sleep(10 * time.Millisecond)
-		_ = state.SetPeerRank("ai-2", federation.RankEntry{CortexID: "01PEER", Rank: 90, ObservedAt: stale(now)})
-	}()
 
 	if err := wrapped(context.Background(), "cron"); err != nil {
 		t.Fatalf("wrapped: %v", err)

--- a/internal/consolidation/rank_test.go
+++ b/internal/consolidation/rank_test.go
@@ -163,10 +163,10 @@ func TestPeerRank_RoundTrip(t *testing.T) {
 		Rank:       77,
 		ObservedAt: "2026-04-21T12:01:00Z",
 	}
-	if err := s.SetPeerRank("ai-2", want); err != nil {
+	if err := s.SetPeerRank("peer-b", want); err != nil {
 		t.Fatalf("SetPeerRank: %v", err)
 	}
-	got, err = s.GetPeerRank("ai-2")
+	got, err = s.GetPeerRank("peer-b")
 	if err != nil {
 		t.Fatalf("GetPeerRank after write: %v", err)
 	}
@@ -180,16 +180,16 @@ func TestPeerRank_Isolation(t *testing.T) {
 	s := newStateForTest(t)
 
 	aEntry := federation.RankEntry{CortexID: "01A", Rank: 10, ObservedAt: "2026-04-21T12:00:00Z"}
-	if err := s.SetPeerRank("ai-2", aEntry); err != nil {
-		t.Fatalf("SetPeerRank ai-2: %v", err)
+	if err := s.SetPeerRank("peer-b", aEntry); err != nil {
+		t.Fatalf("SetPeerRank peer-b: %v", err)
 	}
 
-	b, err := s.GetPeerRank("ai-3")
+	b, err := s.GetPeerRank("peer-c")
 	if err != nil {
-		t.Fatalf("GetPeerRank ai-3: %v", err)
+		t.Fatalf("GetPeerRank peer-c: %v", err)
 	}
 	if b.Rank != consolidation.RankIneligible {
-		t.Errorf("ai-3 rank bled from ai-2: got %d, want %d", b.Rank, consolidation.RankIneligible)
+		t.Errorf("peer-c rank bled from peer-b: got %d, want %d", b.Rank, consolidation.RankIneligible)
 	}
 
 	local, err := s.GetLocalRank()

--- a/internal/cortex/cortex_test.go
+++ b/internal/cortex/cortex_test.go
@@ -656,7 +656,7 @@ func TestSearch_StructuralCharsAsLiterals(t *testing.T) {
 func TestSearch_HyphenatedTerms(t *testing.T) {
 	cx := setup(t)
 
-	tr := trace.New("format-test-create", "note", "hermes/testbot", []string{"hermes-contract-test"}, "Testing create response format.")
+	tr := trace.New("format-test-create", "note", "hermes/agent-3", []string{"hermes-contract-test"}, "Testing create response format.")
 	if err := cx.Add(tr); err != nil {
 		t.Fatalf("Add: %v", err)
 	}
@@ -1203,7 +1203,7 @@ func TestSync_LongTierWithoutDriftStillUpdatesVisibility(t *testing.T) {
 // version of the fix missed cortex_id in its drift check, so this case
 // fell through to the blanket UPDATE and re-tripped the trigger.
 //
-// Real-world setup: file frontmatter says `origin: agentbrain` (matches
+// Real-world setup: file frontmatter says `origin: mycortex` (matches
 // local cortex name); DB row's cortex_id is a foreign ULID. Sync must
 // report drift, leave cortex_id alone, and not abort.
 func TestSync_LongTierForeignCortexIDDoesNotAbort(t *testing.T) {
@@ -1213,12 +1213,12 @@ func TestSync_LongTierForeignCortexIDDoesNotAbort(t *testing.T) {
 	// cortex_id without tripping the immutability trigger (it only
 	// fires when OLD.tier='long' AND NEW.tier='long'). Then flip tier
 	// to long in a single UPDATE that sets both columns at once.
-	tr := trace.New("Federation-inherited long-tier", "context", "hermes/paige", []string{"hermes-session"}, "Body.")
+	tr := trace.New("Federation-inherited long-tier", "context", "hermes/agent-2", []string{"hermes-session"}, "Body.")
 	tr.Origin = cx.Name // mirrors the live bug: name matches, ID won't.
 	if err := cx.Add(tr); err != nil {
 		t.Fatalf("Add: %v", err)
 	}
-	foreignCortexID := "01KNJX4991ASW6NNKS9BQHNCGB" // ai-1's ULID in the live report
+	foreignCortexID := "01JQ3Z4XKP8VY6H7B9W2R5T8MN" // peer-a's ULID in the live report
 	if _, err := cx.DB.Exec(
 		`UPDATE traces SET cortex_id = ?, tier = 'long' WHERE id = ?`,
 		foreignCortexID, tr.ID,
@@ -1704,7 +1704,7 @@ func TestBackfillCreateEvents_SyncedTraceGetsCreate(t *testing.T) {
 
 	// Drop a markdown file directly to disk and Sync it — this is the path
 	// that creates a DB row without an event, exactly like the production
-	// case the user is hitting on ai-1.
+	// case the user is hitting on peer-a.
 	tr := trace.New("Synced trace", "fact", "agent-x", []string{"alpha", "beta"}, "Body content.")
 	if err := tr.Write(cx.TraceFile(tr.ID, false)); err != nil {
 		t.Fatalf("Write: %v", err)
@@ -2420,7 +2420,7 @@ func triggerDivergence(t *testing.T, cx *cortex.Cortex, traceID string) {
 // promote into a create (the snapshot in the event is enough to materialize
 // the trace); the four soft-state mutations (archive/unarchive/trash/recover)
 // store the event idempotently and move on. The original failure mode that
-// motivated this — orphan agentbrain events spamming ai-2/ai-3 with
+// motivated this — orphan mycortex events spamming peer-b/peer-c with
 // "trace not found" replay errors — must stay fixed.
 
 // missingTraceUpdateEvent builds an update event for a trace ID that does

--- a/internal/federation/state_health_test.go
+++ b/internal/federation/state_health_test.go
@@ -41,10 +41,10 @@ func TestPeerHealth_RoundTrip(t *testing.T) {
 		},
 	}
 
-	if err := s.SetPeerHealth("ai-2", want); err != nil {
+	if err := s.SetPeerHealth("peer-b", want); err != nil {
 		t.Fatalf("SetPeerHealth: %v", err)
 	}
-	got, err := s.GetPeerHealth("ai-2")
+	got, err := s.GetPeerHealth("peer-b")
 	if err != nil {
 		t.Fatalf("GetPeerHealth: %v", err)
 	}
@@ -78,11 +78,11 @@ func TestPeerHealth_MissingReturnsEmpty(t *testing.T) {
 
 func TestGetPeerState_IncludesHealth(t *testing.T) {
 	s := newStateForTest(t)
-	err := s.SetPeerHealth("ai-3", federation.PeerHealth{Version: "v0.5.0"})
+	err := s.SetPeerHealth("peer-c", federation.PeerHealth{Version: "v0.5.0"})
 	if err != nil {
 		t.Fatalf("SetPeerHealth: %v", err)
 	}
-	ps, err := s.GetPeerState("ai-3", "https://ai-3:3000")
+	ps, err := s.GetPeerState("peer-c", "https://peer-c:3000")
 	if err != nil {
 		t.Fatalf("GetPeerState: %v", err)
 	}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -86,7 +86,7 @@ func TestTierGlyph(t *testing.T) {
 // keeps that fix from regressing.
 func TestRenderInstructions_IncludesNoemaVersion(t *testing.T) {
 	out := renderInstructions(cortex.Manifest{
-		Name:    "agentbrain",
+		Name:    "mycortex",
 		Version: 2,
 	}, "v0.2.5-test")
 
@@ -163,7 +163,7 @@ func TestRenderInstructions_ManifestVersionReflectsInput(t *testing.T) {
 
 // TestRenderInstructions_WarnsAgainstDateInTitle pins the warning text
 // added after a fleet of agents on the live federation ring was found
-// creating traces with IDs like 20260402-20260402-dadbot-foo. The agents
+// creating traces with IDs like 20260402-20260402-agent-1-foo. The agents
 // were dutifully putting dates in titles to mark when an event occurred,
 // and trace.NewID was prepending today's date on top — producing the
 // doubled prefix. NewID now strips leading YYYYMMDD- and YYYY-MM-DD-

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -211,9 +211,9 @@ func (t *Trace) Write(path string) error {
 // `YYYYMMDD-` or `YYYY-MM-DD-`), the leading date is stripped before
 // today's date is prepended. This is a defensive measure: agents
 // commonly include dates in titles to mark when an event occurred
-// (e.g., "20260402 dadbot heartbeat check"), and without the strip
+// (e.g., "20260402 agent-1 heartbeat check"), and without the strip
 // the resulting ID would carry two date prefixes
-// (`20260402-20260402-dadbot-heartbeat-check`). The strip does not
+// (`20260402-20260402-agent-1-heartbeat-check`). The strip does not
 // validate that the digits form a real calendar date — its only job
 // is to prevent visual prefix duplication in the final ID.
 func NewID(title string) string {

--- a/internal/trace/trace_test.go
+++ b/internal/trace/trace_test.go
@@ -181,13 +181,13 @@ func TestNewID_StripsLeadingDatePrefix(t *testing.T) {
 	}{
 		{
 			name:     "YYYYMMDD prefix with space separator",
-			title:    "20260402 dadbot autonomous infrastructure access",
-			wantSlug: "dadbot-autonomous-infrastructure-access",
+			title:    "20260402 agent-1 autonomous infrastructure access",
+			wantSlug: "agent-1-autonomous-infrastructure-access",
 		},
 		{
 			name:     "YYYYMMDD prefix already slug-shaped",
-			title:    "20260402-dadbot-autonomous-infrastructure-access",
-			wantSlug: "dadbot-autonomous-infrastructure-access",
+			title:    "20260402-agent-1-autonomous-infrastructure-access",
+			wantSlug: "agent-1-autonomous-infrastructure-access",
 		},
 		{
 			name:     "YYYY-MM-DD prefix with space separator",
@@ -211,8 +211,8 @@ func TestNewID_StripsLeadingDatePrefix(t *testing.T) {
 		},
 		{
 			name:     "eight digits without trailing hyphen are not stripped",
-			title:    "20260402dadbot",
-			wantSlug: "20260402dadbot",
+			title:    "20260402agent-1",
+			wantSlug: "20260402agent-1",
 		},
 	}
 

--- a/tests/security-mcp-pentest-playbook.md
+++ b/tests/security-mcp-pentest-playbook.md
@@ -28,8 +28,8 @@ MANIFEST
 NOEMA_MCP_KEY=test-bearer-token-12345 ./files/noema serve \
   --cortex testcortex --transport http \
   --host 127.0.0.1 --port 3000 \
-  --tls-cert /home/mark/.certs/fullchain.cer \
-  --tls-key /home/mark/.certs/home-dns.com.key &
+  --tls-cert /home/user/.certs/fullchain.cer \
+  --tls-key /home/user/.certs/example.com.key &
 SERVER_PID=$!
 sleep 2
 ```


### PR DESCRIPTION
Patch release: deterministic consolidation recheck tests + normalized example identifiers across fixtures/docs. No production behavior change. Tree identical to next.