### PR TITLE
feat(search): semantic-search phase 3 — query path + CLI --semantic

### DIFF
--- a/internal/cli/cmd_search.go
+++ b/internal/cli/cmd_search.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/Fail-Safe/Noema/internal/consolidation"
 	"github.com/Fail-Safe/Noema/internal/cortex"
 )
 
@@ -13,6 +14,7 @@ func searchCmd() *cobra.Command {
 		archived bool
 		trashed  bool
 		all      bool
+		semantic bool
 		typ      string
 	)
 
@@ -26,6 +28,10 @@ func searchCmd() *cobra.Command {
 				return err
 			}
 			defer cx.Close()
+
+			if semantic {
+				return runSemanticSearch(cmd, cx, args[0], all || archived)
+			}
 
 			rows, err := cx.Search(args[0], cortex.ListOptions{
 				Archived: archived,
@@ -48,6 +54,45 @@ func searchCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&archived, "archived", false, "search only archived traces")
 	cmd.Flags().BoolVar(&trashed, "trashed", false, "search only trashed traces")
 	cmd.Flags().BoolVar(&all, "all", false, "search active and archived traces")
+	cmd.Flags().BoolVar(&semantic, "semantic", false, "rank by embedding similarity (needs a configured search: block + `noema embeddings backfill`)")
 	cmd.Flags().StringVar(&typ, "type", "", "filter results by type")
 	return cmd
+}
+
+// runSemanticSearch builds the embedder from the cortex manifest and ranks
+// traces by embedding similarity. Kept separate so the lexical path stays
+// untouched. The embedder reuses the consolidation endpoint config.
+func runSemanticSearch(cmd *cobra.Command, cx *cortex.Cortex, query string, includeArchived bool) error {
+	m, err := cortex.ReadManifest(cx.Dir)
+	if err != nil {
+		return err
+	}
+	if m.Search == nil || m.Search.EmbeddingModel == "" {
+		return fmt.Errorf("semantic search needs search.embedding_model in cortex.md (then: noema embeddings backfill)")
+	}
+	endpoint := m.ResolvedEmbeddingEndpoint()
+	if endpoint == "" {
+		return fmt.Errorf("semantic search needs search.embedding_endpoint (or consolidation.local_llm_endpoint) in cortex.md")
+	}
+	client, err := consolidation.NewHTTPLLMClient(endpoint, m.ResolvedEmbeddingAPIKeyEnv())
+	if err != nil {
+		return fmt.Errorf("embedding client: %w", err)
+	}
+	res, err := cx.SemanticSearch(cmd.Context(), client, query, cortex.SemanticOpts{
+		Model:           m.Search.EmbeddingModel,
+		IncludeArchived: includeArchived,
+	})
+	if err != nil {
+		return fmt.Errorf("semantic search failed: %w", err)
+	}
+	if len(res) == 0 {
+		fmt.Println("No matching traces.")
+		return nil
+	}
+	rows := make([]cortex.Row, len(res))
+	for i, r := range res {
+		rows[i] = r.Row
+	}
+	printTable(rows)
+	return nil
 }

--- a/internal/cli/cmd_similar.go
+++ b/internal/cli/cmd_similar.go
@@ -15,6 +15,7 @@ func similarCmd() *cobra.Command {
 	var (
 		limit    int
 		archived bool
+		semantic bool
 	)
 
 	cmd := &cobra.Command{
@@ -22,7 +23,8 @@ func similarCmd() *cobra.Command {
 		Short: "Find traces with overlapping vocabulary to a given trace",
 		Long: "Surface related traces by FTS5 BM25 ranking against the source trace's most\n" +
 			"distinctive vocabulary. No embedding model required — pure SQLite full-text\n" +
-			"search.",
+			"search. Use --semantic to rank by embedding similarity instead (needs a\n" +
+			"configured search: block and backfilled embeddings).",
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cx, err := resolveCortex()
@@ -30,6 +32,34 @@ func similarCmd() *cobra.Command {
 				return err
 			}
 			defer cx.Close()
+
+			if semantic {
+				m, err := cortex.ReadManifest(cx.Dir)
+				if err != nil {
+					return err
+				}
+				if m.Search == nil || m.Search.EmbeddingModel == "" {
+					return fmt.Errorf("semantic mode needs search.embedding_model in cortex.md (then: noema embeddings backfill)")
+				}
+				res, err := cx.SemanticSimilar(args[0], cortex.SemanticOpts{
+					Model:           m.Search.EmbeddingModel,
+					Limit:           limit,
+					IncludeArchived: archived,
+				})
+				if err != nil {
+					return fmt.Errorf("semantic similar: %w", err)
+				}
+				if len(res) == 0 {
+					fmt.Println("No similar traces found.")
+					return nil
+				}
+				rows := make([]cortex.Row, len(res))
+				for i, r := range res {
+					rows[i] = r.Row
+				}
+				printTable(rows)
+				return nil
+			}
 
 			matches, err := cx.FindSimilar(args[0], cortex.SimilarOpts{
 				Limit:           limit,
@@ -49,6 +79,7 @@ func similarCmd() *cobra.Command {
 
 	cmd.Flags().IntVar(&limit, "limit", 10, "maximum matches to return")
 	cmd.Flags().BoolVar(&archived, "archived", false, "include archived traces in results")
+	cmd.Flags().BoolVar(&semantic, "semantic", false, "rank by embedding similarity instead of FTS5 (needs backfilled embeddings)")
 	return cmd
 }
 

--- a/internal/cortex/actor.go
+++ b/internal/cortex/actor.go
@@ -1,6 +1,7 @@
 package cortex
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"time"
@@ -134,6 +135,42 @@ func (c *Cortex) FindSimilarAs(traceID string, opts SimilarOpts, actor ReadActor
 	}
 	c.bumpSearchHitsForIDs(ids, tiers, topN)
 	return matches, nil
+}
+
+// SemanticSearchAs is the actor-aware counterpart to SemanticSearch: same
+// top-N search_hit_count bump for ActorAgent as SearchAs.
+func (c *Cortex) SemanticSearchAs(ctx context.Context, e Embedder, query string, opts SemanticOpts, actor ReadActor, topN int) ([]ScoredRow, error) {
+	res, err := c.SemanticSearch(ctx, e, query, opts)
+	if err != nil {
+		return nil, err
+	}
+	if actor == ActorAgent && len(res) > 0 {
+		c.bumpSearchHitsForScored(res, topN)
+	}
+	return res, nil
+}
+
+// SemanticSimilarAs is the actor-aware counterpart to SemanticSimilar.
+func (c *Cortex) SemanticSimilarAs(traceID string, opts SemanticOpts, actor ReadActor, topN int) ([]ScoredRow, error) {
+	res, err := c.SemanticSimilar(traceID, opts)
+	if err != nil {
+		return nil, err
+	}
+	if actor == ActorAgent && len(res) > 0 {
+		c.bumpSearchHitsForScored(res, topN)
+	}
+	return res, nil
+}
+
+// bumpSearchHitsForScored adapts []ScoredRow to the shared bump path.
+func (c *Cortex) bumpSearchHitsForScored(res []ScoredRow, topN int) {
+	ids := make([]string, 0, len(res))
+	tiers := make([]string, 0, len(res))
+	for _, r := range res {
+		ids = append(ids, r.ID)
+		tiers = append(tiers, r.Tier)
+	}
+	c.bumpSearchHitsForIDs(ids, tiers, topN)
 }
 
 // bumpSearchHitsForRows is the slice-of-Row entry point used by SearchAs.

--- a/internal/cortex/semantic.go
+++ b/internal/cortex/semantic.go
@@ -1,0 +1,204 @@
+package cortex
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+)
+
+// ScoredRow is one semantic-search result: a trace row plus its cosine
+// similarity to the query (higher is closer; vectors are unit-normalized
+// so cosine equals the dot product).
+type ScoredRow struct {
+	Row
+	Score float64
+}
+
+// SemanticOpts tunes a semantic query.
+type SemanticOpts struct {
+	Model           string // embedding model whose vectors to search
+	Limit           int    // max results (default 10)
+	IncludeArchived bool   // include archived traces (default false)
+}
+
+// SemanticSearch embeds the query string with e and ranks the cortex's
+// stored vectors (for opts.Model) by cosine similarity. Trashed traces are
+// always excluded; archived traces are excluded unless opts.IncludeArchived.
+// An empty query returns no results. The caller supplies the embedder so
+// the cortex package stays free of an import cycle.
+func (c *Cortex) SemanticSearch(ctx context.Context, e Embedder, query string, opts SemanticOpts) ([]ScoredRow, error) {
+	if e == nil {
+		return nil, errors.New("embedder is nil")
+	}
+	if opts.Model == "" {
+		return nil, errors.New("embedding model is empty")
+	}
+	q := strings.TrimSpace(query)
+	if q == "" {
+		return nil, nil
+	}
+	vecs, err := e.Embed(ctx, opts.Model, []string{q})
+	if err != nil {
+		return nil, fmt.Errorf("embedding query: %w", err)
+	}
+	if len(vecs) != 1 || len(vecs[0]) == 0 {
+		return nil, errors.New("embedder returned no query vector")
+	}
+	qv := vecs[0]
+	normalizeEmbedding(qv)
+
+	cands, err := c.loadEmbeddedCandidates(opts.Model, opts.IncludeArchived, "")
+	if err != nil {
+		return nil, err
+	}
+	return topKCosine(qv, cands, effLimit(opts.Limit)), nil
+}
+
+// SemanticSimilar ranks other traces against the stored vector of traceID
+// (no query embedding needed — it reuses the source trace's own vector, a
+// strictly better signal than the lexical FindSimilar's top-term proxy).
+// The source trace must already be embedded for opts.Model.
+func (c *Cortex) SemanticSimilar(traceID string, opts SemanticOpts) ([]ScoredRow, error) {
+	if opts.Model == "" {
+		return nil, errors.New("embedding model is empty")
+	}
+	var blob []byte
+	err := c.DB.QueryRow(
+		`SELECT embedding FROM trace_embeddings WHERE trace_id = ? AND embedding_model = ?`,
+		traceID, opts.Model,
+	).Scan(&blob)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("trace %s has no %s embedding yet (run: noema embeddings backfill)", traceID, opts.Model)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("loading source vector: %w", err)
+	}
+	qv, err := decodeEmbedding(blob)
+	if err != nil {
+		return nil, fmt.Errorf("decoding source vector: %w", err)
+	}
+	// Stored vectors are already normalized; no need to re-normalize.
+	cands, err := c.loadEmbeddedCandidates(opts.Model, opts.IncludeArchived, traceID)
+	if err != nil {
+		return nil, err
+	}
+	return topKCosine(qv, cands, effLimit(opts.Limit)), nil
+}
+
+func effLimit(l int) int {
+	if l <= 0 {
+		return 10
+	}
+	return l
+}
+
+// vectorCand pairs a row with its decoded embedding for ranking.
+type vectorCand struct {
+	row Row
+	vec []float32
+}
+
+// topKCosine ranks candidates by dot product against query (== cosine for
+// unit vectors), descending, and returns the top limit. Candidates whose
+// dimension differs from the query (e.g. a stale row from another model
+// that slipped through) are skipped rather than mis-scored.
+func topKCosine(query []float32, cands []vectorCand, limit int) []ScoredRow {
+	out := make([]ScoredRow, 0, len(cands))
+	for _, c := range cands {
+		if len(c.vec) != len(query) {
+			continue
+		}
+		var dot float64
+		for i := range query {
+			dot += float64(query[i]) * float64(c.vec[i])
+		}
+		out = append(out, ScoredRow{Row: c.row, Score: dot})
+	}
+	sort.SliceStable(out, func(a, b int) bool { return out[a].Score > out[b].Score })
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}
+
+// loadEmbeddedCandidates returns every embedded, ranking-eligible trace for
+// model: non-trashed (archived excluded unless includeArchived), optionally
+// excluding excludeID (the source trace in a similarity query). Vectors
+// containing non-finite values (a corrupted BLOB) are skipped so they can't
+// poison ranking — the finiteness check the Phase-1 review flagged, applied
+// here at the consumer where stored vectors are actually read.
+func (c *Cortex) loadEmbeddedCandidates(model string, includeArchived bool, excludeID string) ([]vectorCand, error) {
+	q := `SELECT t.id, t.title, t.type, t.tier, t.author, t.origin,
+	             t.archived_at, t.trashed_at, t.created_at, t.updated_at,
+	             t.content_hash, t.source_locked, t.source_hash,
+	             te.embedding
+	      FROM trace_embeddings te
+	      JOIN traces t ON t.id = te.trace_id
+	      WHERE te.embedding_model = ? AND t.trashed_at IS NULL`
+	args := []any{model}
+	if !includeArchived {
+		q += ` AND t.archived_at IS NULL`
+	}
+	if excludeID != "" {
+		q += ` AND t.id != ?`
+		args = append(args, excludeID)
+	}
+
+	rows, err := c.DB.Query(q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("loading embedded candidates: %w", err)
+	}
+	defer rows.Close()
+
+	var out []vectorCand
+	for rows.Next() {
+		var r Row
+		var archivedAt, trashedAt, contentHash, sourceHash *string
+		var sourceLocked int
+		var blob []byte
+		if err := rows.Scan(
+			&r.ID, &r.Title, &r.Type, &r.Tier, &r.Author, &r.Origin,
+			&archivedAt, &trashedAt, &r.CreatedAt, &r.UpdatedAt,
+			&contentHash, &sourceLocked, &sourceHash, &blob,
+		); err != nil {
+			return nil, err
+		}
+		if archivedAt != nil {
+			r.ArchivedAt = *archivedAt
+		}
+		if trashedAt != nil {
+			r.TrashedAt = *trashedAt
+		}
+		if contentHash != nil {
+			r.ContentHash = *contentHash
+		}
+		if sourceHash != nil {
+			r.SourceHash = *sourceHash
+		}
+		r.SourceLocked = sourceLocked != 0
+
+		vec, err := decodeEmbedding(blob)
+		if err != nil || !allFinite(vec) {
+			continue // skip corrupted/non-finite vectors
+		}
+		out = append(out, vectorCand{row: r, vec: vec})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// allFinite reports whether every element of v is a finite number.
+func allFinite(v []float32) bool {
+	for _, f := range v {
+		if math.IsNaN(float64(f)) || math.IsInf(float64(f), 0) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/cortex/semantic_internal_test.go
+++ b/internal/cortex/semantic_internal_test.go
@@ -1,0 +1,40 @@
+package cortex
+
+import (
+	"math"
+	"testing"
+)
+
+func TestTopKCosine(t *testing.T) {
+	q := []float32{1, 0, 0}
+	cands := []vectorCand{
+		{row: Row{ID: "a"}, vec: []float32{1, 0, 0}},     // dot 1.0
+		{row: Row{ID: "b"}, vec: []float32{0, 1, 0}},     // dot 0.0
+		{row: Row{ID: "c"}, vec: []float32{0.7, 0.7, 0}}, // dot 0.7
+		{row: Row{ID: "d"}, vec: []float32{1, 0}},        // dim mismatch -> skipped
+	}
+	res := topKCosine(q, cands, 2)
+	if len(res) != 2 {
+		t.Fatalf("got %d results, want 2 (limit)", len(res))
+	}
+	if res[0].ID != "a" || res[1].ID != "c" {
+		t.Errorf("order = [%s %s], want [a c]", res[0].ID, res[1].ID)
+	}
+	// Limit 0 returns all rankable (dim-mismatch still excluded).
+	all := topKCosine(q, cands, 0)
+	if len(all) != 3 {
+		t.Errorf("limit 0 returned %d, want 3", len(all))
+	}
+}
+
+func TestAllFinite(t *testing.T) {
+	if !allFinite([]float32{1, -2, 0.5}) {
+		t.Error("finite vector reported non-finite")
+	}
+	if allFinite([]float32{1, float32(math.Inf(1)), 3}) {
+		t.Error("+Inf not detected")
+	}
+	if allFinite([]float32{float32(math.NaN())}) {
+		t.Error("NaN not detected")
+	}
+}

--- a/internal/cortex/semantic_test.go
+++ b/internal/cortex/semantic_test.go
@@ -1,0 +1,155 @@
+package cortex_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Fail-Safe/Noema/internal/cortex"
+)
+
+// topicEmbedder maps text to a 3-dim "topic" vector by counting occurrences
+// of alpha/beta/gamma, so rankings are deterministic and assertable. (The
+// shared seedTraces helper makes trace i about alpha/beta/gamma by title.)
+type topicEmbedder struct{}
+
+func (topicEmbedder) Embed(ctx context.Context, model string, inputs []string) ([][]float32, error) {
+	out := make([][]float32, len(inputs))
+	for i, in := range inputs {
+		v := []float32{0.01, 0.01, 0.01}
+		for w := range strings.FieldsSeq(strings.ToLower(in)) {
+			switch {
+			case strings.Contains(w, "alpha"):
+				v[0]++
+			case strings.Contains(w, "beta"):
+				v[1]++
+			case strings.Contains(w, "gamma"):
+				v[2]++
+			}
+		}
+		out[i] = v
+	}
+	return out, nil
+}
+
+func setupSemantic(t *testing.T) (*cortex.Cortex, []string) {
+	t.Helper()
+	cx := setup(t)
+	ids := seedTraces(t, cx, 3) // 0=alpha, 1=beta, 2=gamma (by title)
+	if _, err := cx.EmbedBackfill(context.Background(), topicEmbedder{}, "tm", cortex.EmbedBackfillOpts{}); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	return cx, ids
+}
+
+func TestSemanticSearch_RanksByTopic(t *testing.T) {
+	cx, ids := setupSemantic(t)
+	ctx := context.Background()
+
+	res, err := cx.SemanticSearch(ctx, topicEmbedder{}, "alpha alpha alpha", cortex.SemanticOpts{Model: "tm"})
+	if err != nil {
+		t.Fatalf("SemanticSearch: %v", err)
+	}
+	if len(res) != 3 {
+		t.Fatalf("got %d results, want 3", len(res))
+	}
+	if res[0].ID != ids[0] {
+		t.Errorf("top result = %s, want alpha trace %s", res[0].ID, ids[0])
+	}
+
+	res, _ = cx.SemanticSearch(ctx, topicEmbedder{}, "gamma gamma", cortex.SemanticOpts{Model: "tm"})
+	if res[0].ID != ids[2] {
+		t.Errorf("gamma query top = %s, want %s", res[0].ID, ids[2])
+	}
+}
+
+func TestSemanticSearch_LimitAndArchived(t *testing.T) {
+	cx, ids := setupSemantic(t)
+	ctx := context.Background()
+
+	res, _ := cx.SemanticSearch(ctx, topicEmbedder{}, "alpha", cortex.SemanticOpts{Model: "tm", Limit: 1})
+	if len(res) != 1 {
+		t.Fatalf("limit=1 returned %d", len(res))
+	}
+
+	// Archive the beta trace; default search must exclude it.
+	if err := cx.Archive(ids[1]); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	res, _ = cx.SemanticSearch(ctx, topicEmbedder{}, "beta", cortex.SemanticOpts{Model: "tm"})
+	for _, r := range res {
+		if r.ID == ids[1] {
+			t.Error("archived trace returned without IncludeArchived")
+		}
+	}
+	res, _ = cx.SemanticSearch(ctx, topicEmbedder{}, "beta", cortex.SemanticOpts{Model: "tm", IncludeArchived: true})
+	found := false
+	for _, r := range res {
+		if r.ID == ids[1] {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("archived trace missing with IncludeArchived=true")
+	}
+}
+
+func TestSemanticSimilar_ExcludesSource(t *testing.T) {
+	cx, ids := setupSemantic(t)
+
+	res, err := cx.SemanticSimilar(ids[0], cortex.SemanticOpts{Model: "tm"})
+	if err != nil {
+		t.Fatalf("SemanticSimilar: %v", err)
+	}
+	if len(res) != 2 {
+		t.Fatalf("got %d, want 2 (source excluded)", len(res))
+	}
+	for _, r := range res {
+		if r.ID == ids[0] {
+			t.Error("source trace must be excluded from its own similarity")
+		}
+	}
+
+	// A trace with no embedding for the model errors clearly.
+	if _, err := cx.SemanticSimilar(ids[0], cortex.SemanticOpts{Model: "other-model"}); err == nil {
+		t.Error("expected error for un-embedded model")
+	}
+}
+
+func TestSemanticSearch_SkipsNonFiniteVectors(t *testing.T) {
+	cx, ids := setupSemantic(t)
+	ctx := context.Background()
+
+	// Corrupt the gamma trace's stored vector to all +Inf (codec v1: 1-byte
+	// version + little-endian float32 bits; +Inf = 0x7F800000).
+	infBlob := []byte{1, 0x00, 0x00, 0x80, 0x7f, 0x00, 0x00, 0x80, 0x7f, 0x00, 0x00, 0x80, 0x7f}
+	if _, err := cx.DB.Exec(
+		`UPDATE trace_embeddings SET embedding=?, dim=3 WHERE trace_id=?`, infBlob, ids[2],
+	); err != nil {
+		t.Fatalf("corrupt vector: %v", err)
+	}
+
+	res, err := cx.SemanticSearch(ctx, topicEmbedder{}, "gamma", cortex.SemanticOpts{Model: "tm"})
+	if err != nil {
+		t.Fatalf("SemanticSearch: %v", err)
+	}
+	for _, r := range res {
+		if r.ID == ids[2] {
+			t.Error("non-finite (corrupted) vector must be skipped, not ranked")
+		}
+	}
+}
+
+func TestSemanticSearch_Guards(t *testing.T) {
+	cx := setup(t)
+	ctx := context.Background()
+	if _, err := cx.SemanticSearch(ctx, nil, "q", cortex.SemanticOpts{Model: "tm"}); err == nil {
+		t.Error("nil embedder should error")
+	}
+	if _, err := cx.SemanticSearch(ctx, topicEmbedder{}, "q", cortex.SemanticOpts{}); err == nil {
+		t.Error("empty model should error")
+	}
+	if res, err := cx.SemanticSearch(ctx, topicEmbedder{}, "   ", cortex.SemanticOpts{Model: "tm"}); err != nil || res != nil {
+		t.Errorf("blank query => (nil,nil); got (%v,%v)", res, err)
+	}
+}


### PR DESCRIPTION
Phase 3: semantic search is now usable end-to-end (CLI). Builds on #118/#119.

### What's in
- **`cortex.SemanticSearch(ctx, embedder, query, opts)`** — embeds the query, ranks stored vectors by cosine (== dot; unit-normalized), returns `ScoredRow`. Trashed excluded; archived excluded unless `IncludeArchived`.
- **`cortex.SemanticSimilar(traceID, opts)`** — ranks against the source trace's own stored vector (no query embedding needed); clear error if the source isn't embedded yet.
- **`topKCosine` + `loadEmbeddedCandidates`** — pure-Go ranking. Candidates with a dimension mismatch (stale other-model row) or **non-finite values** are skipped — this applies the finiteness guard the Phase-1 review flagged, at the consumer where stored vectors are read, so a corrupted BLOB can't poison ranking.
- **actor**: `SemanticSearchAs` / `SemanticSimilarAs` bump `search_hit_count` for `ActorAgent`, matching the lexical wrappers.
- **CLI**: `noema search --semantic` and `noema similar --semantic`, building the embedder from the manifest (endpoint/key inherited from `consolidation`).

### Deferred (on purpose)
- **MCP `mode` param** → phase 3b (the agent-facing surface; the server already has the manifest to build an embedder).
- **In-memory vector cache** → phase 3c (pure optimization; per-query DB load is correct and fine at target scale).
- **Hybrid RRF fusion** → phase 4 (as planned).

### Tests
`topKCosine` ordering + dim-mismatch skip; `allFinite`; topic-ranked `SemanticSearch`; limit/archived filters; `SemanticSimilar` source-exclusion + un-embedded-model error; **non-finite-vector skip via a corrupted BLOB**; guards. Full build + vet + staticcheck + test + `-race` on touched packages green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)