### PR TITLE
docs(search): document semantic / hybrid search across all surfaces

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,9 @@ Super simple, super basic. Intentionally lightweight. Transparently open.
 **Language:** Go (v1). Revisit Rust if MCP server concurrency demands it.
 - SQLite: `modernc.org/sqlite` (pure-Go, no CGo required)
 - TUI: Charm / Bubble Tea
-- Search: SQLite FTS5 — no semantic/vector search in v1
+- Search: SQLite FTS5 (lexical, always on) plus an **opt-in semantic / hybrid**
+  layer (embeddings + pure-Go cosine; see Semantic Search below). No CGo, no
+  vector extension, no external vector DB.
 
 Markdown files are the content holders of data. The SQLite DB is a basic schema to hold pieces of metadata about the markdown files (location, author, type, tag(s), ...) in order to provide mapping, related contexts, search performance.
 
@@ -194,6 +196,18 @@ The three-tier model completes with an automatic mid→long promoter. A graduati
 ### Search-hit instrumentation (Phase 15.5)
 
 `search_traces` and `find_similar_traces` bump a per-peer `search_hit_count` column in `trace_usage` for the top-N results (default N=3 via `cortex.DefaultSearchHitTopN`) when the caller is `ActorAgent`. This complements `read_count` (which only bumps on `get_trace` / `noema_recall`): auto-injection providers like the Hermes plugin consume search output without ever drilling into individual traces, so without this signal their cortexes generate no usage data and traces never accumulate enough to graduate. The graduation gate and the heuristic short→mid scorer both fold `search_hit_count` into the read bucket at 1:1, which preserves the option to reweight later (the columns stay separate on the wire and in the DB) without a schema change. Long-tier traces are skipped on bump — see `internal/cortex/actor.go` `SearchAs` / `FindSimilarAs` for the rationale and the `bumpSearchHitsForIDs` guard. Migration `015_search_hit_count.sql` adds the column with default 0; older peers in a federation ring stay wire-compatible because `federation.TraceUsage.SearchHitCount` uses `omitempty`.
+
+### Semantic Search (opt-in)
+
+Lexical FTS5 search is always on. An **opt-in semantic layer** adds embedding-based ranking, kept pure-Go: `modernc.org/sqlite` can't load the `sqlite-vec` C extension, so embeddings are stored as a `BLOB` (migration `016_trace_embeddings.sql`: `trace_id, embedding_model, dim, embedding, source_hash, updated_at`) and cosine similarity is computed in Go (brute-force; interactive to ~50k traces — a feasibility spike measured ~7ms/query at 10k×768-dim). Embeddings are a **local derived index, never federated** (vectors from different models aren't comparable, and trace bodies + `content_hash` already sync) — so there is no `sync_events`/wire-format impact, like FTS5.
+
+Enable via a `search:` block in `cortex.md` (off by default): `semantic_enabled: true`, `embedding_model` (required — no baked-in default), `embedding_endpoint` (OpenAI-compatible `/embeddings`; inherits `consolidation.local_llm_endpoint` when empty), optional `api_key_env`, `default_mode` (lexical|semantic|hybrid), `hybrid_weight` (0..1, default 0.5), `max_chars` (per-trace embed-text budget, default 32000 — lower it for small-context embed models), `embed_interval_seconds` (serve maintainer cadence, default 300). `Manifest.ValidateSearch` enforces the cross-field rules. The embedder reuses `consolidation.HTTPLLMClient` via an `Embed()` method; the `cortex.Embedder` interface is defined in `internal/cortex` to avoid an import cycle and injected by the CLI/serve layer.
+
+- **Storage / lifecycle** (`internal/cortex/embedding.go`, `embedding_store.go`): the BLOB codec (1-byte version + LE float32, L2-normalized so cosine == dot), `EmbedBackfill` (idempotent, resumable, `--force`/`--limit`, model-change re-embed; staleness keyed on `source_hash` vs `content_hash`), and `EmbeddingStatus`. Body text = `title + "\n\n" + body`, rune-truncated to `max_chars`.
+- **Query** (`semantic.go`): `SemanticSearch` (embeds the query), `SemanticSimilar` (reuses the source trace's stored vector), `HybridSearch`/`HybridSimilar` (Reciprocal Rank Fusion, K=60, of BM25-ranked `lexicalRanked` + cosine, weighted by `hybrid_weight`). Non-finite or dimension-mismatched stored vectors are skipped at the consumer so a corrupted BLOB can't poison ranking. Actor wrappers (`*As`) bump `search_hit_count` for `ActorAgent`, matching the lexical path.
+- **CLI**: `noema embeddings status|backfill [--force] [--limit]`; `noema search --semantic|--hybrid`; `noema similar --semantic|--hybrid`.
+- **MCP**: `search_traces` and `find_similar_traces` take a `mode` arg (`lexical`|`semantic`|`hybrid`); the server builds the embedder from the manifest and **degrades to lexical with a bracketed note** (never an error) when semantic is unconfigured, the endpoint is unreachable, or the source isn't embedded.
+- **Serve-time freshness** (`internal/embed/Maintainer`): under `noema serve`, a background loop runs a periodic idempotent backfill (gated on the background-work lock) so new/edited traces get embedded without a manual backfill. It is NOT a per-mutation hook — embedding never blocks or fails a write; freshness is eventual, bounded by `embed_interval_seconds`.
 
 ### Automatic LLM distillation (auto_distillation_enabled)
 

--- a/README.md
+++ b/README.md
@@ -210,8 +210,11 @@ noema append <id> [--content <text>]      Append to a Trace body (pipe-friendly:
 noema remove <id>                         Move a Trace to trash (--force to hard-delete)
 noema recover <id>                        Restore a Trace from trash
 noema purge [--days N]                    Permanently delete all trashed Traces older than N days
-noema search <query> [flags]              Full-text search (FTS5)
-noema similar <id> [--limit N]            Find traces with overlapping vocabulary to <id> (BM25-ranked)
+noema search <query> [flags]              Full-text search (FTS5). --semantic / --hybrid
+                                          rank by embedding similarity (needs a search: block + backfill)
+noema similar <id> [--limit N]            Find traces related to <id> (BM25; --semantic / --hybrid for embeddings)
+noema embeddings status                   Show semantic-search embedding coverage (embedded / stale / missing)
+noema embeddings backfill [--force]       Embed traces that are missing or stale (for semantic search)
 
 noema archive <id>                        Archive a Trace
 noema unarchive <id>                      Restore an archived Trace
@@ -305,8 +308,8 @@ Noema can run as an [MCP](https://modelcontextprotocol.io) server, giving any MC
 | `create_trace` | Create a new trace (supports `derived_from`, `origin`) |
 | `update_trace` | Update any subset of fields on an existing trace |
 | `append_trace` | Append content to an existing trace without reading it first (fire-and-forget logging) |
-| `search_traces` | FTS5 full-text search |
-| `find_similar_traces` | Surface traces with overlapping vocabulary (BM25-ranked); useful when you have one trace and want related ones without crafting a query |
+| `search_traces` | Search traces. `mode`: `lexical` (FTS5, default), `semantic` (embedding similarity), or `hybrid` (RRF fusion); semantic/hybrid need a configured `search:` block and fall back to lexical otherwise |
+| `find_similar_traces` | Surface traces related to one you hold. Default ranks by BM25 vocabulary overlap; `mode=semantic`/`hybrid` ranks by embedding similarity to the source trace's vector |
 | `archive_trace` / `unarchive_trace` | Archive a trace or restore it |
 | `delete_trace` / `recover_trace` | Soft-delete (move to trash) or restore from trash |
 | `trace_history` | Event log (audit trail) for a trace |
@@ -499,6 +502,37 @@ watch:
 Loopback is prevented by content hash comparison: when the watcher sees a write, it hashes the body and compares to the DB's `content_hash` — matches are skipped, so Noema's own writes don't trigger duplicate events. Source-locked foreign traces are refused on external edit and logged (the watcher will not silently circumvent a publisher's authority). Malformed drop-in files (missing frontmatter, invalid id) are skipped with a warning.
 
 The watcher runs under both transports because stdio sessions are not always the only mutator — the user may be editing in Obsidian while Claude Code holds a stdio connection, iCloud may deliver deltas from another device, or another noema process may be writing over HTTP on the same cortex. Federation propagation still only happens under `--transport http` (peers need a network endpoint), but external-edit events land in the local log and flow outward the next time an HTTP serve is running. Without any running `serve` process, external edits sit on disk safely, but stay invisible to the DB until `noema sync` (which, by design, emits no events — federation peers won't see those edits).
+
+---
+
+## Semantic search (optional)
+
+Lexical FTS5 search is always on. An **opt-in semantic layer** adds embedding-based ranking — useful when a query matches by *concept* rather than shared words (e.g. "how do we authenticate agents" surfacing a trace titled "bearer-key posture for the MCP endpoint"). It stays true to Noema's lightweight, local-first posture: embeddings are stored as a SQLite `BLOB` and cosine similarity is computed in pure Go — no CGo, no vector extension, no external vector database. Embeddings are a **local index** (never federated), like the FTS5 index.
+
+Enable it with a `search:` block in `cortex.md`:
+
+```yaml
+search:
+  semantic_enabled: true
+  embedding_model: nomic-embed-text          # required — no default
+  embedding_endpoint: http://localhost:11434/v1   # OpenAI-compatible /embeddings;
+                                             # inherits consolidation.local_llm_endpoint if unset
+  # default_mode: hybrid    # lexical | semantic | hybrid (default lexical)
+  # hybrid_weight: 0.5      # vector weight in hybrid fusion (0..1)
+  # max_chars: 32000        # per-trace embed-text budget; lower for small-context models
+```
+
+Then build the index and search:
+
+```sh
+noema embeddings backfill            # embed existing traces (idempotent)
+noema embeddings status              # coverage: embedded / stale / missing
+noema search "concept query" --semantic
+noema search "concept query" --hybrid   # fuse FTS5 + embeddings (reciprocal rank fusion)
+noema similar <id> --semantic
+```
+
+Over MCP, `search_traces` and `find_similar_traces` take a `mode` arg (`lexical` | `semantic` | `hybrid`). If semantic search isn't configured or the embedding endpoint is unreachable, both **degrade to lexical results with a note** rather than erroring. Under `noema serve`, a background maintainer re-embeds new and edited traces on an interval, so the index stays fresh without a manual backfill.
 
 ---
 

--- a/internal/cortex/cortex.go
+++ b/internal/cortex/cortex.go
@@ -1078,8 +1078,8 @@ they keep the database in sync automatically:
 | ` + "`create_trace`" + ` | Create a new trace (supports derived_from, origin) |
 | ` + "`update_trace`" + ` | Update fields of an existing trace |
 | ` + "`append_trace`" + ` | Append content to a trace body (fire-and-forget) |
-| ` + "`search_traces`" + ` | Full-text search across titles and bodies |
-| ` + "`find_similar_traces`" + ` | Surface traces with overlapping vocabulary (BM25-ranked) — useful when you have a trace in hand and want related ones without crafting a query |
+| ` + "`search_traces`" + ` | Search across titles and bodies. ` + "`mode`" + `: ` + "`lexical`" + ` (FTS5, default), ` + "`semantic`" + ` (embedding similarity), or ` + "`hybrid`" + ` (RRF fusion). Semantic/hybrid need a configured ` + "`search:`" + ` block; they fall back to lexical otherwise |
+| ` + "`find_similar_traces`" + ` | Surface traces related to one you have in hand. Default ranks by BM25 vocabulary overlap; ` + "`mode=semantic`" + `/` + "`hybrid`" + ` ranks by embedding similarity to the source trace's own vector |
 | ` + "`archive_trace`" + ` | Archive a trace |
 | ` + "`unarchive_trace`" + ` | Restore an archived trace |
 | ` + "`delete_trace`" + ` | Move a trace to trash (soft-delete, recoverable) |

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1310,6 +1310,10 @@ runs.
 - author should be your agent name so traces are attributable in multi-agent systems.
 - Use derived_from when creating traces based on other traces — it builds a knowledge graph.
 - search_traces supports FTS5 syntax: quoted phrases, AND/OR/NOT, prefix* matching.
+- search_traces / find_similar_traces accept mode=semantic or mode=hybrid for
+  embedding-based ranking when this cortex has a search: block configured and
+  embeddings backfilled (noema embeddings backfill); they fall back to lexical
+  otherwise. Use semantic when a query matches by concept rather than wording.
 `, m.Name, noemaVersion, m.Version, purposeLine, ownerLine, m.Name)
 }
 


### PR DESCRIPTION
Docs pass for the now-complete semantic-search feature (phases 1–4 + 2b). Keeps the docs trio + project docs in sync.

- **README**: new "Semantic search (optional)" section — `cortex.md` `search:` block, `noema embeddings backfill`, `--semantic`/`--hybrid` CLI, MCP `mode` + graceful lexical fallback, serve-time auto-embed. CLI cheatsheet gains `noema embeddings` and the `search`/`similar` flags; MCP tool table notes the `mode` arg.
- **CLAUDE.md**: replaces the stale "no semantic/vector search in v1" line; adds a "Semantic Search (opt-in)" section (BLOB codec, query/RRF, CLI/MCP, serve maintainer, the pure-Go/local-only rationale).
- **AGENTS.md generator** + **get_instructions**: `search_traces`/`find_similar_traces` document `mode=semantic`/`hybrid` and how to enable it.

Only code touched is the AGENTS.md template (self-heals on next `Open`) and the `get_instructions` text — no logic changes. `cortex`/`mcp`/`cli` tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)