### PR TITLE
feat(search): semantic-search phase 2 — backfill, status, embeddings CLI

### DIFF
--- a/internal/cli/cmd_embeddings.go
+++ b/internal/cli/cmd_embeddings.go
@@ -1,0 +1,111 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Fail-Safe/Noema/internal/consolidation"
+	"github.com/Fail-Safe/Noema/internal/cortex"
+)
+
+func embeddingsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "embeddings",
+		Short: "Manage semantic-search embeddings",
+		Long: "Inspect and rebuild the per-trace embedding index used by " +
+			"semantic search. Embeddings are a local index (never federated); " +
+			"configure search.embedding_model + an endpoint in cortex.md.",
+	}
+	cmd.AddCommand(embeddingsStatusCmd(), embeddingsBackfillCmd())
+	return cmd
+}
+
+func embeddingsStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show embedding coverage for the active cortex",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cx, err := resolveCortex()
+			if err != nil {
+				return err
+			}
+			defer cx.Close()
+
+			m, err := cortex.ReadManifest(cx.Dir)
+			if err != nil {
+				return err
+			}
+			model := ""
+			if m.Search != nil {
+				model = m.Search.EmbeddingModel
+			}
+			st, err := cx.EmbeddingStatus(model)
+			if err != nil {
+				return err
+			}
+
+			if m.Search.SemanticOn() {
+				fmt.Printf("Semantic search: enabled (model=%s, endpoint=%s)\n", model, m.ResolvedEmbeddingEndpoint())
+			} else {
+				fmt.Println("Semantic search: disabled (set search.semantic_enabled + search.embedding_model in cortex.md)")
+			}
+			fmt.Printf("Embeddable traces: %d\n", st.Embeddable)
+			fmt.Printf("  embedded (up-to-date): %d\n", st.Embedded)
+			fmt.Printf("  stale (changed or other model): %d\n", st.Stale)
+			fmt.Printf("  missing: %d\n", st.Missing)
+			return nil
+		},
+	}
+}
+
+func embeddingsBackfillCmd() *cobra.Command {
+	var (
+		force bool
+		limit int
+	)
+	cmd := &cobra.Command{
+		Use:   "backfill",
+		Short: "Embed traces that are missing or stale (for semantic search)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cx, err := resolveCortex()
+			if err != nil {
+				return err
+			}
+			defer cx.Close()
+
+			m, err := cortex.ReadManifest(cx.Dir)
+			if err != nil {
+				return err
+			}
+			if m.Search == nil || m.Search.EmbeddingModel == "" {
+				return fmt.Errorf("set search.embedding_model in cortex.md before backfilling")
+			}
+			endpoint := m.ResolvedEmbeddingEndpoint()
+			if endpoint == "" {
+				return fmt.Errorf("set search.embedding_endpoint (or consolidation.local_llm_endpoint) in cortex.md")
+			}
+			client, err := consolidation.NewHTTPLLMClient(endpoint, m.ResolvedEmbeddingAPIKeyEnv())
+			if err != nil {
+				return fmt.Errorf("embedding client: %w", err)
+			}
+
+			fmt.Printf("Backfilling embeddings (model=%s, endpoint=%s)...\n", m.Search.EmbeddingModel, endpoint)
+			res, err := cx.EmbedBackfill(cmd.Context(), client, m.Search.EmbeddingModel, cortex.EmbedBackfillOpts{
+				Force:    force,
+				Limit:    limit,
+				MaxChars: m.Search.EffectiveMaxChars(),
+			})
+			if err != nil {
+				return fmt.Errorf("backfill failed after embedding %d: %w", res.Embedded, err)
+			}
+			fmt.Printf("Done: %d considered, %d embedded.\n", res.Considered, res.Embedded)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&force, "force", false, "re-embed all traces, ignoring staleness")
+	cmd.Flags().IntVar(&limit, "limit", 0, "max traces to process (0 = all)")
+	return cmd
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -116,7 +116,7 @@ func init() {
 	addGrouped(groupTrace,
 		addCmd(), listCmd(), getCmd(), editCmd(), appendCmd(), removeCmd(),
 		searchCmd(), similarCmd(), archiveCmd(), unarchiveCmd(), recoverCmd(), purgeCmd(), syncCmd(),
-		eventsCmd(), resolveCmd(), memoryCmd(), consolidateCmd(),
+		eventsCmd(), resolveCmd(), memoryCmd(), consolidateCmd(), embeddingsCmd(),
 	)
 	addGrouped(groupCortex,
 		initCmd(), useCmd(), cortexCmd(), federationCmd(), migrateCmd(),

--- a/internal/cortex/embedding.go
+++ b/internal/cortex/embedding.go
@@ -1,11 +1,46 @@
 package cortex
 
 import (
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"math"
+	"strings"
 )
+
+// Embedder turns text into vectors. Defined here (not imported from
+// consolidation) so the cortex package stays free of an import cycle —
+// consolidation.HTTPLLMClient satisfies this structurally and is injected
+// by the CLI/serve layer, which may import both packages.
+type Embedder interface {
+	Embed(ctx context.Context, model string, inputs []string) ([][]float32, error)
+}
+
+// embeddingText builds the string sent to the embedding model for a trace:
+// title and body joined, trimmed, and truncated to maxChars runes to stay
+// within model input limits. A blank body embeds the title alone (and vice
+// versa). Truncation is on a rune boundary so a multibyte character is
+// never split.
+func embeddingText(title, body string, maxChars int) string {
+	title = strings.TrimSpace(title)
+	body = strings.TrimSpace(body)
+	var s string
+	switch {
+	case body == "":
+		s = title
+	case title == "":
+		s = body
+	default:
+		s = title + "\n\n" + body
+	}
+	if maxChars > 0 {
+		if r := []rune(s); len(r) > maxChars {
+			s = string(r[:maxChars])
+		}
+	}
+	return s
+}
 
 // embeddingCodecVersion prefixes every stored embedding BLOB so a future
 // encoding (e.g. int8 quantization) can be introduced without ambiguity:

--- a/internal/cortex/embedding_backfill_test.go
+++ b/internal/cortex/embedding_backfill_test.go
@@ -1,0 +1,218 @@
+package cortex_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/Fail-Safe/Noema/internal/consolidation"
+	"github.com/Fail-Safe/Noema/internal/cortex"
+	"github.com/Fail-Safe/Noema/internal/trace"
+)
+
+// stubEmbedder is a deterministic cortex.Embedder for tests: no network,
+// returns one fixed-dim vector per input and records call/input counts.
+type stubEmbedder struct {
+	calls  int
+	inputs int
+	model  string
+	dim    int
+}
+
+func (s *stubEmbedder) Embed(ctx context.Context, model string, inputs []string) ([][]float32, error) {
+	s.calls++
+	s.model = model
+	s.inputs += len(inputs)
+	d := s.dim
+	if d == 0 {
+		d = 4
+	}
+	out := make([][]float32, len(inputs))
+	for i, in := range inputs {
+		v := make([]float32, d)
+		for j := range v {
+			v[j] = float32(len(in)%7 + j + 1)
+		}
+		out[i] = v
+	}
+	return out, nil
+}
+
+func seedTraces(t *testing.T, cx *cortex.Cortex, n int) []string {
+	t.Helper()
+	ids := make([]string, 0, n)
+	titles := []string{"alpha doc", "beta note", "gamma idea", "delta plan", "epsilon log"}
+	for i := range n {
+		tr := trace.New(titles[i%len(titles)], "note", "tester", nil, fmt.Sprintf("body number %d", i))
+		if err := cx.Add(tr); err != nil {
+			t.Fatalf("Add: %v", err)
+		}
+		ids = append(ids, tr.ID)
+	}
+	return ids
+}
+
+func TestEmbedBackfill_Lifecycle(t *testing.T) {
+	cx := setup(t)
+	ctx := context.Background()
+	ids := seedTraces(t, cx, 3)
+
+	// Initially everything is missing.
+	st, err := cx.EmbeddingStatus("m1")
+	if err != nil {
+		t.Fatalf("EmbeddingStatus: %v", err)
+	}
+	if st.Embeddable != 3 || st.Missing != 3 || st.Embedded != 0 {
+		t.Fatalf("initial status = %+v, want embeddable=3 missing=3 embedded=0", st)
+	}
+
+	emb := &stubEmbedder{dim: 4}
+	res, err := cx.EmbedBackfill(ctx, emb, "m1", cortex.EmbedBackfillOpts{})
+	if err != nil {
+		t.Fatalf("EmbedBackfill: %v", err)
+	}
+	if res.Considered != 3 || res.Embedded != 3 {
+		t.Fatalf("backfill result = %+v, want considered=3 embedded=3", res)
+	}
+	if emb.model != "m1" {
+		t.Errorf("embedder saw model %q, want m1", emb.model)
+	}
+
+	st, _ = cx.EmbeddingStatus("m1")
+	if st.Embedded != 3 || st.Missing != 0 || st.Stale != 0 {
+		t.Fatalf("post-backfill status = %+v, want embedded=3", st)
+	}
+
+	// Idempotent: nothing stale, so a second run does no work.
+	res2, _ := cx.EmbedBackfill(ctx, emb, "m1", cortex.EmbedBackfillOpts{})
+	if res2.Considered != 0 || res2.Embedded != 0 {
+		t.Errorf("second run = %+v, want no work (idempotent)", res2)
+	}
+
+	// Stored row: dim correct and source_hash == content_hash.
+	var dim int
+	var sh, ch string
+	if err := cx.DB.QueryRow(`SELECT dim, source_hash FROM trace_embeddings WHERE trace_id=?`, ids[0]).Scan(&dim, &sh); err != nil {
+		t.Fatalf("read embedding row: %v", err)
+	}
+	if err := cx.DB.QueryRow(`SELECT content_hash FROM traces WHERE id=?`, ids[0]).Scan(&ch); err != nil {
+		t.Fatalf("read content_hash: %v", err)
+	}
+	if dim != 4 {
+		t.Errorf("stored dim = %d, want 4", dim)
+	}
+	if sh != ch || sh == "" {
+		t.Errorf("source_hash %q != content_hash %q", sh, ch)
+	}
+
+	// A body edit makes that trace stale again.
+	if err := cx.Append(ids[0], "appended content changes the body hash"); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	st, _ = cx.EmbeddingStatus("m1")
+	if st.Stale != 1 {
+		t.Fatalf("after body edit, stale = %d, want 1", st.Stale)
+	}
+	res3, _ := cx.EmbedBackfill(ctx, emb, "m1", cortex.EmbedBackfillOpts{})
+	if res3.Considered != 1 || res3.Embedded != 1 {
+		t.Errorf("re-embed after edit = %+v, want considered=1 embedded=1", res3)
+	}
+
+	// Switching models invalidates every row for the new model.
+	res4, _ := cx.EmbedBackfill(ctx, emb, "m2", cortex.EmbedBackfillOpts{})
+	if res4.Considered != 3 {
+		t.Errorf("model change considered = %d, want 3", res4.Considered)
+	}
+	if newSt, _ := cx.EmbeddingStatus("m2"); newSt.Embedded != 3 {
+		t.Errorf("m2 embedded = %d, want 3", newSt.Embedded)
+	}
+	if oldSt, _ := cx.EmbeddingStatus("m1"); oldSt.Embedded != 0 || oldSt.Stale != 3 {
+		t.Errorf("m1 status after switch = %+v, want embedded=0 stale=3", oldSt)
+	}
+}
+
+func TestEmbedBackfill_ForceAndLimit(t *testing.T) {
+	cx := setup(t)
+	ctx := context.Background()
+	seedTraces(t, cx, 3)
+	emb := &stubEmbedder{dim: 4}
+
+	if _, err := cx.EmbedBackfill(ctx, emb, "m", cortex.EmbedBackfillOpts{}); err != nil {
+		t.Fatalf("initial backfill: %v", err)
+	}
+	// Force re-embeds even up-to-date rows.
+	r, _ := cx.EmbedBackfill(ctx, emb, "m", cortex.EmbedBackfillOpts{Force: true})
+	if r.Considered != 3 || r.Embedded != 3 {
+		t.Errorf("force = %+v, want considered=3 embedded=3", r)
+	}
+	// Limit caps the run.
+	r2, _ := cx.EmbedBackfill(ctx, emb, "m", cortex.EmbedBackfillOpts{Force: true, Limit: 2})
+	if r2.Considered != 2 || r2.Embedded != 2 {
+		t.Errorf("limit=2 => %+v, want considered=2 embedded=2", r2)
+	}
+}
+
+// TestEmbedBackfill_WithRealHTTPClient runs the backfill through the actual
+// consolidation.HTTPLLMClient against an httptest /embeddings server,
+// proving the real client satisfies cortex.Embedder and the end-to-end
+// wiring stores vectors of the served dimension.
+func TestEmbedBackfill_WithRealHTTPClient(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			Input []string `json:"input"`
+		}
+		_ = json.Unmarshal(body, &req)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("{\"data\":["))
+		for i := range req.Input {
+			if i > 0 {
+				w.Write([]byte(","))
+			}
+			// 3-dim vector per input
+			w.Write([]byte(`{"index":` + strconv.Itoa(i) + `,"embedding":[0.1,0.2,0.3]}`))
+		}
+		w.Write([]byte("]}"))
+	}))
+	defer server.Close()
+
+	cx := setup(t)
+	ids := seedTraces(t, cx, 2)
+	client, err := consolidation.NewHTTPLLMClient(server.URL, "")
+	if err != nil {
+		t.Fatalf("NewHTTPLLMClient: %v", err)
+	}
+	res, err := cx.EmbedBackfill(context.Background(), client, "real-model", cortex.EmbedBackfillOpts{})
+	if err != nil {
+		t.Fatalf("EmbedBackfill: %v", err)
+	}
+	if res.Embedded != 2 {
+		t.Fatalf("embedded = %d, want 2", res.Embedded)
+	}
+	var dim int
+	if err := cx.DB.QueryRow(`SELECT dim FROM trace_embeddings WHERE trace_id=?`, ids[0]).Scan(&dim); err != nil {
+		t.Fatalf("read dim: %v", err)
+	}
+	if dim != 3 {
+		t.Errorf("stored dim = %d, want 3 (from server)", dim)
+	}
+	if st, _ := cx.EmbeddingStatus("real-model"); st.Embedded != 2 {
+		t.Errorf("status embedded = %d, want 2", st.Embedded)
+	}
+}
+
+func TestEmbedBackfill_Guards(t *testing.T) {
+	cx := setup(t)
+	ctx := context.Background()
+	if _, err := cx.EmbedBackfill(ctx, nil, "m", cortex.EmbedBackfillOpts{}); err == nil {
+		t.Error("nil embedder should error")
+	}
+	if _, err := cx.EmbedBackfill(ctx, &stubEmbedder{}, "", cortex.EmbedBackfillOpts{}); err == nil {
+		t.Error("empty model should error")
+	}
+}

--- a/internal/cortex/embedding_store.go
+++ b/internal/cortex/embedding_store.go
@@ -1,0 +1,187 @@
+package cortex
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Fail-Safe/Noema/internal/trace"
+)
+
+// EmbeddingStatus summarizes semantic-search embedding coverage for a given
+// embedding model. "Embeddable" is every non-trashed trace (active +
+// archived); trashed traces are excluded by design. A trace is "embedded"
+// only when it has a row for the active model whose source_hash still
+// matches the trace's content_hash — otherwise it is "stale" (body changed
+// or a different model) or "missing" (no row at all).
+type EmbeddingStatus struct {
+	Model      string
+	Embeddable int
+	Embedded   int
+	Stale      int
+	Missing    int
+}
+
+// EmbeddingStatus computes coverage counts for model. A model of "" reports
+// everything as stale/missing (nothing matches an empty model), which is
+// the correct signal for a cortex that hasn't configured semantic search.
+func (c *Cortex) EmbeddingStatus(model string) (EmbeddingStatus, error) {
+	st := EmbeddingStatus{Model: model}
+	if err := c.DB.QueryRow(`SELECT COUNT(*) FROM traces WHERE trashed_at IS NULL`).Scan(&st.Embeddable); err != nil {
+		return st, fmt.Errorf("count embeddable: %w", err)
+	}
+	var withRow int
+	if err := c.DB.QueryRow(
+		`SELECT COUNT(*) FROM traces t JOIN trace_embeddings te ON te.trace_id = t.id WHERE t.trashed_at IS NULL`,
+	).Scan(&withRow); err != nil {
+		return st, fmt.Errorf("count embedding rows: %w", err)
+	}
+	if err := c.DB.QueryRow(
+		`SELECT COUNT(*) FROM traces t JOIN trace_embeddings te ON te.trace_id = t.id
+		 WHERE t.trashed_at IS NULL AND te.embedding_model = ? AND te.source_hash = t.content_hash`,
+		model,
+	).Scan(&st.Embedded); err != nil {
+		return st, fmt.Errorf("count embedded: %w", err)
+	}
+	st.Missing = st.Embeddable - withRow
+	st.Stale = withRow - st.Embedded
+	return st, nil
+}
+
+// EmbedBackfillOpts tunes a backfill run.
+type EmbedBackfillOpts struct {
+	Force     bool // re-embed every embeddable trace, ignoring staleness
+	Limit     int  // cap traces processed this run (0 = no cap)
+	MaxChars  int  // per-trace text budget (0 = default)
+	BatchSize int  // traces per Embed call (0 = 64)
+}
+
+// EmbedBackfillResult reports what a run did.
+type EmbedBackfillResult struct {
+	Considered int // candidates selected
+	Embedded   int // vectors computed and stored
+}
+
+// EmbedBackfill computes and stores embeddings for traces that are missing
+// or stale for model (or all embeddable traces when Force). It is
+// idempotent (a second run with no changes does nothing), resumable (each
+// batch is committed before the next, so a mid-run failure keeps prior
+// progress), and safe to run while serving (WAL). It never blocks a
+// mutation — callers invoke it explicitly (CLI) or on a schedule.
+//
+// Body text is read from each trace's markdown file (the source of truth);
+// the stored source_hash is the trace's content_hash at selection time, so
+// a later body edit re-marks the row stale.
+func (c *Cortex) EmbedBackfill(ctx context.Context, e Embedder, model string, opts EmbedBackfillOpts) (EmbedBackfillResult, error) {
+	var res EmbedBackfillResult
+	if e == nil {
+		return res, fmt.Errorf("embedder is nil")
+	}
+	if model == "" {
+		return res, fmt.Errorf("embedding model is empty")
+	}
+	batch := opts.BatchSize
+	if batch <= 0 {
+		batch = 64
+	}
+	maxChars := opts.MaxChars
+	if maxChars <= 0 {
+		maxChars = defaultEmbedMaxChars
+	}
+
+	q := `SELECT t.id, t.content_hash FROM traces t
+	      LEFT JOIN trace_embeddings te ON te.trace_id = t.id
+	      WHERE t.trashed_at IS NULL`
+	var args []any
+	if !opts.Force {
+		q += ` AND (te.trace_id IS NULL OR te.embedding_model != ? OR te.source_hash != t.content_hash)`
+		args = append(args, model)
+	}
+	q += ` ORDER BY t.created_at`
+	if opts.Limit > 0 {
+		q += ` LIMIT ?`
+		args = append(args, opts.Limit)
+	}
+
+	rows, err := c.DB.Query(q, args...)
+	if err != nil {
+		return res, fmt.Errorf("query candidates: %w", err)
+	}
+	type cand struct{ id, contentHash string }
+	var cands []cand
+	for rows.Next() {
+		var ce cand
+		if err := rows.Scan(&ce.id, &ce.contentHash); err != nil {
+			rows.Close()
+			return res, fmt.Errorf("scan candidate: %w", err)
+		}
+		cands = append(cands, ce)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return res, fmt.Errorf("iterate candidates: %w", err)
+	}
+	res.Considered = len(cands)
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	for start := 0; start < len(cands); start += batch {
+		if err := ctx.Err(); err != nil {
+			return res, err
+		}
+		end := min(start+batch, len(cands))
+		chunk := cands[start:end]
+
+		texts := make([]string, 0, len(chunk))
+		ids := make([]string, 0, len(chunk))
+		hashes := make([]string, 0, len(chunk))
+		for _, ce := range chunk {
+			r, err := c.Get(ce.id)
+			if err != nil {
+				continue // vanished mid-run; skip
+			}
+			t, err := trace.ParseFile(c.filePath(r))
+			if err != nil {
+				continue // unreadable/malformed; skip
+			}
+			texts = append(texts, embeddingText(r.Title, t.Body, maxChars))
+			ids = append(ids, ce.id)
+			hashes = append(hashes, ce.contentHash)
+		}
+		if len(texts) == 0 {
+			continue
+		}
+
+		vecs, err := e.Embed(ctx, model, texts)
+		if err != nil {
+			return res, fmt.Errorf("embed batch: %w", err)
+		}
+		if len(vecs) != len(texts) {
+			return res, fmt.Errorf("embedder returned %d vectors for %d inputs", len(vecs), len(texts))
+		}
+		for i := range ids {
+			v := vecs[i]
+			normalizeEmbedding(v)
+			if err := c.upsertEmbedding(ids[i], model, len(v), encodeEmbedding(v), hashes[i], now); err != nil {
+				return res, fmt.Errorf("store embedding for %s: %w", ids[i], err)
+			}
+			res.Embedded++
+		}
+	}
+	return res, nil
+}
+
+// upsertEmbedding inserts or replaces the embedding row for a trace.
+func (c *Cortex) upsertEmbedding(id, model string, dim int, blob []byte, sourceHash, updatedAt string) error {
+	_, err := c.DB.Exec(
+		`INSERT INTO trace_embeddings (trace_id, embedding_model, dim, embedding, source_hash, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?)
+		 ON CONFLICT(trace_id) DO UPDATE SET
+		   embedding_model = excluded.embedding_model,
+		   dim             = excluded.dim,
+		   embedding       = excluded.embedding,
+		   source_hash     = excluded.source_hash,
+		   updated_at      = excluded.updated_at`,
+		id, model, dim, blob, sourceHash, updatedAt,
+	)
+	return err
+}

--- a/internal/cortex/embedding_text_test.go
+++ b/internal/cortex/embedding_text_test.go
@@ -1,0 +1,35 @@
+package cortex
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestEmbeddingText(t *testing.T) {
+	if got := embeddingText("Title", "Body", 0); got != "Title\n\nBody" {
+		t.Errorf("title+body = %q", got)
+	}
+	if got := embeddingText("  Title  ", "  Body  ", 0); got != "Title\n\nBody" {
+		t.Errorf("trim = %q", got)
+	}
+	if got := embeddingText("Only title", "   ", 0); got != "Only title" {
+		t.Errorf("empty body => title only, got %q", got)
+	}
+	if got := embeddingText("", "Only body", 0); got != "Only body" {
+		t.Errorf("empty title => body only, got %q", got)
+	}
+	if got := embeddingText("  ", "  ", 0); got != "" {
+		t.Errorf("both empty => empty, got %q", got)
+	}
+
+	// Truncation is rune-bounded and never splits a multibyte character.
+	multi := strings.Repeat("héllo ", 100) // 'é' is 2 bytes
+	got := embeddingText(multi, "", 10)
+	if utf8.RuneCountInString(got) != 10 {
+		t.Errorf("truncated rune count = %d, want 10", utf8.RuneCountInString(got))
+	}
+	if !utf8.ValidString(got) {
+		t.Error("truncation produced invalid UTF-8")
+	}
+}


### PR DESCRIPTION
Phase 2 of semantic search: the deterministic embedding-lifecycle core — compute/store embeddings and report coverage. Builds on #118. Still **off by default** (needs a `search:` block); no query path yet (phase 3).

### What's in
- **`cortex.Embedder`** interface — defined in `cortex` to avoid a `cortex -> consolidation` import cycle; `consolidation.HTTPLLMClient` satisfies it structurally and is injected by the CLI.
- **`embeddingText`** — title+body, trimmed, rune-bounded truncation to `MaxChars` (never splits a multibyte char).
- **`Cortex.EmbeddingStatus(model)`** — embeddable / embedded / stale / missing, keyed on `source_hash == content_hash` (trashed excluded).
- **`Cortex.EmbedBackfill`** — idempotent, resumable (per-batch commit), `Force` + `Limit`, model-change re-embed. Reads body from the markdown file, stores normalized vectors via upsert; staleness keyed on `content_hash`.
- **CLI**: `noema embeddings status` and `noema embeddings backfill [--force] [--limit]`, building the HTTP embedder from the manifest (endpoint/key inherited from `consolidation` when unset).

### Deferred (on purpose)
Write-time async embedding (embed-on-Add/Update/Append) is **deferred to a focused phase-2b PR** so the background-worker concurrency lands in isolation with its own race testing — keeping this PR fully deterministic. For now embeddings are kept fresh via `noema embeddings backfill` (and, later, a scheduled pass).

### Tests
Status transitions; backfill idempotency/force/limit/model-change; body-edit → re-stale; nil-embedder/empty-model guards; `embeddingText` incl. UTF-8 truncation; and an **end-to-end run through the real `consolidation.HTTPLLMClient` over httptest** (proves the interface wiring + served-dimension storage). Full build + vet + test + `-race` on affected packages green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)