### PR TITLE
release: v0.13.2 — watcher re-indexes frontmatter edits + idempotent Add on duplicate

### DIFF
--- a/internal/cortex/add_errors.go
+++ b/internal/cortex/add_errors.go
@@ -115,6 +115,19 @@ func (c *Cortex) describeTraceIDCollision(id string, wrapped error) error {
 	}
 }
 
+// contentHashFor returns the content_hash stored for id, or "" if the
+// row is absent or unreadable. Add uses it on a PK conflict to tell a
+// benign duplicate (same hash → idempotent no-op) apart from a genuine
+// id collision (different content → surfaced to the caller). The lookup
+// runs against the live DB, not the failed insert transaction.
+func (c *Cortex) contentHashFor(id string) string {
+	var h sql.NullString
+	if err := c.DB.QueryRow(`SELECT content_hash FROM traces WHERE id = ?`, id).Scan(&h); err != nil {
+		return ""
+	}
+	return h.String
+}
+
 func nullString(s sql.NullString) string {
 	if s.Valid {
 		return s.String

--- a/internal/cortex/add_errors_test.go
+++ b/internal/cortex/add_errors_test.go
@@ -2,6 +2,7 @@ package cortex_test
 
 import (
 	"errors"
+	"os"
 	"strings"
 	"testing"
 
@@ -38,6 +39,41 @@ func TestAdd_CollidesActive_ReturnsTypedError(t *testing.T) {
 	}
 	if !strings.Contains(collision.Error(), "already exists (currently active)") {
 		t.Errorf("Error() should mention active state, got: %s", collision.Error())
+	}
+}
+
+// TestAdd_DuplicateSameContent_IsIdempotentNoOp is the regression for
+// issue #102. The watcher's reconcile loop can race its own auto-onboard
+// write: one goroutine commits the trace's row while a second, which read
+// the DB a moment earlier and saw no row, also calls Add for the same
+// file. The second Add's insert hits a PK conflict — and the old rollback
+// unconditionally os.Remove'd the file, deleting a trace a live row now
+// owned. A later reconcile then saw file-missing + row-present and trashed
+// it (TestAtomicSaveDoesNotTrash flaked on exactly this under -race). When
+// the existing row carries the same content hash, the duplicate must be a
+// benign no-op that leaves the file untouched.
+func TestAdd_DuplicateSameContent_IsIdempotentNoOp(t *testing.T) {
+	cx := setup(t)
+	first := trace.New("dup-target", "note", "", nil, "identical body")
+	if err := cx.Add(first); err != nil {
+		t.Fatalf("seed Add: %v", err)
+	}
+	path := cx.TraceFile(first.ID, false)
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("seed trace file missing: %v", err)
+	}
+
+	dup := trace.New("dup-target", "note", "", nil, "identical body")
+	if dup.ID != first.ID {
+		t.Fatalf("precondition: same title+body must yield same id (%q vs %q)", dup.ID, first.ID)
+	}
+	if err := cx.Add(dup); err != nil {
+		t.Fatalf("duplicate Add with identical content should be a no-op, got: %v", err)
+	}
+
+	// The rollback must NOT have removed the file the existing row owns.
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("trace file was removed by duplicate Add (issue #102 regression): %v", err)
 	}
 }
 

--- a/internal/cortex/cortex.go
+++ b/internal/cortex/cortex.go
@@ -1178,10 +1178,24 @@ func (c *Cortex) Add(t *trace.Trace) error {
 		return fmt.Errorf("writing trace file: %w", err)
 	}
 	if err := c.insertDB(t); err != nil {
-		os.Remove(path)
 		if pkConflictOnTraceID(err) {
+			// A row with this id already exists. If it carries the same
+			// content hash, a concurrent or duplicate Add already landed
+			// this exact trace — the watcher's reconcile can race its own
+			// auto-onboard write this way (issue #102). The t.Write above
+			// left the canonical file byte-identical, so leave it in
+			// place and treat the duplicate as a benign no-op. Removing
+			// the file here would orphan the live row, and a later
+			// reconcile pass would then misread the gap as an external
+			// delete and trash the trace.
+			if c.contentHashFor(t.ID) == t.ContentHash {
+				return nil
+			}
+			// Genuine collision: a different trace already owns this id.
+			os.Remove(path)
 			return c.describeTraceIDCollision(t.ID, err)
 		}
+		os.Remove(path)
 		return fmt.Errorf("inserting into database: %w", err)
 	}
 	return nil

--- a/internal/watch/reconcile.go
+++ b/internal/watch/reconcile.go
@@ -230,7 +230,7 @@ func (w *Watcher) reconcileExisting(path, id string, dir traceDir, row *cortex.R
 			log.Printf("[watch] external unarchive: %s", id)
 			row, _ = w.cx.Get(id)
 		}
-		if bodyHash != row.ContentHash {
+		if bodyHash != row.ContentHash || indexedMetadataDrift(t, row) {
 			if err := w.cx.UpdateFromFile(id); err != nil {
 				return fmt.Errorf("update: %w", err)
 			}
@@ -254,7 +254,7 @@ func (w *Watcher) reconcileExisting(path, id string, dir traceDir, row *cortex.R
 			log.Printf("[watch] external archive: %s", id)
 			row, _ = w.cx.Get(id)
 		}
-		if bodyHash != row.ContentHash {
+		if bodyHash != row.ContentHash || indexedMetadataDrift(t, row) {
 			if err := w.cx.UpdateFromFile(id); err != nil {
 				return fmt.Errorf("update: %w", err)
 			}
@@ -336,4 +336,48 @@ func (w *Watcher) reconcileMissing(id string, dir traceDir, row *cortex.Row, inD
 		log.Printf("[watch] external purge: %s", id)
 	}
 	return nil
+}
+
+// indexedMetadataDrift reports whether the file's frontmatter carries
+// indexed metadata (title, type, author, tags, derived_from) that differs
+// from the DB row. The watcher's loopback guard keys on the body content
+// hash, so a frontmatter-only external edit — adding a tag in Obsidian's
+// Properties panel, retyping a note as a decision, fixing an author — has
+// a matching body hash and would otherwise be skipped, leaving the DB
+// index (and FTS, lineage) stale: `list_traces tag=X` then returns nothing
+// even though the file plainly carries the tag. Comparing the indexed
+// fields catches those edits and routes them through UpdateFromFile.
+//
+// It stays loopback-safe: Noema's own writes keep frontmatter and DB in
+// lockstep, so a self-write never shows drift here. Tag and lineage lists
+// are compared as sets — the DB returns tags sorted, while frontmatter
+// preserves author order, so a slice-equality check would false-positive.
+func indexedMetadataDrift(t *trace.Trace, row *cortex.Row) bool {
+	return t.Title != row.Title ||
+		t.Type != row.Type ||
+		t.Author != row.Author ||
+		!sameStringSet(t.Tags, row.Tags) ||
+		!sameStringSet(t.DerivedFrom, row.DerivedFrom)
+}
+
+// sameStringSet reports whether a and b contain the same distinct
+// elements, ignoring order and duplicates.
+func sameStringSet(a, b []string) bool {
+	sa := make(map[string]struct{}, len(a))
+	for _, s := range a {
+		sa[s] = struct{}{}
+	}
+	sb := make(map[string]struct{}, len(b))
+	for _, s := range b {
+		sb[s] = struct{}{}
+	}
+	if len(sa) != len(sb) {
+		return false
+	}
+	for s := range sa {
+		if _, ok := sb[s]; !ok {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/watch/watcher_test.go
+++ b/internal/watch/watcher_test.go
@@ -83,6 +83,57 @@ func countByAction(es []event.Event, a event.Action) int {
 	return n
 }
 
+// TestExternalFrontmatterTagEditReindexes pins the tag-drift regression:
+// adding a tag in a trace's frontmatter (e.g. via Obsidian's Properties
+// panel) changes only frontmatter, not the body. The watcher's loopback
+// guard keys on the body hash, so before the fix it skipped the edit and
+// the trace_tags index never learned the tag — list_traces tag=X then
+// returned nothing while the file plainly carried it.
+func TestExternalFrontmatterTagEditReindexes(t *testing.T) {
+	cx, _, id := setupWatcher(t)
+	path := cx.TraceFile(id, false)
+
+	// External edit: add a tag in frontmatter, leave the body identical.
+	// trace.Write recomputes the file's content_hash from the (unchanged)
+	// body, so the body hash still matches the DB — exactly the loopback
+	// guard's blind spot.
+	tr, err := trace.ParseFile(path)
+	if err != nil {
+		t.Fatalf("ParseFile: %v", err)
+	}
+	bodyBefore := tr.Body
+	tr.Tags = append(tr.Tags, "ghostty")
+	if err := tr.Write(path); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	time.Sleep(settleTime)
+
+	// Precondition: the body must be unchanged, or this test isn't
+	// exercising a frontmatter-only edit anymore.
+	reparsed, err := trace.ParseFile(path)
+	if err != nil {
+		t.Fatalf("ParseFile after edit: %v", err)
+	}
+	if reparsed.Body != bodyBefore {
+		t.Fatalf("precondition: body changed (%q -> %q)", bodyBefore, reparsed.Body)
+	}
+
+	// The DB index must now carry the tag so list-by-tag finds it.
+	got, err := cx.List(cortex.ListOptions{Tag: "ghostty"})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	found := false
+	for _, r := range got {
+		if r.ID == id {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("trace %s not returned by list tag=ghostty after a frontmatter tag edit; trace_tags index was not updated", id)
+	}
+}
+
 // TestExternalEditEmitsUpdate writes new body content to the trace file
 // using a non-Noema write path and asserts the watcher emits ActionUpdate.
 func TestExternalEditEmitsUpdate(t *testing.T) {


### PR DESCRIPTION
## Release v0.13.2

Two bug fixes since v0.13.1. `next` is a clean 2-ahead / 0-behind of `main`, so this squash-merges to a single release commit.

### Fixes
- **#102 / #114 — `fix(cortex)`: idempotent `Add` on same-content PK conflict.** A concurrent/duplicate `Add` (the watcher racing its own auto-onboard write) hit a PK conflict whose rollback `os.Remove`'d a file a live row owned; a later reconcile then trashed it (`TestAtomicSaveDoesNotTrash` `-race` flake). Same-content duplicates are now a benign no-op.
- **#115 / #116 — `fix(watch)`: re-index external frontmatter-only edits.** Adding a tag (or changing type/author/derived_from) in a trace's frontmatter — e.g. via Obsidian's Properties panel — left the body unchanged, so the body-hash loopback guard skipped it and the `trace_tags`/FTS/lineage index never updated (`list_traces tag=X` missed the trace). Edit-detection now also fires on indexed-metadata drift; loopback-safe.

Both verified green under `-race`; release branch tree is identical to `next`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)