### PR TITLE
feat(search): semantic-search phase 1 — schema, embeddings client, config

### DIFF
--- a/internal/consolidation/llm.go
+++ b/internal/consolidation/llm.go
@@ -21,6 +21,14 @@ type LLMClient interface {
 	Complete(ctx context.Context, req CompletionRequest) (string, error)
 }
 
+// Embedder is the narrow interface the semantic-search path uses to turn
+// text into vectors. One method, mirroring LLMClient, so the search layer
+// and its tests can stub it without the HTTP dance. HTTPLLMClient
+// satisfies it, reusing the same endpoint/auth config as completions.
+type Embedder interface {
+	Embed(ctx context.Context, model string, inputs []string) ([][]float32, error)
+}
+
 // Message mirrors the OpenAI chat-completions message shape. All
 // providers this client targets (Ollama, LMStudio, llama.cpp server,
 // vLLM, OpenAI, Azure OpenAI) accept the same three roles.
@@ -192,4 +200,140 @@ func (c *HTTPLLMClient) Complete(ctx context.Context, req CompletionRequest) (st
 		}
 	}
 	return choice.Message.Content, nil
+}
+
+// embedRequestBody / embedResponseBody mirror the OpenAI /embeddings
+// shape, which Ollama, llama.cpp server, vLLM, LMStudio and OpenAI all
+// accept. `input` takes an array; `data` comes back with one entry per
+// input, each carrying an `index` aligning it to the request order.
+type embedRequestBody struct {
+	Model string   `json:"model"`
+	Input []string `json:"input"`
+}
+
+type embedResponseBody struct {
+	Data []struct {
+		Index     int       `json:"index"`
+		Embedding []float32 `json:"embedding"`
+	} `json:"data"`
+	Error *struct {
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+// defaultEmbedBatch caps how many inputs ride in one /embeddings call.
+// Local servers can choke on very large batches; 64 is a safe middle
+// ground that still amortizes the per-request overhead.
+const defaultEmbedBatch = 64
+
+// Embed returns one vector per input, preserving input order, by POSTing
+// to {Endpoint}/embeddings in batches of defaultEmbedBatch. An empty
+// inputs slice returns nil without making a request. Reuses the same
+// endpoint, API key, and HTTP client as Complete.
+func (c *HTTPLLMClient) Embed(ctx context.Context, model string, inputs []string) ([][]float32, error) {
+	if model == "" {
+		return nil, errors.New("embedding model is empty")
+	}
+	if len(inputs) == 0 {
+		return nil, nil
+	}
+	out := make([][]float32, 0, len(inputs))
+	for start := 0; start < len(inputs); start += defaultEmbedBatch {
+		end := min(start+defaultEmbedBatch, len(inputs))
+		vecs, err := c.embedBatch(ctx, model, inputs[start:end])
+		if err != nil {
+			return nil, fmt.Errorf("embedding batch [%d:%d]: %w", start, end, err)
+		}
+		out = append(out, vecs...)
+	}
+	return out, nil
+}
+
+func (c *HTTPLLMClient) embedBatch(ctx context.Context, model string, batch []string) ([][]float32, error) {
+	body, err := json.Marshal(embedRequestBody{Model: model, Input: batch})
+	if err != nil {
+		return nil, fmt.Errorf("encoding embeddings request: %w", err)
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.Endpoint+"/embeddings", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("building embeddings request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if c.APIKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+c.APIKey)
+	}
+
+	client := c.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("posting embeddings request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading embeddings response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var parsed embedResponseBody
+		if json.Unmarshal(respBody, &parsed) == nil && parsed.Error != nil {
+			return nil, fmt.Errorf("embeddings endpoint %d: %s", resp.StatusCode, parsed.Error.Message)
+		}
+		snippet := string(respBody)
+		if len(snippet) > 256 {
+			snippet = snippet[:256] + "..."
+		}
+		return nil, fmt.Errorf("embeddings endpoint %d: %s", resp.StatusCode, snippet)
+	}
+
+	var parsed embedResponseBody
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return nil, fmt.Errorf("parsing embeddings response: %w", err)
+	}
+	if parsed.Error != nil {
+		return nil, fmt.Errorf("embeddings error: %s", parsed.Error.Message)
+	}
+	if len(parsed.Data) != len(batch) {
+		return nil, fmt.Errorf("embeddings response count %d != input count %d", len(parsed.Data), len(batch))
+	}
+
+	// Place by `index` when the provider returns a clean permutation of
+	// [0,len); otherwise fall back to response order (some servers omit or
+	// zero the index field). Either way the result aligns to the inputs.
+	byIndex := indicesArePermutation(parsed.Data, len(batch))
+	vecs := make([][]float32, len(batch))
+	for i, d := range parsed.Data {
+		slot := i
+		if byIndex {
+			slot = d.Index
+		}
+		if len(d.Embedding) == 0 {
+			return nil, fmt.Errorf("embeddings response has an empty vector at slot %d", slot)
+		}
+		vecs[slot] = d.Embedding
+	}
+	return vecs, nil
+}
+
+// indicesArePermutation reports whether the response's index fields form a
+// distinct, in-range covering of [0,n) — i.e. trustworthy for placement.
+func indicesArePermutation(data []struct {
+	Index     int       `json:"index"`
+	Embedding []float32 `json:"embedding"`
+}, n int) bool {
+	if len(data) != n {
+		return false
+	}
+	seen := make([]bool, n)
+	for _, d := range data {
+		if d.Index < 0 || d.Index >= n || seen[d.Index] {
+			return false
+		}
+		seen[d.Index] = true
+	}
+	return true
 }

--- a/internal/consolidation/llm.go
+++ b/internal/consolidation/llm.go
@@ -314,6 +314,11 @@ func (c *HTTPLLMClient) embedBatch(ctx context.Context, model string, batch []st
 		if len(d.Embedding) == 0 {
 			return nil, fmt.Errorf("embeddings response has an empty vector at slot %d", slot)
 		}
+		// Non-finite guard is unnecessary here: encoding/json rejects NaN
+		// and out-of-range (±Inf) numbers when decoding into []float32, so
+		// vectors that reach this point are already finite. The decode→rank
+		// consumer path (Phase 3) validates finiteness of stored vectors,
+		// where a corrupted BLOB — not the wire — is the real risk.
 		vecs[slot] = d.Embedding
 	}
 	return vecs, nil

--- a/internal/consolidation/llm_test.go
+++ b/internal/consolidation/llm_test.go
@@ -220,3 +220,141 @@ func TestHTTPLLMClient_EmbedReindexes(t *testing.T) {
 }
 
 func itoa(i int) string { return strconv.Itoa(i) }
+
+// TestHTTPLLMClient_EmbedValidation covers the early-return guards: an
+// empty model errors without a request, and empty/nil inputs return
+// (nil, nil) without hitting the server.
+func TestHTTPLLMClient_EmbedValidation(t *testing.T) {
+	hit := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		w.Write([]byte(`{"data":[]}`))
+	}))
+	defer server.Close()
+	client, err := NewHTTPLLMClient(server.URL, "")
+	if err != nil {
+		t.Fatalf("NewHTTPLLMClient: %v", err)
+	}
+
+	if _, err := client.Embed(context.Background(), "", []string{"a"}); err == nil {
+		t.Error("empty model should error")
+	}
+	if got, err := client.Embed(context.Background(), "m", nil); err != nil || got != nil {
+		t.Errorf("nil inputs => (nil,nil); got (%v,%v)", got, err)
+	}
+	if got, err := client.Embed(context.Background(), "m", []string{}); err != nil || got != nil {
+		t.Errorf("empty inputs => (nil,nil); got (%v,%v)", got, err)
+	}
+	if hit {
+		t.Error("server must not be hit for invalid/empty input")
+	}
+}
+
+// TestHTTPLLMClient_EmbedCountMismatch: a short response (fewer vectors
+// than inputs) must error rather than silently mis-aligning vectors to
+// traces.
+func TestHTTPLLMClient_EmbedCountMismatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"data":[{"index":0,"embedding":[1.0]}]}`)) // 1 vector for 2 inputs
+	}))
+	defer server.Close()
+	client, _ := NewHTTPLLMClient(server.URL, "")
+	_, err := client.Embed(context.Background(), "m", []string{"a", "b"})
+	if err == nil || !strings.Contains(err.Error(), "count") {
+		t.Errorf("expected count-mismatch error, got %v", err)
+	}
+}
+
+// TestHTTPLLMClient_EmbedErrorStatus covers the non-200 branch in
+// embedBatch (separate from Complete's): structured error message and the
+// truncated raw-body fallback.
+func TestHTTPLLMClient_EmbedErrorStatus(t *testing.T) {
+	structured := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error":{"message":"bad model name"}}`))
+	}))
+	defer structured.Close()
+	c1, _ := NewHTTPLLMClient(structured.URL, "")
+	if _, err := c1.Embed(context.Background(), "m", []string{"a"}); err == nil || !strings.Contains(err.Error(), "bad model name") {
+		t.Errorf("expected structured error surfaced, got %v", err)
+	}
+
+	raw := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(strings.Repeat("X", 600))) // > 256, must be truncated
+	}))
+	defer raw.Close()
+	c2, _ := NewHTTPLLMClient(raw.URL, "")
+	_, err := c2.Embed(context.Background(), "m", []string{"a"})
+	if err == nil || !strings.Contains(err.Error(), "...") {
+		t.Errorf("expected truncated raw-body error, got %v", err)
+	}
+}
+
+// TestHTTPLLMClient_EmbedEmptyVectorSlot: a datum with an empty embedding
+// array must error.
+func TestHTTPLLMClient_EmbedEmptyVectorSlot(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"data":[{"index":0,"embedding":[]}]}`))
+	}))
+	defer server.Close()
+	client, _ := NewHTTPLLMClient(server.URL, "")
+	_, err := client.Embed(context.Background(), "m", []string{"a"})
+	if err == nil || !strings.Contains(err.Error(), "empty vector") {
+		t.Errorf("expected empty-vector error, got %v", err)
+	}
+}
+
+// TestHTTPLLMClient_EmbedNonFiniteRejectedByJSON documents the actual
+// safeguard: encoding/json rejects out-of-range (±Inf) and NaN numbers when
+// decoding into []float32, so a non-finite vector can never arrive over the
+// wire — it surfaces as a parse error rather than a poisoned vector.
+func TestHTTPLLMClient_EmbedNonFiniteRejectedByJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"data":[{"index":0,"embedding":[1e999, 0.5]}]}`))
+	}))
+	defer server.Close()
+	client, _ := NewHTTPLLMClient(server.URL, "")
+	if _, err := client.Embed(context.Background(), "m", []string{"a"}); err == nil {
+		t.Error("expected the JSON decoder to reject an out-of-range (±Inf) number")
+	}
+}
+
+// TestHTTPLLMClient_EmbedMultiBatchOneFails: when a later batch fails, the
+// whole call aborts with a wrapped error rather than returning a short
+// slice.
+func TestHTTPLLMClient_EmbedMultiBatchOneFails(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls >= 2 {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`{"error":{"message":"boom"}}`))
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		var req embedRequestBody
+		_ = json.Unmarshal(body, &req)
+		w.Write([]byte("{\"data\":["))
+		for i := range req.Input {
+			if i > 0 {
+				w.Write([]byte(","))
+			}
+			w.Write([]byte(`{"index":` + itoa(i) + `,"embedding":[0.1]}`))
+		}
+		w.Write([]byte("]}"))
+	}))
+	defer server.Close()
+	client, _ := NewHTTPLLMClient(server.URL, "")
+	inputs := make([]string, 100) // forces 2 batches
+	for i := range inputs {
+		inputs[i] = "t" + itoa(i)
+	}
+	got, err := client.Embed(context.Background(), "m", inputs)
+	if err == nil || !strings.Contains(err.Error(), "[64:100]") {
+		t.Errorf("expected wrapped second-batch error, got %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil result on batch failure, got len %d", len(got))
+	}
+}

--- a/internal/consolidation/llm_test.go
+++ b/internal/consolidation/llm_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -124,3 +125,98 @@ func TestNewHTTPLLMClient_ValidatesEndpoint(t *testing.T) {
 		t.Error("empty endpoint should error")
 	}
 }
+
+// TestHTTPLLMClient_Embed verifies the /embeddings envelope: path, auth,
+// model, input-order preservation, and batching across the
+// defaultEmbedBatch boundary. The fake server encodes each input's numeric
+// suffix into the returned vector so alignment is checkable.
+func TestHTTPLLMClient_Embed(t *testing.T) {
+	const wantModel = "nomic-embed-text"
+	const wantToken = "embed-token"
+	batches := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/embeddings" {
+			t.Errorf("endpoint path = %q, want /embeddings", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer "+wantToken {
+			t.Errorf("auth header = %q, want Bearer token", got)
+		}
+		body, _ := io.ReadAll(r.Body)
+		var req embedRequestBody
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Fatalf("decoding request: %v", err)
+		}
+		if req.Model != wantModel {
+			t.Errorf("model = %q, want %q", req.Model, wantModel)
+		}
+		batches++
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("{\"data\":["))
+		for i, in := range req.Input {
+			n := strings.TrimPrefix(in, "t")
+			if i > 0 {
+				w.Write([]byte(","))
+			}
+			// vector = [suffix, 0.0]; index aligns to request order.
+			w.Write([]byte(`{"index":` + itoa(i) + `,"embedding":[` + n + `,0.0]}`))
+		}
+		w.Write([]byte("]}"))
+	}))
+	defer server.Close()
+
+	t.Setenv("TEST_EMBED_KEY", wantToken)
+	client, err := NewHTTPLLMClient(server.URL, "TEST_EMBED_KEY")
+	if err != nil {
+		t.Fatalf("NewHTTPLLMClient: %v", err)
+	}
+
+	// 150 inputs forces 3 batches (64+64+22).
+	inputs := make([]string, 150)
+	for i := range inputs {
+		inputs[i] = "t" + itoa(i)
+	}
+	got, err := client.Embed(context.Background(), wantModel, inputs)
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if len(got) != len(inputs) {
+		t.Fatalf("got %d vectors, want %d", len(got), len(inputs))
+	}
+	if batches != 3 {
+		t.Errorf("server saw %d batches, want 3 (chunking by defaultEmbedBatch)", batches)
+	}
+	for i, v := range got {
+		if len(v) != 2 {
+			t.Fatalf("vector %d has dim %d, want 2", i, len(v))
+		}
+		if int(v[0]) != i {
+			t.Errorf("vector %d carries suffix %v, want %d (order not preserved across batches)", i, v[0], i)
+		}
+	}
+}
+
+// TestHTTPLLMClient_EmbedReindexes verifies that an out-of-order response
+// (data shuffled but carrying correct index fields) is realigned.
+func TestHTTPLLMClient_EmbedReindexes(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Two inputs returned in reverse, but index fields are correct.
+		w.Write([]byte(`{"data":[{"index":1,"embedding":[1.0]},{"index":0,"embedding":[0.0]}]}`))
+	}))
+	defer server.Close()
+
+	client, err := NewHTTPLLMClient(server.URL, "")
+	if err != nil {
+		t.Fatalf("NewHTTPLLMClient: %v", err)
+	}
+	got, err := client.Embed(context.Background(), "m", []string{"a", "b"})
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if got[0][0] != 0.0 || got[1][0] != 1.0 {
+		t.Errorf("reindex failed: got[0]=%v got[1]=%v, want [0] then [1]", got[0], got[1])
+	}
+}
+
+func itoa(i int) string { return strconv.Itoa(i) }

--- a/internal/cortex/cortex.go
+++ b/internal/cortex/cortex.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -40,6 +41,7 @@ type Manifest struct {
 	Federation    *FederationConfig    `yaml:"federation,omitempty"`
 	Watch         *WatchConfig         `yaml:"watch,omitempty"`
 	Consolidation *ConsolidationConfig `yaml:"consolidation,omitempty"`
+	Search        *SearchConfig        `yaml:"search,omitempty"`
 
 	// Body is the free-form markdown content that follows the YAML
 	// frontmatter in cortex.md. Never serialized through YAML; populated
@@ -592,6 +594,154 @@ func (m Manifest) ValidateConsolidation() error {
 	return nil
 }
 
+// Search-mode identifiers. These string values are part of the frozen v1.0
+// surface (the MCP `mode` param and cortex.md `default_mode`); don't rename.
+const (
+	SearchModeLexical  = "lexical"
+	SearchModeSemantic = "semantic"
+	SearchModeHybrid   = "hybrid"
+
+	defaultHybridWeight  = 0.5
+	defaultEmbedMaxChars = 32000
+)
+
+// SearchConfig is the optional `search:` block in cortex.md. It is off by
+// default; semantic search requires SemanticEnabled plus a resolvable
+// embedding endpoint and an explicit embedding model. There is no
+// baked-in default model — we never imply a model we don't ship. The
+// embedding endpoint and API-key env-var fall back to the consolidation
+// block when left empty, so a single local-LLM host can serve both
+// distillation and embeddings from one configuration.
+type SearchConfig struct {
+	// SemanticEnabled is the master opt-in for embedding-based search.
+	// When false (the default), only lexical FTS5 search is available.
+	SemanticEnabled bool `yaml:"semantic_enabled,omitempty"`
+
+	// EmbeddingEndpoint is the OpenAI-compatible base URL for the
+	// /embeddings call. Empty inherits consolidation.local_llm_endpoint.
+	EmbeddingEndpoint string `yaml:"embedding_endpoint,omitempty"`
+
+	// EmbeddingModel is the embedding model identifier. Required when
+	// SemanticEnabled — there is no default.
+	EmbeddingModel string `yaml:"embedding_model,omitempty"`
+
+	// APIKeyEnv names an env var holding the bearer token for the
+	// embedding endpoint. Empty inherits consolidation.api_key_env.
+	APIKeyEnv string `yaml:"api_key_env,omitempty"`
+
+	// DefaultMode is the search mode used when a caller doesn't specify
+	// one: lexical|semantic|hybrid. Empty means lexical, which keeps
+	// existing callers byte-for-byte unchanged.
+	DefaultMode string `yaml:"default_mode,omitempty"`
+
+	// HybridWeight is the vector weight (0..1) in hybrid rank fusion.
+	// Zero/unset means the default 0.5 (equal lexical/semantic).
+	HybridWeight float64 `yaml:"hybrid_weight,omitempty"`
+
+	// MaxChars caps the trace text sent to the embedding model, to stay
+	// within model input limits. Zero/unset means defaultEmbedMaxChars.
+	MaxChars int `yaml:"max_chars,omitempty"`
+}
+
+// SemanticOn reports whether semantic search is enabled. Nil-safe.
+func (sc *SearchConfig) SemanticOn() bool { return sc != nil && sc.SemanticEnabled }
+
+// EffectiveDefaultMode returns the configured default mode or "lexical"
+// when unset.
+func (sc *SearchConfig) EffectiveDefaultMode() string {
+	if sc == nil || sc.DefaultMode == "" {
+		return SearchModeLexical
+	}
+	return sc.DefaultMode
+}
+
+// EffectiveHybridWeight returns the hybrid vector weight, defaulting to
+// 0.5 when unset and clamping to [0,1] otherwise. (An explicit 0 reads as
+// unset and yields the default; use mode=lexical for pure lexical.)
+func (sc *SearchConfig) EffectiveHybridWeight() float64 {
+	if sc == nil || sc.HybridWeight == 0 {
+		return defaultHybridWeight
+	}
+	if sc.HybridWeight < 0 {
+		return 0
+	}
+	if sc.HybridWeight > 1 {
+		return 1
+	}
+	return sc.HybridWeight
+}
+
+// EffectiveMaxChars returns the per-trace embedding text budget, defaulting
+// to 32k characters.
+func (sc *SearchConfig) EffectiveMaxChars() int {
+	if sc == nil || sc.MaxChars <= 0 {
+		return defaultEmbedMaxChars
+	}
+	return sc.MaxChars
+}
+
+// ResolvedEmbeddingEndpoint returns the embedding endpoint, falling back to
+// consolidation.local_llm_endpoint when the search block leaves it empty.
+func (m Manifest) ResolvedEmbeddingEndpoint() string {
+	if m.Search != nil && m.Search.EmbeddingEndpoint != "" {
+		return m.Search.EmbeddingEndpoint
+	}
+	if m.Consolidation != nil {
+		return m.Consolidation.LocalLLMEndpoint
+	}
+	return ""
+}
+
+// ResolvedEmbeddingAPIKeyEnv mirrors ResolvedEmbeddingEndpoint for the
+// API-key env-var name.
+func (m Manifest) ResolvedEmbeddingAPIKeyEnv() string {
+	if m.Search != nil && m.Search.APIKeyEnv != "" {
+		return m.Search.APIKeyEnv
+	}
+	if m.Consolidation != nil {
+		return m.Consolidation.APIKeyEnv
+	}
+	return ""
+}
+
+// ValidateSearch enforces the search block's cross-field rules: an
+// invalid default_mode is rejected even when semantic search is off (so a
+// typo surfaces early), and enabling semantic search requires an explicit
+// embedding model plus a resolvable, well-formed endpoint. Returns nil
+// when the block is absent and no mode override is set.
+func (m Manifest) ValidateSearch() error {
+	sc := m.Search
+	if sc != nil && sc.DefaultMode != "" && !validSearchMode(sc.DefaultMode) {
+		return fmt.Errorf("search.default_mode %q is not one of lexical|semantic|hybrid", sc.DefaultMode)
+	}
+	if !sc.SemanticOn() {
+		return nil
+	}
+	if sc.HybridWeight < 0 || sc.HybridWeight > 1 {
+		return fmt.Errorf("search.hybrid_weight must be in [0,1], got %v", sc.HybridWeight)
+	}
+	if sc.EmbeddingModel == "" {
+		return fmt.Errorf("search.semantic_enabled requires search.embedding_model to be set (no default embedding model is assumed)")
+	}
+	endpoint := m.ResolvedEmbeddingEndpoint()
+	if endpoint == "" {
+		return fmt.Errorf("search.semantic_enabled requires search.embedding_endpoint (or consolidation.local_llm_endpoint) to be set")
+	}
+	if _, err := url.Parse(endpoint); err != nil {
+		return fmt.Errorf("search.embedding_endpoint %q is not a valid URL: %w", endpoint, err)
+	}
+	return nil
+}
+
+func validSearchMode(mode string) bool {
+	switch mode {
+	case SearchModeLexical, SearchModeSemantic, SearchModeHybrid:
+		return true
+	default:
+		return false
+	}
+}
+
 // ReadManifest parses the cortex.md manifest in the given cortex directory.
 // cortex.md is a markdown file with YAML frontmatter: a `---` fence, the
 // manifest YAML, a closing `---` fence, and an optional free-form body.
@@ -614,6 +764,9 @@ func ReadManifest(dir string) (Manifest, error) {
 		return Manifest{}, err
 	}
 	if err := m.ValidateConsolidation(); err != nil {
+		return Manifest{}, err
+	}
+	if err := m.ValidateSearch(); err != nil {
 		return Manifest{}, err
 	}
 	return m, nil

--- a/internal/cortex/embedding.go
+++ b/internal/cortex/embedding.go
@@ -1,0 +1,63 @@
+package cortex
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+)
+
+// embeddingCodecVersion prefixes every stored embedding BLOB so a future
+// encoding (e.g. int8 quantization) can be introduced without ambiguity:
+// the decoder branches on this first byte.
+const embeddingCodecVersion byte = 1
+
+// encodeEmbedding serializes a float32 vector to the BLOB layout stored in
+// trace_embeddings.embedding: a 1-byte version tag followed by little-
+// endian float32 elements. Pure Go, no extension required — similarity is
+// computed in Go over the decoded slices.
+func encodeEmbedding(v []float32) []byte {
+	buf := make([]byte, 1+4*len(v))
+	buf[0] = embeddingCodecVersion
+	for i, f := range v {
+		binary.LittleEndian.PutUint32(buf[1+4*i:], math.Float32bits(f))
+	}
+	return buf
+}
+
+// decodeEmbedding reverses encodeEmbedding. It rejects an unknown version
+// tag and a payload whose length isn't a whole number of float32s.
+func decodeEmbedding(b []byte) ([]float32, error) {
+	if len(b) == 0 {
+		return nil, errors.New("empty embedding blob")
+	}
+	if b[0] != embeddingCodecVersion {
+		return nil, fmt.Errorf("unknown embedding codec version %d", b[0])
+	}
+	payload := b[1:]
+	if len(payload)%4 != 0 {
+		return nil, fmt.Errorf("embedding blob payload length %d is not a multiple of 4", len(payload))
+	}
+	out := make([]float32, len(payload)/4)
+	for i := range out {
+		out[i] = math.Float32frombits(binary.LittleEndian.Uint32(payload[4*i:]))
+	}
+	return out, nil
+}
+
+// normalizeEmbedding scales v to unit L2 norm in place so that cosine
+// similarity reduces to a plain dot product at query time. A zero vector
+// is left unchanged (no division by zero).
+func normalizeEmbedding(v []float32) {
+	var ss float64
+	for _, f := range v {
+		ss += float64(f) * float64(f)
+	}
+	if ss == 0 {
+		return
+	}
+	inv := float32(1 / math.Sqrt(ss))
+	for i := range v {
+		v[i] *= inv
+	}
+}

--- a/internal/cortex/embedding_test.go
+++ b/internal/cortex/embedding_test.go
@@ -65,3 +65,69 @@ func TestNormalizeEmbedding(t *testing.T) {
 		}
 	}
 }
+
+// TestEmbeddingCodec_LargeVectorAndSpecials exercises a realistic 1536-dim
+// vector and confirms the bit-exact path preserves non-finite and signed-
+// zero values (a naive codec could corrupt these). Storage must be
+// faithful even if such values are later rejected at ingest.
+func TestEmbeddingCodec_LargeVectorAndSpecials(t *testing.T) {
+	const dim = 1536
+	v := make([]float32, dim)
+	for i := range v {
+		v[i] = float32(i)*0.001 - 0.5
+	}
+	v[0] = float32(math.NaN())
+	v[1] = float32(math.Inf(1))
+	v[2] = float32(math.Inf(-1))
+	v[3] = float32(math.Copysign(0, -1)) // -0.0
+
+	blob := encodeEmbedding(v)
+	if len(blob) != 1+4*dim {
+		t.Fatalf("blob len = %d, want %d", len(blob), 1+4*dim)
+	}
+	got, err := decodeEmbedding(blob)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != dim {
+		t.Fatalf("decoded len = %d, want %d", len(got), dim)
+	}
+	if !math.IsNaN(float64(got[0])) {
+		t.Errorf("NaN not preserved: %v", got[0])
+	}
+	if !math.IsInf(float64(got[1]), 1) || !math.IsInf(float64(got[2]), -1) {
+		t.Errorf("Inf not preserved: %v %v", got[1], got[2])
+	}
+	// bit-exact check for -0.0 and the rest
+	for i := 4; i < dim; i++ {
+		if math.Float32bits(got[i]) != math.Float32bits(v[i]) {
+			t.Fatalf("elem %d bits differ: got %x want %x", i, math.Float32bits(got[i]), math.Float32bits(v[i]))
+		}
+	}
+	if math.Float32bits(got[3]) != math.Float32bits(v[3]) {
+		t.Errorf("-0.0 not preserved: bits %x", math.Float32bits(got[3]))
+	}
+}
+
+// FuzzDecodeEmbedding guards the decoder against arbitrary bytes (a
+// corrupted or foreign-written trace_embeddings row). It must never panic;
+// on success the length/version invariants must hold.
+func FuzzDecodeEmbedding(f *testing.F) {
+	f.Add(encodeEmbedding([]float32{1, 2, 3}))
+	f.Add(encodeEmbedding(nil))
+	f.Add([]byte{})
+	f.Add([]byte{embeddingCodecVersion})
+	f.Add([]byte{0x02, 0, 0, 0, 0})
+	f.Fuzz(func(t *testing.T, b []byte) {
+		out, err := decodeEmbedding(b)
+		if err != nil {
+			return
+		}
+		if len(b) == 0 || b[0] != embeddingCodecVersion {
+			t.Fatalf("decode accepted invalid header: %v", b)
+		}
+		if len(b) != 1+4*len(out) {
+			t.Fatalf("len invariant broken: blob %d, out %d", len(b), len(out))
+		}
+	})
+}

--- a/internal/cortex/embedding_test.go
+++ b/internal/cortex/embedding_test.go
@@ -1,0 +1,67 @@
+package cortex
+
+import (
+	"math"
+	"testing"
+)
+
+func TestEmbeddingCodec_RoundTrip(t *testing.T) {
+	cases := [][]float32{
+		{},
+		{0},
+		{1.5, -2.25, 0, 3.0e-8, 1234.5},
+	}
+	for _, want := range cases {
+		blob := encodeEmbedding(want)
+		if len(blob) != 1+4*len(want) {
+			t.Fatalf("blob len = %d, want %d", len(blob), 1+4*len(want))
+		}
+		if blob[0] != embeddingCodecVersion {
+			t.Fatalf("version byte = %d, want %d", blob[0], embeddingCodecVersion)
+		}
+		got, err := decodeEmbedding(blob)
+		if err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if len(got) != len(want) {
+			t.Fatalf("decoded len = %d, want %d", len(got), len(want))
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("elem %d = %v, want %v", i, got[i], want[i])
+			}
+		}
+	}
+}
+
+func TestDecodeEmbedding_Errors(t *testing.T) {
+	if _, err := decodeEmbedding(nil); err == nil {
+		t.Error("empty blob should error")
+	}
+	if _, err := decodeEmbedding([]byte{0x02, 0, 0, 0, 0}); err == nil {
+		t.Error("unknown version byte should error")
+	}
+	if _, err := decodeEmbedding([]byte{embeddingCodecVersion, 0, 0, 0}); err == nil {
+		t.Error("payload not a multiple of 4 should error")
+	}
+}
+
+func TestNormalizeEmbedding(t *testing.T) {
+	v := []float32{3, 4} // norm 5
+	normalizeEmbedding(v)
+	var ss float64
+	for _, f := range v {
+		ss += float64(f) * float64(f)
+	}
+	if math.Abs(math.Sqrt(ss)-1) > 1e-6 {
+		t.Errorf("normalized norm = %v, want 1", math.Sqrt(ss))
+	}
+
+	zero := []float32{0, 0, 0}
+	normalizeEmbedding(zero) // must not divide by zero
+	for i, f := range zero {
+		if f != 0 {
+			t.Errorf("zero vector elem %d changed to %v", i, f)
+		}
+	}
+}

--- a/internal/cortex/manifest_search_test.go
+++ b/internal/cortex/manifest_search_test.go
@@ -1,0 +1,85 @@
+package cortex_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Fail-Safe/Noema/internal/cortex"
+)
+
+// TestManifest_SearchBlockRoundTrip is the highest-value Phase 1 serialization
+// guard: a populated `search:` block must survive WriteManifest -> ReadManifest
+// with every field intact. Catches a wrong/missing yaml tag, float drift on
+// hybrid_weight, or ValidateSearch (called inside ReadManifest) rejecting a
+// valid block.
+func TestManifest_SearchBlockRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := cortex.Create("searchcfg", dir); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cdir := filepath.Join(dir, "searchcfg")
+
+	m, err := cortex.ReadManifest(cdir)
+	if err != nil {
+		t.Fatalf("ReadManifest: %v", err)
+	}
+	want := &cortex.SearchConfig{
+		SemanticEnabled:   true,
+		EmbeddingEndpoint: "http://localhost:11434/v1",
+		EmbeddingModel:    "nomic-embed-text",
+		APIKeyEnv:         "EMB_KEY",
+		DefaultMode:       cortex.SearchModeHybrid,
+		HybridWeight:      0.7,
+		MaxChars:          16000,
+	}
+	m.Search = want
+	if err := cortex.WriteManifest(cdir, m); err != nil {
+		t.Fatalf("WriteManifest: %v", err)
+	}
+
+	m2, err := cortex.ReadManifest(cdir)
+	if err != nil {
+		t.Fatalf("ReadManifest (2): %v", err)
+	}
+	if m2.Search == nil {
+		t.Fatal("Search block lost on round-trip")
+	}
+	got := m2.Search
+	if got.SemanticEnabled != want.SemanticEnabled ||
+		got.EmbeddingEndpoint != want.EmbeddingEndpoint ||
+		got.EmbeddingModel != want.EmbeddingModel ||
+		got.APIKeyEnv != want.APIKeyEnv ||
+		got.DefaultMode != want.DefaultMode ||
+		got.HybridWeight != want.HybridWeight ||
+		got.MaxChars != want.MaxChars {
+		t.Errorf("round-trip mismatch:\n got  %+v\n want %+v", got, want)
+	}
+}
+
+// TestManifest_SearchBlockOmittedWhenNil confirms the back-compat promise:
+// a cortex with no search config writes no `search:` key, so older binaries
+// and lexical-only cortexes are unaffected.
+func TestManifest_SearchBlockOmittedWhenNil(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := cortex.Create("plaincfg", dir); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cdir := filepath.Join(dir, "plaincfg")
+
+	m, err := cortex.ReadManifest(cdir)
+	if err != nil {
+		t.Fatalf("ReadManifest: %v", err)
+	}
+	if err := cortex.WriteManifest(cdir, m); err != nil {
+		t.Fatalf("WriteManifest: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(cdir, "cortex.md"))
+	if err != nil {
+		t.Fatalf("read cortex.md: %v", err)
+	}
+	if bytes.Contains(data, []byte("search:")) {
+		t.Errorf("cortex.md unexpectedly contains a search: block:\n%s", data)
+	}
+}

--- a/internal/cortex/search_config_test.go
+++ b/internal/cortex/search_config_test.go
@@ -93,6 +93,40 @@ func TestSearchConfigAccessors(t *testing.T) {
 	}
 }
 
+func TestEffectiveBoundaries(t *testing.T) {
+	hw := []struct {
+		in   float64
+		want float64
+	}{
+		{1, 1},    // exactly 1 passes through
+		{0, 0.5},  // explicit-0 reads as unset -> default (documented quirk)
+		{-0.3, 0}, // negative clamps to 0
+		{0.25, 0.25},
+	}
+	for _, c := range hw {
+		got := (&cortex.SearchConfig{HybridWeight: c.in}).EffectiveHybridWeight()
+		if got != c.want {
+			t.Errorf("EffectiveHybridWeight(%v) = %v, want %v", c.in, got, c.want)
+		}
+	}
+
+	mc := []struct {
+		in   int
+		want int
+	}{
+		{0, 32000},  // unset -> default
+		{-5, 32000}, // negative -> default
+		{1, 1},      // positive passes through
+		{16000, 16000},
+	}
+	for _, c := range mc {
+		got := (&cortex.SearchConfig{MaxChars: c.in}).EffectiveMaxChars()
+		if got != c.want {
+			t.Errorf("EffectiveMaxChars(%d) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
 func TestResolvedEmbeddingEndpoint_Inheritance(t *testing.T) {
 	// Search block wins when set.
 	m := cortex.Manifest{

--- a/internal/cortex/search_config_test.go
+++ b/internal/cortex/search_config_test.go
@@ -1,0 +1,120 @@
+package cortex_test
+
+import (
+	"testing"
+
+	"github.com/Fail-Safe/Noema/internal/cortex"
+)
+
+func TestValidateSearch(t *testing.T) {
+	tests := []struct {
+		name    string
+		m       cortex.Manifest
+		wantErr bool
+	}{
+		{
+			name: "absent block is fine",
+			m:    cortex.Manifest{},
+		},
+		{
+			name:    "disabled but bad default_mode is rejected",
+			m:       cortex.Manifest{Search: &cortex.SearchConfig{DefaultMode: "fuzzy"}},
+			wantErr: true,
+		},
+		{
+			name: "disabled with valid default_mode is fine",
+			m:    cortex.Manifest{Search: &cortex.SearchConfig{DefaultMode: cortex.SearchModeHybrid}},
+		},
+		{
+			name:    "enabled without model is rejected",
+			m:       cortex.Manifest{Search: &cortex.SearchConfig{SemanticEnabled: true, EmbeddingEndpoint: "http://localhost:11434/v1"}},
+			wantErr: true,
+		},
+		{
+			name:    "enabled without any endpoint is rejected",
+			m:       cortex.Manifest{Search: &cortex.SearchConfig{SemanticEnabled: true, EmbeddingModel: "nomic-embed-text"}},
+			wantErr: true,
+		},
+		{
+			name: "enabled, endpoint inherited from consolidation, is fine",
+			m: cortex.Manifest{
+				Consolidation: &cortex.ConsolidationConfig{LocalLLMEndpoint: "http://localhost:11434/v1"},
+				Search:        &cortex.SearchConfig{SemanticEnabled: true, EmbeddingModel: "nomic-embed-text"},
+			},
+		},
+		{
+			name: "enabled with own endpoint + model is fine",
+			m: cortex.Manifest{Search: &cortex.SearchConfig{
+				SemanticEnabled:   true,
+				EmbeddingEndpoint: "http://localhost:11434/v1",
+				EmbeddingModel:    "nomic-embed-text",
+			}},
+		},
+		{
+			name: "hybrid_weight out of range is rejected",
+			m: cortex.Manifest{Search: &cortex.SearchConfig{
+				SemanticEnabled:   true,
+				EmbeddingEndpoint: "http://localhost:11434/v1",
+				EmbeddingModel:    "nomic-embed-text",
+				HybridWeight:      1.5,
+			}},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.m.ValidateSearch()
+			if tt.wantErr != (err != nil) {
+				t.Errorf("ValidateSearch() err = %v, wantErr = %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSearchConfigAccessors(t *testing.T) {
+	var nilCfg *cortex.SearchConfig
+	if nilCfg.SemanticOn() {
+		t.Error("nil config should report semantic off")
+	}
+	if nilCfg.EffectiveDefaultMode() != cortex.SearchModeLexical {
+		t.Error("nil config default mode should be lexical")
+	}
+	if nilCfg.EffectiveHybridWeight() != 0.5 {
+		t.Errorf("nil config hybrid weight = %v, want 0.5", nilCfg.EffectiveHybridWeight())
+	}
+	if nilCfg.EffectiveMaxChars() != 32000 {
+		t.Errorf("nil config max chars = %d, want 32000", nilCfg.EffectiveMaxChars())
+	}
+
+	// Clamp above 1.
+	hi := &cortex.SearchConfig{HybridWeight: 2}
+	if hi.EffectiveHybridWeight() != 1 {
+		t.Errorf("hybrid weight clamp = %v, want 1", hi.EffectiveHybridWeight())
+	}
+}
+
+func TestResolvedEmbeddingEndpoint_Inheritance(t *testing.T) {
+	// Search block wins when set.
+	m := cortex.Manifest{
+		Consolidation: &cortex.ConsolidationConfig{LocalLLMEndpoint: "http://consolidation:1", APIKeyEnv: "C_KEY"},
+		Search:        &cortex.SearchConfig{EmbeddingEndpoint: "http://search:2", APIKeyEnv: "S_KEY"},
+	}
+	if got := m.ResolvedEmbeddingEndpoint(); got != "http://search:2" {
+		t.Errorf("endpoint = %q, want search override", got)
+	}
+	if got := m.ResolvedEmbeddingAPIKeyEnv(); got != "S_KEY" {
+		t.Errorf("apikeyenv = %q, want search override", got)
+	}
+
+	// Falls back to consolidation when search leaves them empty.
+	m2 := cortex.Manifest{
+		Consolidation: &cortex.ConsolidationConfig{LocalLLMEndpoint: "http://consolidation:1", APIKeyEnv: "C_KEY"},
+		Search:        &cortex.SearchConfig{SemanticEnabled: true, EmbeddingModel: "m"},
+	}
+	if got := m2.ResolvedEmbeddingEndpoint(); got != "http://consolidation:1" {
+		t.Errorf("endpoint = %q, want consolidation fallback", got)
+	}
+	if got := m2.ResolvedEmbeddingAPIKeyEnv(); got != "C_KEY" {
+		t.Errorf("apikeyenv = %q, want consolidation fallback", got)
+	}
+}

--- a/internal/db/migration016_test.go
+++ b/internal/db/migration016_test.go
@@ -1,0 +1,109 @@
+package db_test
+
+import (
+	"testing"
+
+	"github.com/Fail-Safe/Noema/internal/db"
+)
+
+// ---- Migration 016: trace_embeddings ----
+
+func TestMigration016_ColumnsAndSchema(t *testing.T) {
+	conn, err := db.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer conn.Close()
+
+	rows, err := conn.Query(`PRAGMA table_info(trace_embeddings)`)
+	if err != nil {
+		t.Fatalf("PRAGMA table_info: %v", err)
+	}
+	defer rows.Close()
+	cols := map[string]struct {
+		notnull int
+		pk      int
+	}{}
+	for rows.Next() {
+		var cid, notnull, pk int
+		var name, ctype string
+		var dflt *string
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			t.Fatalf("Scan: %v", err)
+		}
+		cols[name] = struct {
+			notnull int
+			pk      int
+		}{notnull, pk}
+	}
+	for _, c := range []string{"trace_id", "embedding_model", "dim", "embedding", "source_hash", "updated_at"} {
+		if _, ok := cols[c]; !ok {
+			t.Errorf("trace_embeddings.%s missing after migration 016", c)
+		}
+	}
+	if cols["trace_id"].pk != 1 {
+		t.Error("trace_id should be the primary key")
+	}
+	if cols["embedding"].notnull != 1 {
+		t.Error("embedding should be NOT NULL")
+	}
+}
+
+// TestMigration016_EmbeddingFKCascade locks in ON DELETE CASCADE: deleting a
+// trace removes its embedding row (foreign_keys is enabled per the DSN).
+func TestMigration016_EmbeddingFKCascade(t *testing.T) {
+	conn, err := db.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer conn.Close()
+
+	if _, err := conn.Exec(
+		`INSERT INTO traces (id, title, type, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`,
+		"20260603-emb", "embed me", "note", "2026-06-03T00:00:00Z", "2026-06-03T00:00:00Z",
+	); err != nil {
+		t.Fatalf("seed trace: %v", err)
+	}
+	if _, err := conn.Exec(
+		`INSERT INTO trace_embeddings (trace_id, embedding_model, dim, embedding, source_hash, updated_at) VALUES (?, ?, ?, ?, ?, ?)`,
+		"20260603-emb", "nomic-embed-text", 3, []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13}, "sha256:abc", "2026-06-03T00:00:00Z",
+	); err != nil {
+		t.Fatalf("seed embedding: %v", err)
+	}
+
+	if _, err := conn.Exec(`DELETE FROM traces WHERE id = ?`, "20260603-emb"); err != nil {
+		t.Fatalf("delete trace: %v", err)
+	}
+
+	var n int
+	if err := conn.QueryRow(`SELECT COUNT(*) FROM trace_embeddings WHERE trace_id = ?`, "20260603-emb").Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("embedding row not cascade-deleted; %d remain", n)
+	}
+}
+
+// TestMigration016_RejectsNullEmbedding confirms the NOT NULL constraint on
+// the embedding BLOB column.
+func TestMigration016_RejectsNullEmbedding(t *testing.T) {
+	conn, err := db.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer conn.Close()
+
+	if _, err := conn.Exec(
+		`INSERT INTO traces (id, title, type, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`,
+		"20260603-x", "x", "note", "2026-06-03T00:00:00Z", "2026-06-03T00:00:00Z",
+	); err != nil {
+		t.Fatalf("seed trace: %v", err)
+	}
+	_, err = conn.Exec(
+		`INSERT INTO trace_embeddings (trace_id, embedding_model, dim, embedding, source_hash, updated_at) VALUES (?, ?, ?, NULL, ?, ?)`,
+		"20260603-x", "m", 3, "sha256:x", "2026-06-03T00:00:00Z",
+	)
+	if err == nil {
+		t.Error("NULL embedding should be rejected by NOT NULL")
+	}
+}

--- a/internal/db/migrations/016_trace_embeddings.sql
+++ b/internal/db/migrations/016_trace_embeddings.sql
@@ -1,0 +1,32 @@
+-- trace_embeddings stores one semantic embedding vector per trace for the
+-- opt-in semantic-search path. It is a LOCAL derived index, like the FTS5
+-- table: vectors are computed by each cortex from its own configured
+-- embedding model and are never federated (vectors from different models
+-- aren't comparable, and trace bodies + content_hash already sync). Older
+-- peers and cortexes without a `search:` config simply lack this table and
+-- serve lexical search only, so a mixed-version ring degrades gracefully
+-- with no wire-format change.
+--
+-- Storage is pure-Go-friendly: `embedding` is a BLOB (1-byte codec version
+-- + little-endian float32[dim]); modernc.org/sqlite can't load the
+-- sqlite-vec C extension, so cosine similarity is computed in Go over these
+-- blobs. A feasibility spike confirmed brute-force is interactive at the
+-- target scale (single-digit ms for ~10k traces). See
+-- docs/plans/semantic-search-plan.md in the Noema-design repo.
+--
+-- `source_hash` records the trace's content_hash at embed time; when a
+-- body edit changes content_hash the row is stale and gets re-embedded on
+-- the next backfill or write hook. `embedding_model` lets a model change be
+-- detected and trigger a full recompute. ON DELETE CASCADE drops the vector
+-- when the trace row is hard-removed.
+CREATE TABLE trace_embeddings (
+    trace_id        TEXT    NOT NULL PRIMARY KEY,
+    embedding_model TEXT    NOT NULL,
+    dim             INTEGER NOT NULL,
+    embedding       BLOB    NOT NULL,
+    source_hash     TEXT    NOT NULL,
+    updated_at      TEXT    NOT NULL,
+    FOREIGN KEY (trace_id) REFERENCES traces(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_trace_embeddings_model ON trace_embeddings(embedding_model);


### PR DESCRIPTION
Phase 1 of the pre-v1 semantic-search feature. Design: `semantic-search-plan.md` (Noema-design).

**Inert by design** — no query path, write-time lifecycle hooks, or MCP/CLI changes yet (phases 2-4). Nothing changes for existing users until a `search:` block opts in. Lands the frozen-for-v1 scaffolding now while breaking changes are still free.

### What's in
- **Migration 016 `trace_embeddings`** — per-trace embedding BLOB (`trace_id, embedding_model, dim, embedding, source_hash, updated_at`), `ON DELETE CASCADE`. A **local-only derived index** (never federated — like FTS5): no `sync_events`/wire-format change, mixed-version rings just serve lexical.
- **`HTTPLLMClient.Embed` + `Embedder` interface** — OpenAI-compatible `/embeddings`, reusing the consolidation endpoint/auth/client. Batches by 64, preserves input order (realigns on response `index` when the provider sends a clean permutation, else positional).
- **Embedding BLOB codec** — 1-byte version tag + little-endian float32; `normalizeEmbedding` so cosine reduces to a dot product. Pure-Go (no `sqlite-vec`).
- **`SearchConfig` (`search:` block)** — off by default. Semantic requires an explicit `embedding_model` (no baked-in default) + a resolvable endpoint (own or inherited from `consolidation`). `default_mode`/`hybrid_weight`/`max_chars` accessors; `ValidateSearch` wired into `ReadManifest`.

### Surface frozen here (intentional, for v1)
`search:` config block, the `trace_embeddings` table, and the embedding BLOB codec version. The `mode` MCP param and `noema embeddings` CLI arrive in later phases.

### Tests
Embed envelope + 3-batch chunking + out-of-order reindex; codec round-trip/error/normalize; `ValidateSearch` matrix incl. consolidation-endpoint inheritance; accessor defaults. Full `build + vet + test` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)