### PR TITLE
feat(search): semantic-search phase 3b — MCP mode param

### DIFF
--- a/internal/mcp/semantic_test.go
+++ b/internal/mcp/semantic_test.go
@@ -1,0 +1,191 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Fail-Safe/Noema/internal/consolidation"
+	"github.com/Fail-Safe/Noema/internal/cortex"
+	"github.com/Fail-Safe/Noema/internal/trace"
+)
+
+func topicVec(s string) [3]float32 {
+	v := [3]float32{0.01, 0.01, 0.01}
+	for w := range strings.FieldsSeq(strings.ToLower(s)) {
+		switch {
+		case strings.Contains(w, "alpha"):
+			v[0]++
+		case strings.Contains(w, "beta"):
+			v[1]++
+		case strings.Contains(w, "gamma"):
+			v[2]++
+		}
+	}
+	return v
+}
+
+// topicEmbedServer is an OpenAI-compatible /embeddings endpoint returning a
+// deterministic 3-dim topic vector per input, so MCP semantic ranking is
+// assertable end-to-end without a real model.
+func topicEmbedServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			Input []string `json:"input"`
+		}
+		_ = json.Unmarshal(body, &req)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("{\"data\":["))
+		for i, in := range req.Input {
+			if i > 0 {
+				w.Write([]byte(","))
+			}
+			v := topicVec(in)
+			fmt.Fprintf(w, `{"index":%d,"embedding":[%v,%v,%v]}`, i, v[0], v[1], v[2])
+		}
+		w.Write([]byte("]}"))
+	}))
+}
+
+func writeSearchConfig(t *testing.T, cx *cortex.Cortex, endpoint, model string) {
+	t.Helper()
+	m, err := cortex.ReadManifest(cx.Dir)
+	if err != nil {
+		t.Fatalf("ReadManifest: %v", err)
+	}
+	m.Search = &cortex.SearchConfig{
+		SemanticEnabled:   true,
+		EmbeddingEndpoint: endpoint,
+		EmbeddingModel:    model,
+	}
+	if err := cortex.WriteManifest(cx.Dir, m); err != nil {
+		t.Fatalf("WriteManifest: %v", err)
+	}
+}
+
+func TestResolveSearchMode(t *testing.T) {
+	cx := newTestCortex(t)
+
+	// Unconfigured: default is lexical; explicit semantic yields no embedder.
+	if mode, e, _ := resolveSearchMode(cx, ""); mode != cortex.SearchModeLexical || e != nil {
+		t.Errorf("unconfigured default = (%s, embedder!=nil:%v), want lexical/nil", mode, e != nil)
+	}
+	if mode, e, _ := resolveSearchMode(cx, "semantic"); mode != cortex.SearchModeSemantic || e != nil {
+		t.Errorf("semantic-unconfigured = (%s, embedder!=nil:%v), want semantic/nil-embedder", mode, e != nil)
+	}
+
+	// Configured: semantic yields an embedder + model.
+	writeSearchConfig(t, cx, "http://localhost:1", "tm")
+	mode, e, model := resolveSearchMode(cx, "semantic")
+	if mode != cortex.SearchModeSemantic || e == nil || model != "tm" {
+		t.Errorf("configured semantic = (%s, embedder!=nil:%v, model=%q), want semantic/embedder/tm", mode, e != nil, model)
+	}
+}
+
+func TestSearchTraces_SemanticFallsBackToLexical(t *testing.T) {
+	cx := newTestCortex(t)
+	tr := trace.New("findable thing", "note", "agent", nil, "body about widgets")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	s := NewServer(cx, "test", "")
+
+	// Semantic requested but unconfigured -> note + lexical results.
+	text, isErr := callTool(t, s, "search_traces", map[string]any{"query": "findable", "mode": "semantic"})
+	if isErr {
+		t.Fatalf("search_traces errored: %s", text)
+	}
+	if !strings.Contains(text, "not configured") {
+		t.Errorf("expected fallback note, got:\n%s", text)
+	}
+	if !strings.Contains(text, tr.ID) {
+		t.Errorf("expected lexical result for %s, got:\n%s", tr.ID, text)
+	}
+}
+
+func TestSearchTraces_SemanticEndToEnd(t *testing.T) {
+	server := topicEmbedServer(t)
+	defer server.Close()
+
+	cx := newTestCortex(t)
+	writeSearchConfig(t, cx, server.URL, "tm")
+	add := func(title, body string) string {
+		tr := trace.New(title, "note", "agent", nil, body)
+		if err := cx.Add(tr); err != nil {
+			t.Fatalf("Add: %v", err)
+		}
+		return tr.ID
+	}
+	alphaID := add("alpha topic", "alpha alpha content")
+	add("beta topic", "beta beta content")
+	gammaID := add("gamma topic", "gamma gamma content")
+
+	// Backfill embeddings through the same endpoint the handler will use.
+	client, err := consolidation.NewHTTPLLMClient(server.URL, "")
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	if _, err := cx.EmbedBackfill(context.Background(), client, "tm", cortex.EmbedBackfillOpts{}); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+
+	s := NewServer(cx, "test", "")
+	text, isErr := callTool(t, s, "search_traces", map[string]any{"query": "alpha alpha alpha", "mode": "semantic"})
+	if isErr {
+		t.Fatalf("search_traces errored: %s", text)
+	}
+	if strings.Contains(text, "not configured") || strings.Contains(text, "unavailable") {
+		t.Fatalf("unexpected fallback note in semantic result:\n%s", text)
+	}
+	// The alpha trace should rank above the gamma trace in the output.
+	ai := strings.Index(text, alphaID)
+	gi := strings.Index(text, gammaID)
+	if ai < 0 {
+		t.Fatalf("alpha trace %s missing from results:\n%s", alphaID, text)
+	}
+	if gi >= 0 && ai > gi {
+		t.Errorf("alpha (%d) should rank before gamma (%d) for an alpha query:\n%s", ai, gi, text)
+	}
+}
+
+func TestFindSimilar_SemanticEndToEnd(t *testing.T) {
+	server := topicEmbedServer(t)
+	defer server.Close()
+
+	cx := newTestCortex(t)
+	writeSearchConfig(t, cx, server.URL, "tm")
+	mk := func(title, body string) string {
+		tr := trace.New(title, "note", "agent", nil, body)
+		if err := cx.Add(tr); err != nil {
+			t.Fatalf("Add: %v", err)
+		}
+		return tr.ID
+	}
+	src := mk("alpha source", "alpha alpha alpha")
+	mk("beta other", "beta beta")
+	mk("alpha cousin", "alpha alpha")
+
+	client, _ := consolidation.NewHTTPLLMClient(server.URL, "")
+	if _, err := cx.EmbedBackfill(context.Background(), client, "tm", cortex.EmbedBackfillOpts{}); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+
+	s := NewServer(cx, "test", "")
+	text, isErr := callTool(t, s, "find_similar_traces", map[string]any{"trace_id": src, "mode": "semantic"})
+	if isErr {
+		t.Fatalf("find_similar_traces errored: %s", text)
+	}
+	if strings.Contains(text, "unavailable") || strings.Contains(text, "not configured") {
+		t.Fatalf("unexpected fallback note:\n%s", text)
+	}
+	if strings.Contains(text, src) {
+		t.Errorf("source trace must be excluded from its own similarity:\n%s", text)
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -11,11 +11,60 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
+	"github.com/Fail-Safe/Noema/internal/consolidation"
 	"github.com/Fail-Safe/Noema/internal/cortex"
 	"github.com/Fail-Safe/Noema/internal/event"
 	"github.com/Fail-Safe/Noema/internal/federation"
 	"github.com/Fail-Safe/Noema/internal/trace"
 )
+
+// resolveSearchMode determines the effective search mode for a request and,
+// for semantic/hybrid modes, builds the embedder from the cortex manifest.
+// It returns (mode, embedder, model): the embedder is nil when semantic
+// search isn't configured (no model/endpoint) so callers degrade to lexical.
+// reqMode is the caller-supplied "mode" arg ("" means use the manifest
+// default, which is lexical unless configured otherwise).
+func resolveSearchMode(cx *cortex.Cortex, reqMode string) (string, cortex.Embedder, string) {
+	m, err := cortex.ReadManifest(cx.Dir)
+	if err != nil {
+		return cortex.SearchModeLexical, nil, ""
+	}
+	mode := reqMode
+	if mode == "" {
+		mode = m.Search.EffectiveDefaultMode()
+	}
+	if mode == cortex.SearchModeLexical {
+		return cortex.SearchModeLexical, nil, ""
+	}
+	if m.Search == nil || m.Search.EmbeddingModel == "" {
+		return mode, nil, ""
+	}
+	endpoint := m.ResolvedEmbeddingEndpoint()
+	if endpoint == "" {
+		return mode, nil, ""
+	}
+	client, err := consolidation.NewHTTPLLMClient(endpoint, m.ResolvedEmbeddingAPIKeyEnv())
+	if err != nil {
+		return mode, nil, ""
+	}
+	return mode, client, m.Search.EmbeddingModel
+}
+
+func scoredToRows(s []cortex.ScoredRow) []cortex.Row {
+	rows := make([]cortex.Row, len(s))
+	for i := range s {
+		rows[i] = s[i].Row
+	}
+	return rows
+}
+
+func scoredToMatches(s []cortex.ScoredRow) []cortex.SimilarMatch {
+	out := make([]cortex.SimilarMatch, len(s))
+	for i := range s {
+		out[i] = cortex.SimilarMatch{Row: s[i].Row, Score: s[i].Score}
+	}
+	return out
+}
 
 // NewServer builds an MCP server exposing all Cortex operations. The
 // version string is plumbed through to the MCP protocol's serverInfo
@@ -189,45 +238,92 @@ func NewServer(cx *cortex.Cortex, noemaVersion string, federationMode string) *s
 		mcp.WithDescription("Full-text search across traces"),
 		mcp.WithString("query", mcp.Description("Search query"), mcp.Required()),
 		mcp.WithBoolean("all", mcp.Description("Include archived traces")),
+		mcp.WithString("mode", mcp.Description("Search mode: 'lexical' (FTS5, default), 'semantic' (embedding similarity), or 'hybrid'. Semantic/hybrid need a configured search: block; if unavailable, falls back to lexical.")),
 	), func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		query, err := req.RequireString("query")
 		if err != nil {
 			return nil, err
 		}
-		// Agent-initiated searches bump search_hit_count on the top-N
-		// results. Auto-injection providers (Hermes, etc.) consume search
-		// output without ever calling get_trace, so without this bump the
-		// graduation gate never sees signal from those reads. See
-		// internal/cortex/actor.go SearchAs for the rationale.
+		includeArchived := req.GetBool("all", false)
+		mode, emb, model := resolveSearchMode(cx, req.GetString("mode", ""))
+
+		// Semantic/hybrid path with graceful degradation to lexical: a
+		// missing config or an unreachable endpoint should still return
+		// useful (lexical) results with a note, never an error.
+		note := ""
+		if mode == cortex.SearchModeSemantic || mode == cortex.SearchModeHybrid {
+			if emb == nil {
+				note = "[semantic search not configured; showing lexical results]\n"
+			} else if res, serr := cx.SemanticSearchAs(ctx, emb, query, cortex.SemanticOpts{
+				Model:           model,
+				IncludeArchived: includeArchived,
+			}, cortex.ActorAgent, cortex.DefaultSearchHitTopN); serr != nil {
+				note = "[semantic search unavailable (" + serr.Error() + "); showing lexical results]\n"
+			} else {
+				out := formatRows(scoredToRows(res))
+				if mode == cortex.SearchModeHybrid {
+					out = "[hybrid fusion not yet available; showing semantic results]\n" + out
+				}
+				return mcp.NewToolResultText(out), nil
+			}
+		}
+
+		// Lexical (default or fallback). Agent-initiated searches bump
+		// search_hit_count on the top-N results — see actor.go SearchAs.
 		rows, err := cx.SearchAs(query, cortex.ListOptions{
-			All: req.GetBool("all", false),
+			All: includeArchived,
 		}, cortex.ActorAgent, cortex.DefaultSearchHitTopN)
 		if err != nil {
 			return nil, err
 		}
-		return mcp.NewToolResultText(formatRows(rows)), nil
+		return mcp.NewToolResultText(note + formatRows(rows)), nil
 	})
 
 	s.AddTool(mcp.NewTool("find_similar_traces",
-		mcp.WithDescription("Find traces with overlapping vocabulary to a given trace, ranked by FTS5 BM25. Useful when you have one trace and want to surface related ones without crafting a search query."),
+		mcp.WithDescription("Find traces related to a given trace. Default mode ranks by FTS5 BM25 vocabulary overlap; 'semantic' mode ranks by embedding similarity to the source trace's own vector (needs a configured search: block + backfilled embeddings). Useful when you have one trace and want related ones without crafting a query."),
 		mcp.WithString("trace_id", mcp.Description("ID of the source trace"), mcp.Required()),
 		mcp.WithNumber("limit", mcp.Description("Maximum matches to return (default 10)")),
 		mcp.WithBoolean("include_archived", mcp.Description("Include archived traces (default false)")),
+		mcp.WithString("mode", mcp.Description("'lexical' (FTS5, default) or 'semantic'/'hybrid' (embedding similarity). Falls back to lexical if semantic isn't configured or the source isn't embedded.")),
 	), func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		traceID, err := req.RequireString("trace_id")
 		if err != nil {
 			return nil, err
 		}
-		opts := cortex.SimilarOpts{
-			Limit:           int(req.GetFloat("limit", 0)),
-			IncludeArchived: req.GetBool("include_archived", false),
+		limit := int(req.GetFloat("limit", 0))
+		includeArchived := req.GetBool("include_archived", false)
+		// Semantic similarity uses the source's stored vector — no embedder
+		// needed — so we only require the configured model from the manifest.
+		mode, _, model := resolveSearchMode(cx, req.GetString("mode", ""))
+
+		note := ""
+		if mode == cortex.SearchModeSemantic || mode == cortex.SearchModeHybrid {
+			if model == "" {
+				note = "[semantic search not configured; showing lexical results]\n"
+			} else if res, serr := cx.SemanticSimilarAs(traceID, cortex.SemanticOpts{
+				Model:           model,
+				Limit:           limit,
+				IncludeArchived: includeArchived,
+			}, cortex.ActorAgent, cortex.DefaultSearchHitTopN); serr != nil {
+				note = "[semantic similar unavailable (" + serr.Error() + "); showing lexical results]\n"
+			} else {
+				out := formatSimilarMatches(scoredToMatches(res))
+				if mode == cortex.SearchModeHybrid {
+					out = "[hybrid fusion not yet available; showing semantic results]\n" + out
+				}
+				return mcp.NewToolResultText(out), nil
+			}
 		}
-		// Same actor-aware bump as search_traces; see SearchAs for why.
-		matches, err := cx.FindSimilarAs(traceID, opts, cortex.ActorAgent, cortex.DefaultSearchHitTopN)
+
+		// Lexical (default or fallback). Same actor-aware bump as search_traces.
+		matches, err := cx.FindSimilarAs(traceID, cortex.SimilarOpts{
+			Limit:           limit,
+			IncludeArchived: includeArchived,
+		}, cortex.ActorAgent, cortex.DefaultSearchHitTopN)
 		if err != nil {
 			return nil, err
 		}
-		return mcp.NewToolResultText(formatSimilarMatches(matches)), nil
+		return mcp.NewToolResultText(note + formatSimilarMatches(matches)), nil
 	})
 
 	s.AddTool(mcp.NewTool("delete_trace",
@@ -986,10 +1082,13 @@ Choose the type that best reflects the intent of the memory:
   append_trace id content        → append content to an existing trace's body
                                    without reading the full trace first; ideal
                                    for running logs and fire-and-forget writes
-  search_traces query [all]      → FTS5 full-text search
-  find_similar_traces trace_id [limit] [include_archived]
-                                 → traces with overlapping vocabulary,
-                                   ranked by BM25 (lower score = closer
+  search_traces query [all] [mode]
+                                 → full-text (lexical, default) or embedding
+                                   (mode=semantic) search; semantic needs a
+                                   configured search: block, else falls back
+  find_similar_traces trace_id [limit] [include_archived] [mode]
+                                 → related traces by BM25 vocabulary overlap,
+                                   or mode=semantic for embedding similarity
                                    match). Useful when you have one
                                    trace in hand and want to surface
                                    related ones without crafting a query


### PR DESCRIPTION
Phase 3b: semantic search reachable by **agents** via MCP. Builds on #120.

- **`mode` arg** on `search_traces` and `find_similar_traces`: `lexical` (FTS5, default), `semantic` (embedding cosine), `hybrid`.
- **`resolveSearchMode`** picks the effective mode (caller arg → `search.default_mode` → lexical) and builds the embedder from the manifest (endpoint/key inherited from `consolidation`). `find_similar` semantic uses the source's stored vector (no embedder call).
- **Graceful degradation**: unconfigured semantic, an unreachable endpoint, or an un-embedded source → lexical results with a bracketed `[...]` note, never an error. The agent always gets usable output.
- **hybrid** returns semantic results with a note for now (true RRF fusion is phase 4). `get_instructions` updated.

### Tests
`resolveSearchMode` (default/unconfigured/configured); semantic→lexical fallback note; **end-to-end semantic `search_traces` and `find_similar_traces` via an httptest `/embeddings` server** using the real `consolidation.HTTPLLMClient` (asserts ranking + source exclusion). Full build + vet + test + `-race` green.

After this, there's a real agent-facing surface to exercise — worth redeploying to testbot and running a semantic MCP playbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)