### PR TITLE
fix(cortex): make Add idempotent on same-content PK conflict (#102)

### DIFF
--- a/internal/cortex/add_errors.go
+++ b/internal/cortex/add_errors.go
@@ -115,6 +115,19 @@ func (c *Cortex) describeTraceIDCollision(id string, wrapped error) error {
 	}
 }
 
+// contentHashFor returns the content_hash stored for id, or "" if the
+// row is absent or unreadable. Add uses it on a PK conflict to tell a
+// benign duplicate (same hash → idempotent no-op) apart from a genuine
+// id collision (different content → surfaced to the caller). The lookup
+// runs against the live DB, not the failed insert transaction.
+func (c *Cortex) contentHashFor(id string) string {
+	var h sql.NullString
+	if err := c.DB.QueryRow(`SELECT content_hash FROM traces WHERE id = ?`, id).Scan(&h); err != nil {
+		return ""
+	}
+	return h.String
+}
+
 func nullString(s sql.NullString) string {
 	if s.Valid {
 		return s.String

--- a/internal/cortex/add_errors_test.go
+++ b/internal/cortex/add_errors_test.go
@@ -2,6 +2,7 @@ package cortex_test
 
 import (
 	"errors"
+	"os"
 	"strings"
 	"testing"
 
@@ -38,6 +39,41 @@ func TestAdd_CollidesActive_ReturnsTypedError(t *testing.T) {
 	}
 	if !strings.Contains(collision.Error(), "already exists (currently active)") {
 		t.Errorf("Error() should mention active state, got: %s", collision.Error())
+	}
+}
+
+// TestAdd_DuplicateSameContent_IsIdempotentNoOp is the regression for
+// issue #102. The watcher's reconcile loop can race its own auto-onboard
+// write: one goroutine commits the trace's row while a second, which read
+// the DB a moment earlier and saw no row, also calls Add for the same
+// file. The second Add's insert hits a PK conflict — and the old rollback
+// unconditionally os.Remove'd the file, deleting a trace a live row now
+// owned. A later reconcile then saw file-missing + row-present and trashed
+// it (TestAtomicSaveDoesNotTrash flaked on exactly this under -race). When
+// the existing row carries the same content hash, the duplicate must be a
+// benign no-op that leaves the file untouched.
+func TestAdd_DuplicateSameContent_IsIdempotentNoOp(t *testing.T) {
+	cx := setup(t)
+	first := trace.New("dup-target", "note", "", nil, "identical body")
+	if err := cx.Add(first); err != nil {
+		t.Fatalf("seed Add: %v", err)
+	}
+	path := cx.TraceFile(first.ID, false)
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("seed trace file missing: %v", err)
+	}
+
+	dup := trace.New("dup-target", "note", "", nil, "identical body")
+	if dup.ID != first.ID {
+		t.Fatalf("precondition: same title+body must yield same id (%q vs %q)", dup.ID, first.ID)
+	}
+	if err := cx.Add(dup); err != nil {
+		t.Fatalf("duplicate Add with identical content should be a no-op, got: %v", err)
+	}
+
+	// The rollback must NOT have removed the file the existing row owns.
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("trace file was removed by duplicate Add (issue #102 regression): %v", err)
 	}
 }
 

--- a/internal/cortex/cortex.go
+++ b/internal/cortex/cortex.go
@@ -1178,10 +1178,24 @@ func (c *Cortex) Add(t *trace.Trace) error {
 		return fmt.Errorf("writing trace file: %w", err)
 	}
 	if err := c.insertDB(t); err != nil {
-		os.Remove(path)
 		if pkConflictOnTraceID(err) {
+			// A row with this id already exists. If it carries the same
+			// content hash, a concurrent or duplicate Add already landed
+			// this exact trace — the watcher's reconcile can race its own
+			// auto-onboard write this way (issue #102). The t.Write above
+			// left the canonical file byte-identical, so leave it in
+			// place and treat the duplicate as a benign no-op. Removing
+			// the file here would orphan the live row, and a later
+			// reconcile pass would then misread the gap as an external
+			// delete and trash the trace.
+			if c.contentHashFor(t.ID) == t.ContentHash {
+				return nil
+			}
+			// Genuine collision: a different trace already owns this id.
+			os.Remove(path)
 			return c.describeTraceIDCollision(t.ID, err)
 		}
+		os.Remove(path)
 		return fmt.Errorf("inserting into database: %w", err)
 	}
 	return nil


### PR DESCRIPTION
Closes #102.

## Root cause

`TestAtomicSaveDoesNotTrash` flaked under `-race` because of a destructive rollback in `cortex.Add`, not a watcher-timing issue per se:

1. `reconcileExisting` reads the DB for the freshly auto-onboarded file `B`, sees no row yet (`inDB=false`), and falls to the `!inDB` → `cx.Add(t)` branch.
2. Meanwhile the auto-onboard's own `Add` commits `B`'s row.
3. The second `Add` writes `B`, hits a `traces.id` **PK conflict**, and its rollback ran `os.Remove(path)` — **deleting a file a live row now owned**.
4. A later reconcile saw file-missing + row-present → `IngestExternalDelete` → **trash**. The test's poll for the rescued file found nothing → fail at `atomic_save_test.go:55`.

This is the issue's preferred **option 1** (idempotent on matching content hash), implemented at the `Add` layer so it protects *every* caller (watcher, MCP, CLI), not just the auto-onboard path.

## Fix

On a `traces.id` PK conflict, look up the existing row's `content_hash`:
- **same hash** → benign duplicate; the `t.Write` above left the file byte-identical, so leave it and return `nil` (no remove, no error).
- **different hash** → genuine collision; keep the existing `os.Remove` + `ErrTraceIDExists` behavior unchanged.

## Verification

- New `TestAdd_DuplicateSameContent_IsIdempotentNoOp` pins the regression deterministically (file must survive a same-content duplicate `Add`).
- Existing collision tests (`TestAdd_Collides{Active,Trashed,Archived,PurgedTombstone}`, `TestAdd_DuplicateID`) unchanged and green — genuine collisions still error.
- Previously-flaky `TestAtomicSaveDoesNotTrash`: **green 100×** under `-race`, plus **4 CPU-saturated concurrent instances ×30** (120 more runs) to mimic a loaded CI runner.
- `go build ./...`, `go vet ./...`, `go test ./...` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)