### PR TITLE
feat(obsidian): bearer-key rejection notice + test-connection button (v0.2.1)

### DIFF
--- a/plugins/obsidian/README.md
+++ b/plugins/obsidian/README.md
@@ -6,7 +6,7 @@ Lineage view and tier visibility for [Noema](https://github.com/Fail-Safe/Noema)
 
 - **Lineage sidebar.** When you open a trace, the sidebar shows its `derived_from` ancestors and the traces derived from it, both clickable. Useful for navigating "where did this come from / what came out of this" without leaving the editor.
 - **Tier badge in the status bar.** Shows `[s]` / `[m]` / `[L]` for the currently-open trace and a tooltip note that long-tier traces are immutable.
-- **Connection status.** The same status bar item shows whether the plugin is connected to a `noema serve --transport http` endpoint.
+- **Connection status.** The same status bar item shows whether the plugin is connected to a `noema serve --transport http` endpoint. A keyed-mode server that rejects (or requires) the bearer key shows `noema: unauthorized` instead of `noema: disconnected`, and pops a one-time notice pointing you at the bearer-key setting — so a wrong key reads as a credential problem, not an unreachable server.
 
 That's intentionally the whole feature set for v0.1. File-explorer decorations, trace creation UI, and FTS5-backed search are reasonable next-version additions but aren't here yet.
 
@@ -19,6 +19,7 @@ That's intentionally the whole feature set for v0.1. File-explorer decorations, 
 5. Open the plugin's settings tab and set:
    - **HTTP endpoint** — e.g. `https://noema.local:3000`
    - **Bearer key** — required if the server is in keyed mode (`NOEMA_MCP_KEY` or `access.shared_key_file`); leave empty for open-mode (loopback only).
+   - **Test connection** — click to probe the endpoint immediately and get a notice telling you whether it connected, was rejected (HTTP 401, fix the key), or was unreachable.
 6. Open the lineage sidebar via the command palette: `Noema: Open lineage view`.
 
 The status bar will show `noema: <cortex-name>` once the connection succeeds.

--- a/plugins/obsidian/manifest.json
+++ b/plugins/obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "noema",
   "name": "Noema",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "minAppVersion": "1.4.0",
   "description": "Lineage view and tier visibility for Noema cortex traces. Connects to a noema serve --transport http endpoint.",
   "author": "Mark Baker",

--- a/plugins/obsidian/manifest.json
+++ b/plugins/obsidian/manifest.json
@@ -1,10 +1,10 @@
 {
   "id": "noema",
   "name": "Noema",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "minAppVersion": "1.4.0",
-  "description": "Lineage view and tier visibility for Noema cortex traces. Connects to a noema serve --transport http endpoint.",
-  "author": "Mark Baker",
+  "description": "Lineage view and tier visibility for Noema cortex traces. Connects to a `noema serve --transport http` endpoint.",
+  "author": "Mark Baker (https://github.com/Fail-Safe)",
   "authorUrl": "https://github.com/Fail-Safe/Noema",
   "fundingUrl": "",
   "isDesktopOnly": false

--- a/plugins/obsidian/package.json
+++ b/plugins/obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noema-obsidian",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Lineage view and tier visibility for Noema cortex traces inside Obsidian.",
   "main": "main.js",
   "scripts": {

--- a/plugins/obsidian/package.json
+++ b/plugins/obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noema-obsidian",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Lineage view and tier visibility for Noema cortex traces inside Obsidian.",
   "main": "main.js",
   "scripts": {

--- a/plugins/obsidian/src/main.ts
+++ b/plugins/obsidian/src/main.ts
@@ -1,13 +1,19 @@
 import { Notice, Plugin, TFile, WorkspaceLeaf } from "obsidian";
 import { DEFAULT_SETTINGS, NoemaSettings, NoemaSettingTab } from "./settings";
 import { LineageView, LINEAGE_VIEW_TYPE } from "./lineage-view";
-import { McpClient } from "./mcp-client";
+import { McpClient, UnauthorizedError } from "./mcp-client";
 import { readTraceMetadata, tierGlyph, tierLabel } from "./tier-status";
 import { CreateTraceModal } from "./create-modal";
 import { ImmutableWarning } from "./immutable-warning";
 import { openAppendModalFromActive } from "./append-modal";
 
 const STATUS_PING_INTERVAL_MS = 30_000;
+
+// ConnState is the outcome of the most recent cortex_identity probe.
+// "unauthorized" is a first-class state rather than a flavor of
+// "disconnected" because the remedy is different and we want to nudge
+// the user toward it (see setConnState's one-shot Notice).
+type ConnState = "connected" | "disconnected" | "unauthorized";
 
 // NoemaPlugin is the Obsidian-side entry point. It wires up:
 //
@@ -30,7 +36,11 @@ export default class NoemaPlugin extends Plugin {
 	// "foreign" (warn) or local (don't warn).
 	cortexName = "";
 	private statusBarEl: HTMLElement | null = null;
-	private connected = false;
+	// connState tracks the last probe result. "unauthorized" is split
+	// out from "disconnected" so a rejected/missing bearer key reads as
+	// a credential problem (actionable: fix the key) rather than as an
+	// unreachable server (actionable: check the endpoint/network).
+	private connState: ConnState = "disconnected";
 	private immutableWarning: ImmutableWarning | null = null;
 
 	async onload(): Promise<void> {
@@ -158,7 +168,7 @@ export default class NoemaPlugin extends Plugin {
 	refreshClient(): void {
 		if (!this.settings.endpoint) {
 			this.client = null;
-			this.connected = false;
+			this.connState = "disconnected";
 			this.renderStatus();
 			return;
 		}
@@ -173,21 +183,93 @@ export default class NoemaPlugin extends Plugin {
 		this.pingConnection();
 	}
 
-	private async pingConnection(): Promise<void> {
+	// probe runs one cortex_identity round-trip and classifies the
+	// outcome, updating cortexName as a side effect. It does NOT touch
+	// the status bar or fire notices — callers decide how to surface the
+	// result. Both the background ping and the settings "Test
+	// connection" button build on it so they classify failures
+	// identically.
+	private async probe(): Promise<ConnState> {
 		if (!this.client) {
-			this.connected = false;
 			this.cortexName = "";
-			this.renderStatus();
-			return;
+			return "disconnected";
 		}
 		try {
 			const id = await this.client.cortexIdentity();
-			this.connected = true;
 			this.cortexName = id.name;
-		} catch {
-			this.connected = false;
+			return "connected";
+		} catch (err) {
+			this.cortexName = "";
+			// A bearer-key rejection is distinct from "server's not
+			// there" — the AuthMiddleware 401 surfaces as
+			// UnauthorizedError, everything else (DNS, TLS, refused
+			// connection, 5xx) is a plain disconnect.
+			return err instanceof UnauthorizedError ? "unauthorized" : "disconnected";
 		}
+	}
+
+	private async pingConnection(): Promise<void> {
+		this.setConnState(await this.probe());
 		this.renderStatus();
+	}
+
+	// testConnection is the explicit, user-triggered probe behind the
+	// settings "Test connection" button. Unlike the passive ping, it
+	// reports an outcome on every invocation — that's the whole point of
+	// a test button — so it writes connState directly rather than
+	// through setConnState, whose Notice fires only on transitions (which
+	// would leave a repeat click on an already-unauthorized server
+	// silent). The status bar still stays in sync.
+	async testConnection(): Promise<void> {
+		if (!this.settings.endpoint) {
+			new Notice("Noema: set an HTTP endpoint first.");
+			return;
+		}
+		// The settings onChange handlers keep the client current, but a
+		// freshly-opened settings tab with a saved endpoint may not have
+		// constructed one yet if the endpoint was unset at load.
+		if (!this.client) {
+			this.client = new McpClient(this.settings.endpoint, this.settings.bearerKey);
+		}
+		const state = await this.probe();
+		this.connState = state;
+		this.renderStatus();
+		switch (state) {
+			case "connected":
+				new Notice(`Noema: connected to ${this.cortexName || this.settings.endpoint}.`);
+				break;
+			case "unauthorized":
+				new Notice(
+					this.settings.bearerKey
+						? `Noema: ${this.settings.endpoint} rejected the bearer key (HTTP 401). Check the key below.`
+						: `Noema: ${this.settings.endpoint} requires a bearer key (HTTP 401). Set one below.`,
+					8000
+				);
+				break;
+			case "disconnected":
+				new Notice(`Noema: couldn't reach ${this.settings.endpoint}.`);
+				break;
+		}
+	}
+
+	// setConnState updates the cached state and, on the *transition*
+	// into "unauthorized", fires a single Notice. Gating on the
+	// transition (rather than the state) keeps the 30s ping loop from
+	// re-toasting the same rejection every tick — the user gets one
+	// actionable nudge when the auth failure first appears, and again
+	// only if they recover and then break it again.
+	private setConnState(next: ConnState): void {
+		const prev = this.connState;
+		this.connState = next;
+		if (next === "unauthorized" && prev !== "unauthorized") {
+			const detail = this.settings.bearerKey
+				? "the bearer key was rejected"
+				: "this server requires a bearer key";
+			new Notice(
+				`Noema: ${detail} (HTTP 401). Update it in the Noema plugin settings.`,
+				8000
+			);
+		}
 	}
 
 	private renderStatus(): void {
@@ -219,10 +301,17 @@ export default class NoemaPlugin extends Plugin {
 			conn.setAttr("title", "Set an HTTP endpoint in settings to connect.");
 			return;
 		}
-		if (this.connected) {
+		if (this.connState === "connected") {
 			conn.setText(`noema: ${this.cortexName || "connected"}`);
 			conn.setAttr("title", `Connected to ${this.settings.endpoint}`);
 			conn.addClass("noema-status-ok");
+		} else if (this.connState === "unauthorized") {
+			conn.setText("noema: unauthorized");
+			conn.setAttr(
+				"title",
+				`${this.settings.endpoint} rejected the bearer key (HTTP 401). Check the key in Noema settings.`
+			);
+			conn.addClass("noema-status-err");
 		} else {
 			conn.setText("noema: disconnected");
 			conn.setAttr("title", `Couldn't reach ${this.settings.endpoint}`);

--- a/plugins/obsidian/src/mcp-client.ts
+++ b/plugins/obsidian/src/mcp-client.ts
@@ -28,6 +28,22 @@ export class JsonRpcError extends Error {
 	}
 }
 
+// UnauthorizedError signals that the server rejected our credentials —
+// an HTTP 401 from noema's AuthMiddleware, which fires before any MCP
+// routing when the server is in keyed mode and the Authorization header
+// is missing or doesn't match. It's distinct from generic transport
+// failures (server down, DNS, TLS) and from InvalidSessionError (404)
+// so the plugin can tell the user "your bearer key is wrong" rather
+// than the ambiguous "disconnected". serverMessage carries the body the
+// middleware returned (e.g. `unauthorized: NOEMA_MCP_KEY ... required`)
+// when one was present.
+export class UnauthorizedError extends Error {
+	constructor(public serverMessage?: string) {
+		super("MCP server rejected the bearer key (HTTP 401)");
+		this.name = "UnauthorizedError";
+	}
+}
+
 export interface NoemaIdentity {
 	id: string;
 	name: string;
@@ -263,7 +279,7 @@ export class McpClient {
 			params: {
 				protocolVersion: MCP_PROTOCOL_VERSION,
 				capabilities: {},
-				clientInfo: { name: "noema-obsidian", version: "0.1.0" },
+				clientInfo: { name: "noema-obsidian", version: "0.2.0" },
 			},
 		};
 		const resp = await fetch(url, {
@@ -271,6 +287,12 @@ export class McpClient {
 			headers,
 			body: JSON.stringify(initBody),
 		});
+		if (resp.status === 401) {
+			// Keyed-mode server, missing/wrong bearer key. Surface this
+			// distinctly — re-handshaking won't help, the credential is
+			// the problem.
+			throw new UnauthorizedError(await read401Message(resp));
+		}
 		if (!resp.ok) {
 			throw new Error(`initialize: HTTP ${resp.status}: ${resp.statusText}`);
 		}
@@ -310,6 +332,13 @@ export class McpClient {
 			headers,
 			body: JSON.stringify({ jsonrpc: "2.0", id, ...body }),
 		});
+		if (resp.status === 401) {
+			// Bearer key rejected mid-session (e.g. the server was
+			// restarted into keyed mode, or the key was rotated). The
+			// retry loop deliberately does NOT re-handshake on this —
+			// re-sending the same bad key just 401s again.
+			throw new UnauthorizedError(await read401Message(resp));
+		}
 		if (resp.status === 404) {
 			// "Invalid session ID" or similar. Caller will re-
 			// handshake and retry. We swallow the body here because
@@ -355,6 +384,28 @@ class InvalidSessionError extends Error {
 	constructor() {
 		super("invalid MCP session");
 		this.name = "InvalidSessionError";
+	}
+}
+
+// read401Message best-effort-extracts the human-readable reason from a
+// 401 response body. noema's AuthMiddleware returns
+// `{"error":"unauthorized: ..."}`; anything else (proxy, gateway) we
+// just hand back verbatim, trimmed. Never throws — a missing/garbled
+// body simply yields undefined so the caller falls back to its default
+// message.
+async function read401Message(resp: Response): Promise<string | undefined> {
+	try {
+		const text = (await resp.text()).trim();
+		if (!text) return undefined;
+		try {
+			const parsed = JSON.parse(text) as { error?: string };
+			if (parsed && typeof parsed.error === "string") return parsed.error;
+		} catch {
+			// Not JSON — return the raw body.
+		}
+		return text;
+	} catch {
+		return undefined;
 	}
 }
 

--- a/plugins/obsidian/src/mcp-client.ts
+++ b/plugins/obsidian/src/mcp-client.ts
@@ -279,7 +279,7 @@ export class McpClient {
 			params: {
 				protocolVersion: MCP_PROTOCOL_VERSION,
 				capabilities: {},
-				clientInfo: { name: "noema-obsidian", version: "0.2.0" },
+				clientInfo: { name: "noema-obsidian", version: "0.2.1" },
 			},
 		};
 		const resp = await fetch(url, {

--- a/plugins/obsidian/src/settings.ts
+++ b/plugins/obsidian/src/settings.ts
@@ -68,6 +68,26 @@ export class NoemaSettingTab extends PluginSettingTab {
 				text.inputEl.type = "password";
 			});
 
+		// An explicit probe button. The plugin already probes on every
+		// endpoint/key edit and every 30s, but a button gives confirmation
+		// on demand — including the "still wrong" case, where the passive
+		// transition-gated notice stays silent.
+		new Setting(containerEl)
+			.setName("Test connection")
+			.setDesc("Probe the endpoint now with the current key and report the result.")
+			.addButton((btn) =>
+				btn.setButtonText("Test connection").onClick(async () => {
+					btn.setDisabled(true);
+					btn.setButtonText("Testing…");
+					try {
+						await this.plugin.testConnection();
+					} finally {
+						btn.setButtonText("Test connection");
+						btn.setDisabled(false);
+					}
+				})
+			);
+
 		new Setting(containerEl)
 			.setName("Traces folder")
 			.setDesc("Folder inside the vault that contains trace markdown files. Default: traces")


### PR DESCRIPTION
## What

Makes the Obsidian plugin distinguish an MCP **bearer-key rejection** from a generic disconnect, and adds an on-demand connection test.

- **mcp-client:** new `UnauthorizedError`, thrown on HTTP 401 from `AuthMiddleware` in both the `initialize` handshake and `rpc()`. The session-retry loop does not re-handshake on it (re-sending a bad key just 401s again).
- **main:** connection state split into `connected` / `disconnected` / `unauthorized`; status bar shows `noema: unauthorized` and a one-time `Notice` fires on the *transition* into that state (transition-gated, so the 30s ping loop never spams).
- **settings:** a **Test connection** button that probes on demand and reports the outcome on every click — including the still-unauthorized case the passive notice intentionally stays silent for.
- **version:** bumped 0.1.0 → 0.2.1 across `manifest.json`, `package.json`, and the MCP `clientInfo`.

## Notes

- `main.js` is git-ignored; only source + docs are in the diff.
- Tested locally against a keyed-mode `noema serve --transport http` (correct key, wrong key, no key, dead endpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)