### PR TITLE
feat(search): semantic-search phase 2b — serve-time embed maintainer

### DIFF
--- a/internal/cli/cmd_serve.go
+++ b/internal/cli/cmd_serve.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
@@ -19,6 +20,7 @@ import (
 	"github.com/Fail-Safe/Noema/internal/config"
 	"github.com/Fail-Safe/Noema/internal/consolidation"
 	"github.com/Fail-Safe/Noema/internal/cortex"
+	"github.com/Fail-Safe/Noema/internal/embed"
 	"github.com/Fail-Safe/Noema/internal/federation"
 	"github.com/Fail-Safe/Noema/internal/lock"
 	mcpserver "github.com/Fail-Safe/Noema/internal/mcp"
@@ -29,17 +31,17 @@ import (
 
 func serveCmd() *cobra.Command {
 	var (
-		transport         string
-		hosts             []string
-		port              int
+		transport            string
+		hosts                []string
+		port                 int
 		tlsCert              string
 		tlsKey               string
 		insecureAllowExpired bool
 		logFile              string
-		logStderr         bool
-		printConfig       bool
-		printSystemdUnit  bool
-		printLaunchdPlist bool
+		logStderr            bool
+		printConfig          bool
+		printSystemdUnit     bool
+		printLaunchdPlist    bool
 	)
 
 	cmd := &cobra.Command{
@@ -138,6 +140,7 @@ func serveCmd() *cobra.Command {
 			var eligibility *consolidation.EligibilityLoop
 			var watchdog *consolidation.Watchdog
 			var certMonitor *mcpserver.CertMonitor
+			var embedMaintainer *embed.Maintainer
 
 			// Per-cortex background-work coordination. Concurrent serve
 			// processes on the same cortex (long-lived `--transport http`
@@ -226,6 +229,14 @@ func serveCmd() *cobra.Command {
 			// trash/update event for the same fsnotify trigger.
 			if gotLock && manifestErr == nil && m.Watch.WatchEnabled() {
 				watcher = startWatcher(cx, m.Watch)
+			}
+
+			// Embed maintainer: when semantic search is configured, keep the
+			// embedding index fresh by periodically backfilling new/edited
+			// traces. Gated on the background-work lock so only one serve
+			// process embeds per cortex (backfill is idempotent regardless).
+			if gotLock && manifestErr == nil && m.Search.SemanticOn() {
+				embedMaintainer = startEmbedMaintainer(cx, m)
 			}
 
 			// Consolidation agent: opt-in; drives memory-tier
@@ -434,6 +445,9 @@ func serveCmd() *cobra.Command {
 			if watcher != nil {
 				watcher.Stop()
 			}
+			if embedMaintainer != nil {
+				embedMaintainer.Stop()
+			}
 			if consolidator != nil {
 				consolidator.Stop()
 			}
@@ -499,6 +513,34 @@ func startWatcher(cx *cortex.Cortex, cfg *cortex.WatchConfig) *watch.Watcher {
 		return nil
 	}
 	return w
+}
+
+// startEmbedMaintainer wires the manifest's search config into a background
+// loop that periodically backfills semantic embeddings (idempotent). Returns
+// nil (and logs) when the embedder can't be built, so a misconfigured
+// endpoint degrades to "no auto-embed" rather than taking down serve.
+func startEmbedMaintainer(cx *cortex.Cortex, m cortex.Manifest) *embed.Maintainer {
+	model := ""
+	if m.Search != nil {
+		model = m.Search.EmbeddingModel
+	}
+	endpoint := m.ResolvedEmbeddingEndpoint()
+	if model == "" || endpoint == "" {
+		fmt.Printf("[embed] semantic enabled but model/endpoint unresolved; auto-embed disabled\n")
+		return nil
+	}
+	client, err := consolidation.NewHTTPLLMClient(endpoint, m.ResolvedEmbeddingAPIKeyEnv())
+	if err != nil {
+		fmt.Printf("[embed] client construct failed: %v (auto-embed disabled)\n", err)
+		return nil
+	}
+	maxChars := m.Search.EffectiveMaxChars()
+	mt := embed.New(m.Search.EffectiveEmbedInterval(), func(ctx context.Context) (int, error) {
+		res, err := cx.EmbedBackfill(ctx, client, model, cortex.EmbedBackfillOpts{MaxChars: maxChars})
+		return res.Embedded, err
+	})
+	mt.Start()
+	return mt
 }
 
 // startConsolidator wires the manifest's consolidation config into a

--- a/internal/cortex/cortex.go
+++ b/internal/cortex/cortex.go
@@ -601,8 +601,9 @@ const (
 	SearchModeSemantic = "semantic"
 	SearchModeHybrid   = "hybrid"
 
-	defaultHybridWeight  = 0.5
-	defaultEmbedMaxChars = 32000
+	defaultHybridWeight         = 0.5
+	defaultEmbedMaxChars        = 32000
+	defaultEmbedIntervalSeconds = 300
 )
 
 // SearchConfig is the optional `search:` block in cortex.md. It is off by
@@ -641,6 +642,11 @@ type SearchConfig struct {
 	// MaxChars caps the trace text sent to the embedding model, to stay
 	// within model input limits. Zero/unset means defaultEmbedMaxChars.
 	MaxChars int `yaml:"max_chars,omitempty"`
+
+	// EmbedIntervalSeconds is how often the serve-time embed maintainer
+	// runs a backfill pass to embed new/edited traces. Zero/unset means
+	// defaultEmbedIntervalSeconds. Only used under `noema serve`.
+	EmbedIntervalSeconds int `yaml:"embed_interval_seconds,omitempty"`
 }
 
 // SemanticOn reports whether semantic search is enabled. Nil-safe.
@@ -678,6 +684,15 @@ func (sc *SearchConfig) EffectiveMaxChars() int {
 		return defaultEmbedMaxChars
 	}
 	return sc.MaxChars
+}
+
+// EffectiveEmbedInterval returns the serve-time backfill cadence, defaulting
+// to 5 minutes.
+func (sc *SearchConfig) EffectiveEmbedInterval() time.Duration {
+	if sc == nil || sc.EmbedIntervalSeconds <= 0 {
+		return defaultEmbedIntervalSeconds * time.Second
+	}
+	return time.Duration(sc.EmbedIntervalSeconds) * time.Second
 }
 
 // ResolvedEmbeddingEndpoint returns the embedding endpoint, falling back to

--- a/internal/embed/maintainer.go
+++ b/internal/embed/maintainer.go
@@ -1,0 +1,84 @@
+// Package embed runs a background maintainer that keeps a cortex's semantic
+// embedding index fresh under `noema serve`. Traces created or edited while
+// the server runs get embedded automatically, without a manual `noema
+// embeddings backfill`.
+//
+// It is deliberately NOT a per-mutation hook: embedding an external endpoint
+// must never block or fail a trace write. Instead the maintainer runs an
+// idempotent backfill pass on an interval (only missing/stale traces are
+// embedded), mirroring the lifecycle of the filesystem watcher and
+// federation syncer — construct, Start, Stop. Freshness is eventual, bounded
+// by the interval.
+package embed
+
+import (
+	"context"
+	"log"
+	"sync"
+	"time"
+)
+
+// Maintainer periodically runs a backfill pass. The pass function is
+// injected (the serve layer wires it to Cortex.EmbedBackfill) so the loop
+// stays free of cortex/embedder dependencies and is trivially testable.
+type Maintainer struct {
+	backfill func(context.Context) (int, error)
+	interval time.Duration
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+// New builds a Maintainer that runs backfill every interval. backfill
+// returns the number of traces embedded and an error; both are for logging
+// only — a failing pass is retried on the next tick.
+func New(interval time.Duration, backfill func(context.Context) (int, error)) *Maintainer {
+	if interval <= 0 {
+		interval = 5 * time.Minute
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Maintainer{backfill: backfill, interval: interval, ctx: ctx, cancel: cancel}
+}
+
+// Start launches the background loop. It runs one pass immediately (so a
+// freshly-started server catches up on anything written while it was down),
+// then once per interval until Stop.
+func (m *Maintainer) Start() {
+	log.Printf("[embed] maintainer active, interval=%s", m.interval)
+	m.wg.Add(1)
+	go m.run()
+}
+
+func (m *Maintainer) run() {
+	defer m.wg.Done()
+	m.pass()
+	t := time.NewTicker(m.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-m.ctx.Done():
+			return
+		case <-t.C:
+			m.pass()
+		}
+	}
+}
+
+func (m *Maintainer) pass() {
+	n, err := m.backfill(m.ctx)
+	switch {
+	case m.ctx.Err() != nil:
+		return // shutting down — swallow any partial-pass error
+	case err != nil:
+		log.Printf("[embed] backfill pass failed: %v", err)
+	case n > 0:
+		log.Printf("[embed] embedded %d trace(s)", n)
+	}
+}
+
+// Stop cancels the loop and blocks until the goroutine drains.
+func (m *Maintainer) Stop() {
+	m.cancel()
+	m.wg.Wait()
+}

--- a/internal/embed/maintainer_test.go
+++ b/internal/embed/maintainer_test.go
@@ -1,0 +1,76 @@
+package embed
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// waitFor receives n times from ch within the timeout or fails.
+func waitFor(t *testing.T, ch <-chan struct{}, n int) {
+	t.Helper()
+	for i := range n {
+		select {
+		case <-ch:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for pass %d/%d", i+1, n)
+		}
+	}
+}
+
+func TestMaintainer_RunsInitialAndPeriodic(t *testing.T) {
+	var calls int32
+	ran := make(chan struct{}, 64)
+	m := New(15*time.Millisecond, func(ctx context.Context) (int, error) {
+		atomic.AddInt32(&calls, 1)
+		ran <- struct{}{}
+		return 0, nil
+	})
+	m.Start()
+	// Initial pass + at least two ticks.
+	waitFor(t, ran, 3)
+	m.Stop()
+
+	// After Stop, no further passes.
+	settled := atomic.LoadInt32(&calls)
+	time.Sleep(60 * time.Millisecond)
+	if got := atomic.LoadInt32(&calls); got != settled {
+		t.Errorf("maintainer ran %d more pass(es) after Stop", got-settled)
+	}
+}
+
+func TestMaintainer_ErrorsAreNonFatal(t *testing.T) {
+	ran := make(chan struct{}, 64)
+	m := New(15*time.Millisecond, func(ctx context.Context) (int, error) {
+		ran <- struct{}{}
+		return 0, errors.New("boom")
+	})
+	m.Start()
+	// A failing pass must not stop the loop — expect repeated passes.
+	waitFor(t, ran, 3)
+	m.Stop()
+}
+
+func TestMaintainer_StopIsIdempotentAndDrains(t *testing.T) {
+	m := New(10*time.Millisecond, func(ctx context.Context) (int, error) {
+		// Respect cancellation so Stop drains promptly.
+		select {
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		default:
+			return 1, nil
+		}
+	})
+	m.Start()
+	time.Sleep(25 * time.Millisecond)
+	m.Stop() // must return (drain) without hanging
+}
+
+func TestNew_DefaultsZeroInterval(t *testing.T) {
+	m := New(0, func(ctx context.Context) (int, error) { return 0, nil })
+	if m.interval != 5*time.Minute {
+		t.Errorf("zero interval = %s, want 5m default", m.interval)
+	}
+}


### PR DESCRIPTION
Phase 2b: embeddings stay fresh automatically. Under `noema serve`, traces created/edited while running get embedded without a manual `noema embeddings backfill`. Builds on #119/#122.

### Design: periodic maintainer, not a per-mutation hook
Embedding an external endpoint must never block or fail a trace write, so this is **not** an Add/Update hook. Instead a background maintainer (`internal/embed`) runs an **idempotent backfill pass on an interval** (only missing/stale traces embed), mirroring the watcher/syncer lifecycle (construct/Start/Stop, own context + waitgroup). Freshness is eventual, bounded by the interval; on-demand `embeddings backfill` still covers immediate needs.

### What's in
- **`internal/embed.Maintainer`** — ticker loop with an *injected* backfill func, so it's decoupled from cortex/embedder and fully unit-testable. Runs an initial pass on start (catches up on writes made while the server was down); failing passes are logged + retried, never fatal.
- **`SearchConfig.EmbedIntervalSeconds`** (+ `EffectiveEmbedInterval`, default 5m).
- **serve**: `startEmbedMaintainer` gated on the background-work lock + semantic config (only one process embeds per cortex; backfill is idempotent regardless), stopped on shutdown with the other components.

### Tests
Initial + periodic passes, errors non-fatal, `Stop` drains, zero-interval default — all under `-race`. Full build + vet + test green.

This is the last freshness/UX gap; remaining arc items are 3c (in-memory vector cache, pure speed) and the `max_chars` graceful-degradation polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)