### PR TITLE
fix(watch): re-index external frontmatter-only edits (#115)

### DIFF
--- a/internal/watch/reconcile.go
+++ b/internal/watch/reconcile.go
@@ -230,7 +230,7 @@ func (w *Watcher) reconcileExisting(path, id string, dir traceDir, row *cortex.R
 			log.Printf("[watch] external unarchive: %s", id)
 			row, _ = w.cx.Get(id)
 		}
-		if bodyHash != row.ContentHash {
+		if bodyHash != row.ContentHash || indexedMetadataDrift(t, row) {
 			if err := w.cx.UpdateFromFile(id); err != nil {
 				return fmt.Errorf("update: %w", err)
 			}
@@ -254,7 +254,7 @@ func (w *Watcher) reconcileExisting(path, id string, dir traceDir, row *cortex.R
 			log.Printf("[watch] external archive: %s", id)
 			row, _ = w.cx.Get(id)
 		}
-		if bodyHash != row.ContentHash {
+		if bodyHash != row.ContentHash || indexedMetadataDrift(t, row) {
 			if err := w.cx.UpdateFromFile(id); err != nil {
 				return fmt.Errorf("update: %w", err)
 			}
@@ -336,4 +336,48 @@ func (w *Watcher) reconcileMissing(id string, dir traceDir, row *cortex.Row, inD
 		log.Printf("[watch] external purge: %s", id)
 	}
 	return nil
+}
+
+// indexedMetadataDrift reports whether the file's frontmatter carries
+// indexed metadata (title, type, author, tags, derived_from) that differs
+// from the DB row. The watcher's loopback guard keys on the body content
+// hash, so a frontmatter-only external edit — adding a tag in Obsidian's
+// Properties panel, retyping a note as a decision, fixing an author — has
+// a matching body hash and would otherwise be skipped, leaving the DB
+// index (and FTS, lineage) stale: `list_traces tag=X` then returns nothing
+// even though the file plainly carries the tag. Comparing the indexed
+// fields catches those edits and routes them through UpdateFromFile.
+//
+// It stays loopback-safe: Noema's own writes keep frontmatter and DB in
+// lockstep, so a self-write never shows drift here. Tag and lineage lists
+// are compared as sets — the DB returns tags sorted, while frontmatter
+// preserves author order, so a slice-equality check would false-positive.
+func indexedMetadataDrift(t *trace.Trace, row *cortex.Row) bool {
+	return t.Title != row.Title ||
+		t.Type != row.Type ||
+		t.Author != row.Author ||
+		!sameStringSet(t.Tags, row.Tags) ||
+		!sameStringSet(t.DerivedFrom, row.DerivedFrom)
+}
+
+// sameStringSet reports whether a and b contain the same distinct
+// elements, ignoring order and duplicates.
+func sameStringSet(a, b []string) bool {
+	sa := make(map[string]struct{}, len(a))
+	for _, s := range a {
+		sa[s] = struct{}{}
+	}
+	sb := make(map[string]struct{}, len(b))
+	for _, s := range b {
+		sb[s] = struct{}{}
+	}
+	if len(sa) != len(sb) {
+		return false
+	}
+	for s := range sa {
+		if _, ok := sb[s]; !ok {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/watch/watcher_test.go
+++ b/internal/watch/watcher_test.go
@@ -83,6 +83,57 @@ func countByAction(es []event.Event, a event.Action) int {
 	return n
 }
 
+// TestExternalFrontmatterTagEditReindexes pins the tag-drift regression:
+// adding a tag in a trace's frontmatter (e.g. via Obsidian's Properties
+// panel) changes only frontmatter, not the body. The watcher's loopback
+// guard keys on the body hash, so before the fix it skipped the edit and
+// the trace_tags index never learned the tag — list_traces tag=X then
+// returned nothing while the file plainly carried it.
+func TestExternalFrontmatterTagEditReindexes(t *testing.T) {
+	cx, _, id := setupWatcher(t)
+	path := cx.TraceFile(id, false)
+
+	// External edit: add a tag in frontmatter, leave the body identical.
+	// trace.Write recomputes the file's content_hash from the (unchanged)
+	// body, so the body hash still matches the DB — exactly the loopback
+	// guard's blind spot.
+	tr, err := trace.ParseFile(path)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	bodyBefore := tr.Body
+	tr.Tags = append(tr.Tags, "ghostty")
+	if err := tr.Write(path); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	time.Sleep(settleTime)
+
+	// Precondition: the body must be unchanged, or this test isn't
+	// exercising a frontmatter-only edit anymore.
+	reparsed, err := trace.ParseFile(path)
+	if err != nil {
+		t.Fatalf("ParseFile after edit: %v", err)
+	}
+	if reparsed.Body != bodyBefore {
+		t.Fatalf("precondition: body changed (%q -> %q)", bodyBefore, reparsed.Body)
+	}
+
+	// The DB index must now carry the tag so list-by-tag finds it.
+	got, err := cx.List(cortex.ListOptions{Tag: "ghostty"})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	found := false
+	for _, r := range got {
+		if r.ID == id {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("trace %s not returned by list tag=ghostty after a frontmatter tag edit; trace_tags index was not updated", id)
+	}
+}
+
 // TestExternalEditEmitsUpdate writes new body content to the trace file
 // using a non-Noema write path and asserts the watcher emits ActionUpdate.
 func TestExternalEditEmitsUpdate(t *testing.T) {


### PR DESCRIPTION
Closes #115.

## Problem

The watcher's external-edit detection compared **only the body content hash** (`reconcile.go` dirActive/dirArchive branches). A frontmatter-only edit — adding a tag via Obsidian's Properties panel, changing `type`/`author`/`derived_from` — leaves the body unchanged, so `bodyHash == row.ContentHash`. The content-hash loopback guard (meant to skip Noema's own writes) then skipped `UpdateFromFile`, and the `trace_tags` / FTS / `trace_lineage` index never updated.

Result: `list_traces tag=X` returned nothing while the file plainly had `tags: [X]`; `search_traces` still found it (FTS on title/body); `get_trace` showed stale empty tags.

## Fix

Extend both edit branches to also fire `UpdateFromFile` when the file's indexed frontmatter metadata drifts from the DB row:

```go
if bodyHash != row.ContentHash || indexedMetadataDrift(t, row) { ... }
```

`indexedMetadataDrift` compares `title`, `type`, `author`, `tags`, `derived_from`. Tag/lineage lists are compared **as sets** (the DB returns tags sorted; frontmatter preserves authoring order, so slice equality would false-positive).

**Loopback-safe:** Noema's own writes keep frontmatter and the DB in lockstep, so a self-write shows no metadata drift — the guard still suppresses Noema's own writes exactly as before. `UpdateFromFile` doesn't rewrite the file (no new fsnotify event), so there's no edit loop.

## Tests

- `TestExternalFrontmatterTagEditReindexes` — adds a tag to frontmatter only (body byte-identical), asserts `list tag=X` then finds the trace. **Verified to fail on the pre-fix body-only gate** and pass with the fix.
- Full `internal/watch` and `internal/cortex` suites green, including under `-race`.

## Note

Discovered via two real traces whose tags (added through Obsidian) never reached the index. `noema sync` is the immediate remediation for already-drifted traces (re-walks files and rewrites `trace_tags`); this PR stops the drift at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)