### PR TITLE
feat(search): semantic-search phase 4 — hybrid RRF fusion

### DIFF
--- a/internal/cli/cmd_search.go
+++ b/internal/cli/cmd_search.go
@@ -15,6 +15,7 @@ func searchCmd() *cobra.Command {
 		trashed  bool
 		all      bool
 		semantic bool
+		hybrid   bool
 		typ      string
 	)
 
@@ -29,8 +30,8 @@ func searchCmd() *cobra.Command {
 			}
 			defer cx.Close()
 
-			if semantic {
-				return runSemanticSearch(cmd, cx, args[0], all || archived)
+			if semantic || hybrid {
+				return runVectorSearch(cmd, cx, args[0], all || archived, hybrid)
 			}
 
 			rows, err := cx.Search(args[0], cortex.ListOptions{
@@ -54,15 +55,17 @@ func searchCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&archived, "archived", false, "search only archived traces")
 	cmd.Flags().BoolVar(&trashed, "trashed", false, "search only trashed traces")
 	cmd.Flags().BoolVar(&all, "all", false, "search active and archived traces")
-	cmd.Flags().BoolVar(&semantic, "semantic", false, "rank by embedding similarity (needs a configured search: block + `noema embeddings backfill`)")
+	cmd.Flags().BoolVar(&semantic, "semantic", false, "rank by embedding similarity (needs a configured search: block + backfilled embeddings)")
+	cmd.Flags().BoolVar(&hybrid, "hybrid", false, "fuse lexical (FTS5) + semantic rankings via reciprocal rank fusion")
 	cmd.Flags().StringVar(&typ, "type", "", "filter results by type")
 	return cmd
 }
 
-// runSemanticSearch builds the embedder from the cortex manifest and ranks
-// traces by embedding similarity. Kept separate so the lexical path stays
+// runVectorSearch builds the embedder from the cortex manifest and ranks
+// traces by embedding similarity (hybrid=false) or by RRF fusion of lexical
+// + semantic (hybrid=true). Kept separate so the lexical path stays
 // untouched. The embedder reuses the consolidation endpoint config.
-func runSemanticSearch(cmd *cobra.Command, cx *cortex.Cortex, query string, includeArchived bool) error {
+func runVectorSearch(cmd *cobra.Command, cx *cortex.Cortex, query string, includeArchived, hybrid bool) error {
 	m, err := cortex.ReadManifest(cx.Dir)
 	if err != nil {
 		return err
@@ -78,12 +81,15 @@ func runSemanticSearch(cmd *cobra.Command, cx *cortex.Cortex, query string, incl
 	if err != nil {
 		return fmt.Errorf("embedding client: %w", err)
 	}
-	res, err := cx.SemanticSearch(cmd.Context(), client, query, cortex.SemanticOpts{
-		Model:           m.Search.EmbeddingModel,
-		IncludeArchived: includeArchived,
-	})
+	opts := cortex.SemanticOpts{Model: m.Search.EmbeddingModel, IncludeArchived: includeArchived}
+	var res []cortex.ScoredRow
+	if hybrid {
+		res, err = cx.HybridSearch(cmd.Context(), client, query, opts, m.Search.EffectiveHybridWeight())
+	} else {
+		res, err = cx.SemanticSearch(cmd.Context(), client, query, opts)
+	}
 	if err != nil {
-		return fmt.Errorf("semantic search failed: %w", err)
+		return fmt.Errorf("vector search failed: %w", err)
 	}
 	if len(res) == 0 {
 		fmt.Println("No matching traces.")

--- a/internal/cli/cmd_similar.go
+++ b/internal/cli/cmd_similar.go
@@ -16,6 +16,7 @@ func similarCmd() *cobra.Command {
 		limit    int
 		archived bool
 		semantic bool
+		hybrid   bool
 	)
 
 	cmd := &cobra.Command{
@@ -33,7 +34,7 @@ func similarCmd() *cobra.Command {
 			}
 			defer cx.Close()
 
-			if semantic {
+			if semantic || hybrid {
 				m, err := cortex.ReadManifest(cx.Dir)
 				if err != nil {
 					return err
@@ -41,13 +42,15 @@ func similarCmd() *cobra.Command {
 				if m.Search == nil || m.Search.EmbeddingModel == "" {
 					return fmt.Errorf("semantic mode needs search.embedding_model in cortex.md (then: noema embeddings backfill)")
 				}
-				res, err := cx.SemanticSimilar(args[0], cortex.SemanticOpts{
-					Model:           m.Search.EmbeddingModel,
-					Limit:           limit,
-					IncludeArchived: archived,
-				})
+				opts := cortex.SemanticOpts{Model: m.Search.EmbeddingModel, Limit: limit, IncludeArchived: archived}
+				var res []cortex.ScoredRow
+				if hybrid {
+					res, err = cx.HybridSimilar(args[0], opts, m.Search.EffectiveHybridWeight())
+				} else {
+					res, err = cx.SemanticSimilar(args[0], opts)
+				}
 				if err != nil {
-					return fmt.Errorf("semantic similar: %w", err)
+					return fmt.Errorf("vector similar: %w", err)
 				}
 				if len(res) == 0 {
 					fmt.Println("No similar traces found.")
@@ -80,6 +83,7 @@ func similarCmd() *cobra.Command {
 	cmd.Flags().IntVar(&limit, "limit", 10, "maximum matches to return")
 	cmd.Flags().BoolVar(&archived, "archived", false, "include archived traces in results")
 	cmd.Flags().BoolVar(&semantic, "semantic", false, "rank by embedding similarity instead of FTS5 (needs backfilled embeddings)")
+	cmd.Flags().BoolVar(&hybrid, "hybrid", false, "fuse lexical + semantic similarity via reciprocal rank fusion")
 	return cmd
 }
 

--- a/internal/cortex/actor.go
+++ b/internal/cortex/actor.go
@@ -162,6 +162,30 @@ func (c *Cortex) SemanticSimilarAs(traceID string, opts SemanticOpts, actor Read
 	return res, nil
 }
 
+// HybridSearchAs is the actor-aware counterpart to HybridSearch.
+func (c *Cortex) HybridSearchAs(ctx context.Context, e Embedder, query string, opts SemanticOpts, weight float64, actor ReadActor, topN int) ([]ScoredRow, error) {
+	res, err := c.HybridSearch(ctx, e, query, opts, weight)
+	if err != nil {
+		return nil, err
+	}
+	if actor == ActorAgent && len(res) > 0 {
+		c.bumpSearchHitsForScored(res, topN)
+	}
+	return res, nil
+}
+
+// HybridSimilarAs is the actor-aware counterpart to HybridSimilar.
+func (c *Cortex) HybridSimilarAs(traceID string, opts SemanticOpts, weight float64, actor ReadActor, topN int) ([]ScoredRow, error) {
+	res, err := c.HybridSimilar(traceID, opts, weight)
+	if err != nil {
+		return nil, err
+	}
+	if actor == ActorAgent && len(res) > 0 {
+		c.bumpSearchHitsForScored(res, topN)
+	}
+	return res, nil
+}
+
 // bumpSearchHitsForScored adapts []ScoredRow to the shared bump path.
 func (c *Cortex) bumpSearchHitsForScored(res []ScoredRow, topN int) {
 	ids := make([]string, 0, len(res))

--- a/internal/cortex/semantic.go
+++ b/internal/cortex/semantic.go
@@ -10,47 +10,41 @@ import (
 	"strings"
 )
 
-// ScoredRow is one semantic-search result: a trace row plus its cosine
-// similarity to the query (higher is closer; vectors are unit-normalized
-// so cosine equals the dot product).
+// ScoredRow is one ranked result: a trace row plus a score. For semantic
+// search the score is cosine similarity (higher is closer); for hybrid it
+// is the fused reciprocal-rank score (also higher-is-better, but on a
+// different scale — treat it as opaque ordering).
 type ScoredRow struct {
 	Row
 	Score float64
 }
 
-// SemanticOpts tunes a semantic query.
+// SemanticOpts tunes a semantic or hybrid query.
 type SemanticOpts struct {
 	Model           string // embedding model whose vectors to search
 	Limit           int    // max results (default 10)
 	IncludeArchived bool   // include archived traces (default false)
 }
 
-// SemanticSearch embeds the query string with e and ranks the cortex's
-// stored vectors (for opts.Model) by cosine similarity. Trashed traces are
-// always excluded; archived traces are excluded unless opts.IncludeArchived.
-// An empty query returns no results. The caller supplies the embedder so
-// the cortex package stays free of an import cycle.
-func (c *Cortex) SemanticSearch(ctx context.Context, e Embedder, query string, opts SemanticOpts) ([]ScoredRow, error) {
-	if e == nil {
-		return nil, errors.New("embedder is nil")
-	}
-	if opts.Model == "" {
-		return nil, errors.New("embedding model is empty")
-	}
-	q := strings.TrimSpace(query)
-	if q == "" {
-		return nil, nil
-	}
-	vecs, err := e.Embed(ctx, opts.Model, []string{q})
-	if err != nil {
-		return nil, fmt.Errorf("embedding query: %w", err)
-	}
-	if len(vecs) != 1 || len(vecs[0]) == 0 {
-		return nil, errors.New("embedder returned no query vector")
-	}
-	qv := vecs[0]
-	normalizeEmbedding(qv)
+// rrfK is the Reciprocal Rank Fusion constant. 60 is the value from the
+// original RRF paper and the de-facto default; it damps the contribution
+// of low-ranked items without a tuning knob.
+const rrfK = 60.0
 
+// hybridLexicalPool bounds how many lexical (FindSimilar) candidates feed
+// hybrid similarity fusion. Semantic contributes all embedded candidates;
+// the lexical BM25 side is naturally top-k, so we request a generous pool.
+const hybridLexicalPool = 50
+
+// SemanticSearch embeds the query with e and ranks the cortex's stored
+// vectors (for opts.Model) by cosine similarity. Trashed traces are always
+// excluded; archived traces are excluded unless opts.IncludeArchived. An
+// empty query returns no results.
+func (c *Cortex) SemanticSearch(ctx context.Context, e Embedder, query string, opts SemanticOpts) ([]ScoredRow, error) {
+	qv, err := c.embedQuery(ctx, e, opts.Model, query)
+	if err != nil || qv == nil {
+		return nil, err
+	}
 	cands, err := c.loadEmbeddedCandidates(opts.Model, opts.IncludeArchived, "")
 	if err != nil {
 		return nil, err
@@ -59,34 +53,111 @@ func (c *Cortex) SemanticSearch(ctx context.Context, e Embedder, query string, o
 }
 
 // SemanticSimilar ranks other traces against the stored vector of traceID
-// (no query embedding needed — it reuses the source trace's own vector, a
-// strictly better signal than the lexical FindSimilar's top-term proxy).
-// The source trace must already be embedded for opts.Model.
+// (no query embedding — it reuses the source trace's own vector). The
+// source trace must already be embedded for opts.Model.
 func (c *Cortex) SemanticSimilar(traceID string, opts SemanticOpts) ([]ScoredRow, error) {
-	if opts.Model == "" {
-		return nil, errors.New("embedding model is empty")
-	}
-	var blob []byte
-	err := c.DB.QueryRow(
-		`SELECT embedding FROM trace_embeddings WHERE trace_id = ? AND embedding_model = ?`,
-		traceID, opts.Model,
-	).Scan(&blob)
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, fmt.Errorf("trace %s has no %s embedding yet (run: noema embeddings backfill)", traceID, opts.Model)
-	}
+	qv, err := c.sourceVector(traceID, opts.Model)
 	if err != nil {
-		return nil, fmt.Errorf("loading source vector: %w", err)
+		return nil, err
 	}
-	qv, err := decodeEmbedding(blob)
-	if err != nil {
-		return nil, fmt.Errorf("decoding source vector: %w", err)
-	}
-	// Stored vectors are already normalized; no need to re-normalize.
 	cands, err := c.loadEmbeddedCandidates(opts.Model, opts.IncludeArchived, traceID)
 	if err != nil {
 		return nil, err
 	}
 	return topKCosine(qv, cands, effLimit(opts.Limit)), nil
+}
+
+// HybridSearch fuses lexical (FTS5 BM25) and semantic (embedding cosine)
+// rankings of the query via Reciprocal Rank Fusion, weighted by weight
+// (0 = pure lexical, 1 = pure semantic; clamped). Both rankers contribute
+// their full ranked lists; the fused top opts.Limit is returned.
+func (c *Cortex) HybridSearch(ctx context.Context, e Embedder, query string, opts SemanticOpts, weight float64) ([]ScoredRow, error) {
+	qv, err := c.embedQuery(ctx, e, opts.Model, query)
+	if err != nil || qv == nil {
+		return nil, err
+	}
+	cands, err := c.loadEmbeddedCandidates(opts.Model, opts.IncludeArchived, "")
+	if err != nil {
+		return nil, err
+	}
+	sem := topKCosine(qv, cands, 0)
+	lex, err := c.lexicalRanked(query, opts.IncludeArchived)
+	if err != nil {
+		return nil, err
+	}
+	return rrfFuse(lex, sem, weight, effLimit(opts.Limit)), nil
+}
+
+// HybridSimilar fuses lexical FindSimilar and SemanticSimilar rankings for
+// a source trace. Like HybridSearch, weight blends the two (0 = lexical,
+// 1 = semantic).
+func (c *Cortex) HybridSimilar(traceID string, opts SemanticOpts, weight float64) ([]ScoredRow, error) {
+	qv, err := c.sourceVector(traceID, opts.Model)
+	if err != nil {
+		return nil, err
+	}
+	cands, err := c.loadEmbeddedCandidates(opts.Model, opts.IncludeArchived, traceID)
+	if err != nil {
+		return nil, err
+	}
+	sem := topKCosine(qv, cands, 0)
+	lexMatches, err := c.FindSimilar(traceID, SimilarOpts{Limit: hybridLexicalPool, IncludeArchived: opts.IncludeArchived})
+	if err != nil {
+		return nil, err
+	}
+	lex := make([]Row, len(lexMatches))
+	for i := range lexMatches {
+		lex[i] = lexMatches[i].Row
+	}
+	return rrfFuse(lex, sem, weight, effLimit(opts.Limit)), nil
+}
+
+// embedQuery embeds and unit-normalizes a single query string. Returns
+// (nil, nil) for a blank query so callers can short-circuit to empty
+// results. The embedder/model guards live here so every query path shares
+// them.
+func (c *Cortex) embedQuery(ctx context.Context, e Embedder, model, query string) ([]float32, error) {
+	if e == nil {
+		return nil, errors.New("embedder is nil")
+	}
+	if model == "" {
+		return nil, errors.New("embedding model is empty")
+	}
+	q := strings.TrimSpace(query)
+	if q == "" {
+		return nil, nil
+	}
+	vecs, err := e.Embed(ctx, model, []string{q})
+	if err != nil {
+		return nil, fmt.Errorf("embedding query: %w", err)
+	}
+	if len(vecs) != 1 || len(vecs[0]) == 0 {
+		return nil, errors.New("embedder returned no query vector")
+	}
+	qv := vecs[0]
+	normalizeEmbedding(qv)
+	return qv, nil
+}
+
+// sourceVector loads and decodes the stored embedding for traceID under
+// model (already normalized at store time). Returns a clear error if the
+// trace isn't embedded yet.
+func (c *Cortex) sourceVector(traceID, model string) ([]float32, error) {
+	if model == "" {
+		return nil, errors.New("embedding model is empty")
+	}
+	var blob []byte
+	err := c.DB.QueryRow(
+		`SELECT embedding FROM trace_embeddings WHERE trace_id = ? AND embedding_model = ?`,
+		traceID, model,
+	).Scan(&blob)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("trace %s has no %s embedding yet (run: noema embeddings backfill)", traceID, model)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("loading source vector: %w", err)
+	}
+	return decodeEmbedding(blob)
 }
 
 func effLimit(l int) int {
@@ -103,9 +174,8 @@ type vectorCand struct {
 }
 
 // topKCosine ranks candidates by dot product against query (== cosine for
-// unit vectors), descending, and returns the top limit. Candidates whose
-// dimension differs from the query (e.g. a stale row from another model
-// that slipped through) are skipped rather than mis-scored.
+// unit vectors), descending, and returns the top limit (0 = all).
+// Candidates whose dimension differs from the query are skipped.
 func topKCosine(query []float32, cands []vectorCand, limit int) []ScoredRow {
 	out := make([]ScoredRow, 0, len(cands))
 	for _, c := range cands {
@@ -125,12 +195,88 @@ func topKCosine(query []float32, cands []vectorCand, limit int) []ScoredRow {
 	return out
 }
 
+// rrfFuse combines a lexical ranking (Rows in relevance order) and a
+// semantic ranking (ScoredRows in cosine order) by Reciprocal Rank Fusion:
+// each item gets sum over rankers of w_r / (rrfK + rank), with rank 1-based
+// and w split by weight (semantic) vs 1-weight (lexical). Items appearing
+// in both rankers accumulate from both. Ties break on ID for deterministic
+// output regardless of map/scan order. Returns the fused top limit.
+func rrfFuse(lex []Row, sem []ScoredRow, weight float64, limit int) []ScoredRow {
+	if weight < 0 {
+		weight = 0
+	}
+	if weight > 1 {
+		weight = 1
+	}
+	pos := make(map[string]int, len(lex)+len(sem))
+	var out []ScoredRow
+	add := func(r Row, contrib float64) {
+		if p, ok := pos[r.ID]; ok {
+			out[p].Score += contrib
+			return
+		}
+		pos[r.ID] = len(out)
+		out = append(out, ScoredRow{Row: r, Score: contrib})
+	}
+	for i, r := range lex {
+		add(r, (1-weight)/(rrfK+float64(i+1)))
+	}
+	for i, s := range sem {
+		add(s.Row, weight/(rrfK+float64(i+1)))
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Score != out[j].Score {
+			return out[i].Score > out[j].Score
+		}
+		return out[i].ID < out[j].ID
+	})
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}
+
+// lexicalRanked runs the query through FTS5 and returns matching rows in
+// BM25 relevance order (best first) — the lexical input to hybrid fusion.
+// Trashed excluded; archived excluded unless includeArchived.
+func (c *Cortex) lexicalRanked(query string, includeArchived bool) ([]Row, error) {
+	ftsQuery := SanitizeFTS5Query(query)
+	if strings.TrimSpace(ftsQuery) == "" {
+		return nil, nil
+	}
+	q := `SELECT t.id, t.title, t.type, t.tier, t.author, t.origin,
+	             t.archived_at, t.trashed_at, t.created_at, t.updated_at,
+	             t.content_hash, t.source_locked, t.source_hash
+	      FROM traces t
+	      JOIN traces_fts ON traces_fts.id = t.id
+	      WHERE traces_fts MATCH ? AND t.trashed_at IS NULL`
+	if !includeArchived {
+		q += ` AND t.archived_at IS NULL`
+	}
+	q += ` ORDER BY bm25(traces_fts)`
+
+	rows, err := c.DB.Query(q, ftsQuery)
+	if err != nil {
+		return nil, fmt.Errorf("lexical ranking query: %w", err)
+	}
+	defer rows.Close()
+	var out []Row
+	for rows.Next() {
+		r, err := scanRowWithNullable(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
 // loadEmbeddedCandidates returns every embedded, ranking-eligible trace for
 // model: non-trashed (archived excluded unless includeArchived), optionally
 // excluding excludeID (the source trace in a similarity query). Vectors
 // containing non-finite values (a corrupted BLOB) are skipped so they can't
-// poison ranking — the finiteness check the Phase-1 review flagged, applied
-// here at the consumer where stored vectors are actually read.
+// poison ranking — the finiteness check applied at the consumer where
+// stored vectors are read.
 func (c *Cortex) loadEmbeddedCandidates(model string, includeArchived bool, excludeID string) ([]vectorCand, error) {
 	q := `SELECT t.id, t.title, t.type, t.tier, t.author, t.origin,
 	             t.archived_at, t.trashed_at, t.created_at, t.updated_at,
@@ -167,30 +313,47 @@ func (c *Cortex) loadEmbeddedCandidates(model string, includeArchived bool, excl
 		); err != nil {
 			return nil, err
 		}
-		if archivedAt != nil {
-			r.ArchivedAt = *archivedAt
-		}
-		if trashedAt != nil {
-			r.TrashedAt = *trashedAt
-		}
-		if contentHash != nil {
-			r.ContentHash = *contentHash
-		}
-		if sourceHash != nil {
-			r.SourceHash = *sourceHash
-		}
-		r.SourceLocked = sourceLocked != 0
-
+		applyNullable(&r, archivedAt, trashedAt, contentHash, sourceHash, sourceLocked)
 		vec, err := decodeEmbedding(blob)
 		if err != nil || !allFinite(vec) {
 			continue // skip corrupted/non-finite vectors
 		}
 		out = append(out, vectorCand{row: r, vec: vec})
 	}
-	if err := rows.Err(); err != nil {
-		return nil, err
+	return out, rows.Err()
+}
+
+// scanRowWithNullable scans the standard 13-column trace projection (no
+// embedding) into a Row, handling the nullable columns.
+func scanRowWithNullable(rows *sql.Rows) (Row, error) {
+	var r Row
+	var archivedAt, trashedAt, contentHash, sourceHash *string
+	var sourceLocked int
+	if err := rows.Scan(
+		&r.ID, &r.Title, &r.Type, &r.Tier, &r.Author, &r.Origin,
+		&archivedAt, &trashedAt, &r.CreatedAt, &r.UpdatedAt,
+		&contentHash, &sourceLocked, &sourceHash,
+	); err != nil {
+		return r, err
 	}
-	return out, nil
+	applyNullable(&r, archivedAt, trashedAt, contentHash, sourceHash, sourceLocked)
+	return r, nil
+}
+
+func applyNullable(r *Row, archivedAt, trashedAt, contentHash, sourceHash *string, sourceLocked int) {
+	if archivedAt != nil {
+		r.ArchivedAt = *archivedAt
+	}
+	if trashedAt != nil {
+		r.TrashedAt = *trashedAt
+	}
+	if contentHash != nil {
+		r.ContentHash = *contentHash
+	}
+	if sourceHash != nil {
+		r.SourceHash = *sourceHash
+	}
+	r.SourceLocked = sourceLocked != 0
 }
 
 // allFinite reports whether every element of v is a finite number.

--- a/internal/cortex/semantic_internal_test.go
+++ b/internal/cortex/semantic_internal_test.go
@@ -27,6 +27,39 @@ func TestTopKCosine(t *testing.T) {
 	}
 }
 
+func TestRRFFuse(t *testing.T) {
+	lex := []Row{{ID: "a"}, {ID: "b"}, {ID: "c"}}                                     // lexical order a,b,c
+	sem := []ScoredRow{{Row: Row{ID: "c"}}, {Row: Row{ID: "d"}}, {Row: Row{ID: "a"}}} // semantic order c,d,a
+	ids := func(rs []ScoredRow) []string {
+		out := make([]string, len(rs))
+		for i := range rs {
+			out[i] = rs[i].ID
+		}
+		return out
+	}
+
+	// weight 0 => pure lexical order (items only in semantic get score 0, sink).
+	if got := ids(rrfFuse(lex, sem, 0, 0)); got[0] != "a" || got[1] != "b" || got[2] != "c" {
+		t.Errorf("weight 0 top3 = %v, want [a b c]", got[:3])
+	}
+	// weight 1 => pure semantic order.
+	if got := ids(rrfFuse(lex, sem, 1, 0)); got[0] != "c" || got[1] != "d" || got[2] != "a" {
+		t.Errorf("weight 1 top3 = %v, want [c d a]", got[:3])
+	}
+	// weight .5 => a & c tie (symmetric), b & d tie; ID breaks ties.
+	if got := ids(rrfFuse(lex, sem, 0.5, 0)); got[0] != "a" || got[1] != "c" || got[2] != "b" || got[3] != "d" {
+		t.Errorf("weight .5 = %v, want [a c b d]", got)
+	}
+	// limit truncates.
+	if l := rrfFuse(lex, sem, 0.5, 2); len(l) != 2 {
+		t.Errorf("limit 2 returned %d", len(l))
+	}
+	// weight > 1 clamps to 1 (same as semantic order).
+	if got := ids(rrfFuse(lex, sem, 5, 0)); got[0] != "c" {
+		t.Errorf("weight 5 should clamp to 1; top = %s, want c", got[0])
+	}
+}
+
 func TestAllFinite(t *testing.T) {
 	if !allFinite([]float32{1, -2, 0.5}) {
 		t.Error("finite vector reported non-finite")

--- a/internal/cortex/semantic_test.go
+++ b/internal/cortex/semantic_test.go
@@ -140,6 +140,49 @@ func TestSemanticSearch_SkipsNonFiniteVectors(t *testing.T) {
 	}
 }
 
+func TestHybridSearch_FusesAndRanks(t *testing.T) {
+	cx, ids := setupSemantic(t)
+	ctx := context.Background()
+
+	// "alpha" matches the alpha trace both lexically (title token) and
+	// semantically (topic vector), so it must rank first; semantic
+	// contributes the other topics, so all 3 appear.
+	res, err := cx.HybridSearch(ctx, topicEmbedder{}, "alpha alpha", cortex.SemanticOpts{Model: "tm"}, 0.5)
+	if err != nil {
+		t.Fatalf("HybridSearch: %v", err)
+	}
+	if len(res) != 3 {
+		t.Fatalf("got %d fused results, want 3", len(res))
+	}
+	if res[0].ID != ids[0] {
+		t.Errorf("top fused result = %s, want alpha trace %s", res[0].ID, ids[0])
+	}
+
+	// Blank query short-circuits; nil embedder errors.
+	if r, err := cx.HybridSearch(ctx, topicEmbedder{}, "  ", cortex.SemanticOpts{Model: "tm"}, 0.5); err != nil || r != nil {
+		t.Errorf("blank query => (nil,nil); got (%v,%v)", r, err)
+	}
+	if _, err := cx.HybridSearch(ctx, nil, "x", cortex.SemanticOpts{Model: "tm"}, 0.5); err == nil {
+		t.Error("nil embedder should error")
+	}
+}
+
+func TestHybridSimilar_ExcludesSource(t *testing.T) {
+	cx, ids := setupSemantic(t)
+	res, err := cx.HybridSimilar(ids[0], cortex.SemanticOpts{Model: "tm"}, 0.5)
+	if err != nil {
+		t.Fatalf("HybridSimilar: %v", err)
+	}
+	for _, r := range res {
+		if r.ID == ids[0] {
+			t.Error("source trace must be excluded from its own hybrid similarity")
+		}
+	}
+	if len(res) == 0 {
+		t.Error("expected fused similar results")
+	}
+}
+
 func TestSemanticSearch_Guards(t *testing.T) {
 	cx := setup(t)
 	ctx := context.Background()

--- a/internal/mcp/semantic_test.go
+++ b/internal/mcp/semantic_test.go
@@ -74,18 +74,21 @@ func TestResolveSearchMode(t *testing.T) {
 	cx := newTestCortex(t)
 
 	// Unconfigured: default is lexical; explicit semantic yields no embedder.
-	if mode, e, _ := resolveSearchMode(cx, ""); mode != cortex.SearchModeLexical || e != nil {
+	if mode, e, _, _ := resolveSearchMode(cx, ""); mode != cortex.SearchModeLexical || e != nil {
 		t.Errorf("unconfigured default = (%s, embedder!=nil:%v), want lexical/nil", mode, e != nil)
 	}
-	if mode, e, _ := resolveSearchMode(cx, "semantic"); mode != cortex.SearchModeSemantic || e != nil {
+	if mode, e, _, _ := resolveSearchMode(cx, "semantic"); mode != cortex.SearchModeSemantic || e != nil {
 		t.Errorf("semantic-unconfigured = (%s, embedder!=nil:%v), want semantic/nil-embedder", mode, e != nil)
 	}
 
-	// Configured: semantic yields an embedder + model.
+	// Configured: semantic yields an embedder + model + default weight.
 	writeSearchConfig(t, cx, "http://localhost:1", "tm")
-	mode, e, model := resolveSearchMode(cx, "semantic")
+	mode, e, model, weight := resolveSearchMode(cx, "semantic")
 	if mode != cortex.SearchModeSemantic || e == nil || model != "tm" {
 		t.Errorf("configured semantic = (%s, embedder!=nil:%v, model=%q), want semantic/embedder/tm", mode, e != nil, model)
+	}
+	if weight != 0.5 {
+		t.Errorf("default hybrid weight = %v, want 0.5", weight)
 	}
 }
 
@@ -152,6 +155,41 @@ func TestSearchTraces_SemanticEndToEnd(t *testing.T) {
 	}
 	if gi >= 0 && ai > gi {
 		t.Errorf("alpha (%d) should rank before gamma (%d) for an alpha query:\n%s", ai, gi, text)
+	}
+}
+
+func TestSearchTraces_HybridEndToEnd(t *testing.T) {
+	server := topicEmbedServer(t)
+	defer server.Close()
+
+	cx := newTestCortex(t)
+	writeSearchConfig(t, cx, server.URL, "tm")
+	add := func(title, body string) string {
+		tr := trace.New(title, "note", "agent", nil, body)
+		if err := cx.Add(tr); err != nil {
+			t.Fatalf("Add: %v", err)
+		}
+		return tr.ID
+	}
+	alphaID := add("alpha topic", "alpha alpha content")
+	add("beta topic", "beta beta content")
+
+	client, _ := consolidation.NewHTTPLLMClient(server.URL, "")
+	if _, err := cx.EmbedBackfill(context.Background(), client, "tm", cortex.EmbedBackfillOpts{}); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+
+	s := NewServer(cx, "test", "")
+	text, isErr := callTool(t, s, "search_traces", map[string]any{"query": "alpha alpha", "mode": "hybrid"})
+	if isErr {
+		t.Fatalf("search_traces hybrid errored: %s", text)
+	}
+	// Real RRF fusion now — no "not yet available" or fallback note.
+	if strings.Contains(text, "not yet") || strings.Contains(text, "unavailable") || strings.Contains(text, "not configured") {
+		t.Fatalf("unexpected note in hybrid result:\n%s", text)
+	}
+	if !strings.Contains(text, alphaID) {
+		t.Errorf("alpha trace %s missing from hybrid results:\n%s", alphaID, text)
 	}
 }
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -20,34 +20,35 @@ import (
 
 // resolveSearchMode determines the effective search mode for a request and,
 // for semantic/hybrid modes, builds the embedder from the cortex manifest.
-// It returns (mode, embedder, model): the embedder is nil when semantic
-// search isn't configured (no model/endpoint) so callers degrade to lexical.
-// reqMode is the caller-supplied "mode" arg ("" means use the manifest
-// default, which is lexical unless configured otherwise).
-func resolveSearchMode(cx *cortex.Cortex, reqMode string) (string, cortex.Embedder, string) {
+// It returns (mode, embedder, model, hybridWeight): the embedder is nil when
+// semantic search isn't configured (no model/endpoint) so callers degrade to
+// lexical. reqMode is the caller-supplied "mode" arg ("" means use the
+// manifest default, which is lexical unless configured otherwise).
+func resolveSearchMode(cx *cortex.Cortex, reqMode string) (string, cortex.Embedder, string, float64) {
 	m, err := cortex.ReadManifest(cx.Dir)
 	if err != nil {
-		return cortex.SearchModeLexical, nil, ""
+		return cortex.SearchModeLexical, nil, "", 0
 	}
+	weight := m.Search.EffectiveHybridWeight()
 	mode := reqMode
 	if mode == "" {
 		mode = m.Search.EffectiveDefaultMode()
 	}
 	if mode == cortex.SearchModeLexical {
-		return cortex.SearchModeLexical, nil, ""
+		return cortex.SearchModeLexical, nil, "", weight
 	}
 	if m.Search == nil || m.Search.EmbeddingModel == "" {
-		return mode, nil, ""
+		return mode, nil, "", weight
 	}
 	endpoint := m.ResolvedEmbeddingEndpoint()
 	if endpoint == "" {
-		return mode, nil, ""
+		return mode, nil, "", weight
 	}
 	client, err := consolidation.NewHTTPLLMClient(endpoint, m.ResolvedEmbeddingAPIKeyEnv())
 	if err != nil {
-		return mode, nil, ""
+		return mode, nil, "", weight
 	}
-	return mode, client, m.Search.EmbeddingModel
+	return mode, client, m.Search.EmbeddingModel, weight
 }
 
 func scoredToRows(s []cortex.ScoredRow) []cortex.Row {
@@ -245,7 +246,7 @@ func NewServer(cx *cortex.Cortex, noemaVersion string, federationMode string) *s
 			return nil, err
 		}
 		includeArchived := req.GetBool("all", false)
-		mode, emb, model := resolveSearchMode(cx, req.GetString("mode", ""))
+		mode, emb, model, weight := resolveSearchMode(cx, req.GetString("mode", ""))
 
 		// Semantic/hybrid path with graceful degradation to lexical: a
 		// missing config or an unreachable endpoint should still return
@@ -254,17 +255,20 @@ func NewServer(cx *cortex.Cortex, noemaVersion string, federationMode string) *s
 		if mode == cortex.SearchModeSemantic || mode == cortex.SearchModeHybrid {
 			if emb == nil {
 				note = "[semantic search not configured; showing lexical results]\n"
-			} else if res, serr := cx.SemanticSearchAs(ctx, emb, query, cortex.SemanticOpts{
-				Model:           model,
-				IncludeArchived: includeArchived,
-			}, cortex.ActorAgent, cortex.DefaultSearchHitTopN); serr != nil {
-				note = "[semantic search unavailable (" + serr.Error() + "); showing lexical results]\n"
 			} else {
-				out := formatRows(scoredToRows(res))
+				opts := cortex.SemanticOpts{Model: model, IncludeArchived: includeArchived}
+				var res []cortex.ScoredRow
+				var serr error
 				if mode == cortex.SearchModeHybrid {
-					out = "[hybrid fusion not yet available; showing semantic results]\n" + out
+					res, serr = cx.HybridSearchAs(ctx, emb, query, opts, weight, cortex.ActorAgent, cortex.DefaultSearchHitTopN)
+				} else {
+					res, serr = cx.SemanticSearchAs(ctx, emb, query, opts, cortex.ActorAgent, cortex.DefaultSearchHitTopN)
 				}
-				return mcp.NewToolResultText(out), nil
+				if serr != nil {
+					note = "[" + mode + " search unavailable (" + serr.Error() + "); showing lexical results]\n"
+				} else {
+					return mcp.NewToolResultText(formatRows(scoredToRows(res))), nil
+				}
 			}
 		}
 
@@ -292,26 +296,29 @@ func NewServer(cx *cortex.Cortex, noemaVersion string, federationMode string) *s
 		}
 		limit := int(req.GetFloat("limit", 0))
 		includeArchived := req.GetBool("include_archived", false)
-		// Semantic similarity uses the source's stored vector — no embedder
-		// needed — so we only require the configured model from the manifest.
-		mode, _, model := resolveSearchMode(cx, req.GetString("mode", ""))
+		// Similarity uses the source's stored vector (semantic) and/or
+		// FindSimilar (lexical) — no query embedder needed — so we only
+		// require the configured model from the manifest.
+		mode, _, model, weight := resolveSearchMode(cx, req.GetString("mode", ""))
 
 		note := ""
 		if mode == cortex.SearchModeSemantic || mode == cortex.SearchModeHybrid {
 			if model == "" {
 				note = "[semantic search not configured; showing lexical results]\n"
-			} else if res, serr := cx.SemanticSimilarAs(traceID, cortex.SemanticOpts{
-				Model:           model,
-				Limit:           limit,
-				IncludeArchived: includeArchived,
-			}, cortex.ActorAgent, cortex.DefaultSearchHitTopN); serr != nil {
-				note = "[semantic similar unavailable (" + serr.Error() + "); showing lexical results]\n"
 			} else {
-				out := formatSimilarMatches(scoredToMatches(res))
+				opts := cortex.SemanticOpts{Model: model, Limit: limit, IncludeArchived: includeArchived}
+				var res []cortex.ScoredRow
+				var serr error
 				if mode == cortex.SearchModeHybrid {
-					out = "[hybrid fusion not yet available; showing semantic results]\n" + out
+					res, serr = cx.HybridSimilarAs(traceID, opts, weight, cortex.ActorAgent, cortex.DefaultSearchHitTopN)
+				} else {
+					res, serr = cx.SemanticSimilarAs(traceID, opts, cortex.ActorAgent, cortex.DefaultSearchHitTopN)
 				}
-				return mcp.NewToolResultText(out), nil
+				if serr != nil {
+					note = "[" + mode + " similar unavailable (" + serr.Error() + "); showing lexical results]\n"
+				} else {
+					return mcp.NewToolResultText(formatSimilarMatches(scoredToMatches(res))), nil
+				}
 			}
 		}
 


### PR DESCRIPTION
Phase 4 completes the `mode` triad: **lexical | semantic | hybrid**. `hybrid` no longer falls back to semantic — it now performs real **Reciprocal Rank Fusion** of the FTS5 (BM25) and embedding (cosine) rankings. Builds on #121.

### What's in
- **`rrfFuse`**: `score = Σ w_r/(60+rank)`, `weight` splits semantic vs lexical (clamped to [0,1]); ID-tiebreak for deterministic output.
- **`lexicalRanked`**: a BM25-ordered FTS5 query — the lexical input to fusion (the existing `Search` orders by `created_at`, not relevance, so hybrid needed a real relevance ranking).
- **`HybridSearch` / `HybridSimilar`** (+ actor bump wrappers). Similar fuses `FindSimilar` (BM25 over distinctive terms) with `SemanticSimilar` (source vector). Shared `embedQuery` / `sourceVector` / row-scan helpers refactored out.
- **MCP**: `mode=hybrid` on both tools runs real fusion (weight from `search.hybrid_weight`); `resolveSearchMode` returns the weight. Still degrades to lexical-with-note on any failure.
- **CLI**: `noema search --hybrid`, `noema similar --hybrid`. Also fixed a cobra quirk where backticks in the `--semantic` help rendered a bogus arg placeholder.

### Tests
`rrfFuse` (weight 0/0.5/1 + clamp + tiebreak + limit); `HybridSearch` fusion/ranking + guards; `HybridSimilar` source-exclusion; **MCP hybrid end-to-end via httptest** (asserts no fallback note). Full build + vet + test + `-race` green.

### Remaining in the arc
3c in-memory vector cache (optimization), 2b write-time async embedding, and a `max_chars` UX polish (graceful handling when an input exceeds the model's token limit — surfaced live on ai-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)