### PR TITLE
release: v0.14.0 — opt-in semantic & hybrid search

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,9 @@ Super simple, super basic. Intentionally lightweight. Transparently open.
 **Language:** Go (v1). Revisit Rust if MCP server concurrency demands it.
 - SQLite: `modernc.org/sqlite` (pure-Go, no CGo required)
 - TUI: Charm / Bubble Tea
-- Search: SQLite FTS5 — no semantic/vector search in v1
+- Search: SQLite FTS5 (lexical, always on) plus an **opt-in semantic / hybrid**
+  layer (embeddings + pure-Go cosine; see Semantic Search below). No CGo, no
+  vector extension, no external vector DB.
 
 Markdown files are the content holders of data. The SQLite DB is a basic schema to hold pieces of metadata about the markdown files (location, author, type, tag(s), ...) in order to provide mapping, related contexts, search performance.
 
@@ -194,6 +196,18 @@ The three-tier model completes with an automatic mid→long promoter. A graduati
 ### Search-hit instrumentation (Phase 15.5)
 
 `search_traces` and `find_similar_traces` bump a per-peer `search_hit_count` column in `trace_usage` for the top-N results (default N=3 via `cortex.DefaultSearchHitTopN`) when the caller is `ActorAgent`. This complements `read_count` (which only bumps on `get_trace` / `noema_recall`): auto-injection providers like the Hermes plugin consume search output without ever drilling into individual traces, so without this signal their cortexes generate no usage data and traces never accumulate enough to graduate. The graduation gate and the heuristic short→mid scorer both fold `search_hit_count` into the read bucket at 1:1, which preserves the option to reweight later (the columns stay separate on the wire and in the DB) without a schema change. Long-tier traces are skipped on bump — see `internal/cortex/actor.go` `SearchAs` / `FindSimilarAs` for the rationale and the `bumpSearchHitsForIDs` guard. Migration `015_search_hit_count.sql` adds the column with default 0; older peers in a federation ring stay wire-compatible because `federation.TraceUsage.SearchHitCount` uses `omitempty`.
+
+### Semantic Search (opt-in)
+
+Lexical FTS5 search is always on. An **opt-in semantic layer** adds embedding-based ranking, kept pure-Go: `modernc.org/sqlite` can't load the `sqlite-vec` C extension, so embeddings are stored as a `BLOB` (migration `016_trace_embeddings.sql`: `trace_id, embedding_model, dim, embedding, source_hash, updated_at`) and cosine similarity is computed in Go (brute-force; interactive to ~50k traces — a feasibility spike measured ~7ms/query at 10k×768-dim). Embeddings are a **local derived index, never federated** (vectors from different models aren't comparable, and trace bodies + `content_hash` already sync) — so there is no `sync_events`/wire-format impact, like FTS5.
+
+Enable via a `search:` block in `cortex.md` (off by default): `semantic_enabled: true`, `embedding_model` (required — no baked-in default), `embedding_endpoint` (OpenAI-compatible `/embeddings`; inherits `consolidation.local_llm_endpoint` when empty), optional `api_key_env`, `default_mode` (lexical|semantic|hybrid), `hybrid_weight` (0..1, default 0.5), `max_chars` (per-trace embed-text budget, default 32000 — lower it for small-context embed models), `embed_interval_seconds` (serve maintainer cadence, default 300). `Manifest.ValidateSearch` enforces the cross-field rules. The embedder reuses `consolidation.HTTPLLMClient` via an `Embed()` method; the `cortex.Embedder` interface is defined in `internal/cortex` to avoid an import cycle and injected by the CLI/serve layer.
+
+- **Storage / lifecycle** (`internal/cortex/embedding.go`, `embedding_store.go`): the BLOB codec (1-byte version + LE float32, L2-normalized so cosine == dot), `EmbedBackfill` (idempotent, resumable, `--force`/`--limit`, model-change re-embed; staleness keyed on `source_hash` vs `content_hash`), and `EmbeddingStatus`. Body text = `title + "\n\n" + body`, rune-truncated to `max_chars`.
+- **Query** (`semantic.go`): `SemanticSearch` (embeds the query), `SemanticSimilar` (reuses the source trace's stored vector), `HybridSearch`/`HybridSimilar` (Reciprocal Rank Fusion, K=60, of BM25-ranked `lexicalRanked` + cosine, weighted by `hybrid_weight`). Non-finite or dimension-mismatched stored vectors are skipped at the consumer so a corrupted BLOB can't poison ranking. Actor wrappers (`*As`) bump `search_hit_count` for `ActorAgent`, matching the lexical path.
+- **CLI**: `noema embeddings status|backfill [--force] [--limit]`; `noema search --semantic|--hybrid`; `noema similar --semantic|--hybrid`.
+- **MCP**: `search_traces` and `find_similar_traces` take a `mode` arg (`lexical`|`semantic`|`hybrid`); the server builds the embedder from the manifest and **degrades to lexical with a bracketed note** (never an error) when semantic is unconfigured, the endpoint is unreachable, or the source isn't embedded.
+- **Serve-time freshness** (`internal/embed/Maintainer`): under `noema serve`, a background loop runs a periodic idempotent backfill (gated on the background-work lock) so new/edited traces get embedded without a manual backfill. It is NOT a per-mutation hook — embedding never blocks or fails a write; freshness is eventual, bounded by `embed_interval_seconds`.
 
 ### Automatic LLM distillation (auto_distillation_enabled)
 

--- a/README.md
+++ b/README.md
@@ -210,8 +210,11 @@ noema append <id> [--content <text>]      Append to a Trace body (pipe-friendly:
 noema remove <id>                         Move a Trace to trash (--force to hard-delete)
 noema recover <id>                        Restore a Trace from trash
 noema purge [--days N]                    Permanently delete all trashed Traces older than N days
-noema search <query> [flags]              Full-text search (FTS5)
-noema similar <id> [--limit N]            Find traces with overlapping vocabulary to <id> (BM25-ranked)
+noema search <query> [flags]              Full-text search (FTS5). --semantic / --hybrid
+                                          rank by embedding similarity (needs a search: block + backfill)
+noema similar <id> [--limit N]            Find traces related to <id> (BM25; --semantic / --hybrid for embeddings)
+noema embeddings status                   Show semantic-search embedding coverage (embedded / stale / missing)
+noema embeddings backfill [--force]       Embed traces that are missing or stale (for semantic search)
 
 noema archive <id>                        Archive a Trace
 noema unarchive <id>                      Restore an archived Trace
@@ -305,8 +308,8 @@ Noema can run as an [MCP](https://modelcontextprotocol.io) server, giving any MC
 | `create_trace` | Create a new trace (supports `derived_from`, `origin`) |
 | `update_trace` | Update any subset of fields on an existing trace |
 | `append_trace` | Append content to an existing trace without reading it first (fire-and-forget logging) |
-| `search_traces` | FTS5 full-text search |
-| `find_similar_traces` | Surface traces with overlapping vocabulary (BM25-ranked); useful when you have one trace and want related ones without crafting a query |
+| `search_traces` | Search traces. `mode`: `lexical` (FTS5, default), `semantic` (embedding similarity), or `hybrid` (RRF fusion); semantic/hybrid need a configured `search:` block and fall back to lexical otherwise |
+| `find_similar_traces` | Surface traces related to one you hold. Default ranks by BM25 vocabulary overlap; `mode=semantic`/`hybrid` ranks by embedding similarity to the source trace's vector |
 | `archive_trace` / `unarchive_trace` | Archive a trace or restore it |
 | `delete_trace` / `recover_trace` | Soft-delete (move to trash) or restore from trash |
 | `trace_history` | Event log (audit trail) for a trace |
@@ -499,6 +502,37 @@ watch:
 Loopback is prevented by content hash comparison: when the watcher sees a write, it hashes the body and compares to the DB's `content_hash` — matches are skipped, so Noema's own writes don't trigger duplicate events. Source-locked foreign traces are refused on external edit and logged (the watcher will not silently circumvent a publisher's authority). Malformed drop-in files (missing frontmatter, invalid id) are skipped with a warning.
 
 The watcher runs under both transports because stdio sessions are not always the only mutator — the user may be editing in Obsidian while Claude Code holds a stdio connection, iCloud may deliver deltas from another device, or another noema process may be writing over HTTP on the same cortex. Federation propagation still only happens under `--transport http` (peers need a network endpoint), but external-edit events land in the local log and flow outward the next time an HTTP serve is running. Without any running `serve` process, external edits sit on disk safely, but stay invisible to the DB until `noema sync` (which, by design, emits no events — federation peers won't see those edits).
+
+---
+
+## Semantic search (optional)
+
+Lexical FTS5 search is always on. An **opt-in semantic layer** adds embedding-based ranking — useful when a query matches by *concept* rather than shared words (e.g. "how do we authenticate agents" surfacing a trace titled "bearer-key posture for the MCP endpoint"). It stays true to Noema's lightweight, local-first posture: embeddings are stored as a SQLite `BLOB` and cosine similarity is computed in pure Go — no CGo, no vector extension, no external vector database. Embeddings are a **local index** (never federated), like the FTS5 index.
+
+Enable it with a `search:` block in `cortex.md`:
+
+```yaml
+search:
+  semantic_enabled: true
+  embedding_model: nomic-embed-text          # required — no default
+  embedding_endpoint: http://localhost:11434/v1   # OpenAI-compatible /embeddings;
+                                             # inherits consolidation.local_llm_endpoint if unset
+  # default_mode: hybrid    # lexical | semantic | hybrid (default lexical)
+  # hybrid_weight: 0.5      # vector weight in hybrid fusion (0..1)
+  # max_chars: 32000        # per-trace embed-text budget; lower for small-context models
+```
+
+Then build the index and search:
+
+```sh
+noema embeddings backfill            # embed existing traces (idempotent)
+noema embeddings status              # coverage: embedded / stale / missing
+noema search "concept query" --semantic
+noema search "concept query" --hybrid   # fuse FTS5 + embeddings (reciprocal rank fusion)
+noema similar <id> --semantic
+```
+
+Over MCP, `search_traces` and `find_similar_traces` take a `mode` arg (`lexical` | `semantic` | `hybrid`). If semantic search isn't configured or the embedding endpoint is unreachable, both **degrade to lexical results with a note** rather than erroring. Under `noema serve`, a background maintainer re-embeds new and edited traces on an interval, so the index stays fresh without a manual backfill.
 
 ---
 

--- a/internal/cli/cmd_embeddings.go
+++ b/internal/cli/cmd_embeddings.go
@@ -1,0 +1,111 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Fail-Safe/Noema/internal/consolidation"
+	"github.com/Fail-Safe/Noema/internal/cortex"
+)
+
+func embeddingsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "embeddings",
+		Short: "Manage semantic-search embeddings",
+		Long: "Inspect and rebuild the per-trace embedding index used by " +
+			"semantic search. Embeddings are a local index (never federated); " +
+			"configure search.embedding_model + an endpoint in cortex.md.",
+	}
+	cmd.AddCommand(embeddingsStatusCmd(), embeddingsBackfillCmd())
+	return cmd
+}
+
+func embeddingsStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "status",
+		Short: "Show embedding coverage for the active cortex",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cx, err := resolveCortex()
+			if err != nil {
+				return err
+			}
+			defer cx.Close()
+
+			m, err := cortex.ReadManifest(cx.Dir)
+			if err != nil {
+				return err
+			}
+			model := ""
+			if m.Search != nil {
+				model = m.Search.EmbeddingModel
+			}
+			st, err := cx.EmbeddingStatus(model)
+			if err != nil {
+				return err
+			}
+
+			if m.Search.SemanticOn() {
+				fmt.Printf("Semantic search: enabled (model=%s, endpoint=%s)\n", model, m.ResolvedEmbeddingEndpoint())
+			} else {
+				fmt.Println("Semantic search: disabled (set search.semantic_enabled + search.embedding_model in cortex.md)")
+			}
+			fmt.Printf("Embeddable traces: %d\n", st.Embeddable)
+			fmt.Printf("  embedded (up-to-date): %d\n", st.Embedded)
+			fmt.Printf("  stale (changed or other model): %d\n", st.Stale)
+			fmt.Printf("  missing: %d\n", st.Missing)
+			return nil
+		},
+	}
+}
+
+func embeddingsBackfillCmd() *cobra.Command {
+	var (
+		force bool
+		limit int
+	)
+	cmd := &cobra.Command{
+		Use:   "backfill",
+		Short: "Embed traces that are missing or stale (for semantic search)",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cx, err := resolveCortex()
+			if err != nil {
+				return err
+			}
+			defer cx.Close()
+
+			m, err := cortex.ReadManifest(cx.Dir)
+			if err != nil {
+				return err
+			}
+			if m.Search == nil || m.Search.EmbeddingModel == "" {
+				return fmt.Errorf("set search.embedding_model in cortex.md before backfilling")
+			}
+			endpoint := m.ResolvedEmbeddingEndpoint()
+			if endpoint == "" {
+				return fmt.Errorf("set search.embedding_endpoint (or consolidation.local_llm_endpoint) in cortex.md")
+			}
+			client, err := consolidation.NewHTTPLLMClient(endpoint, m.ResolvedEmbeddingAPIKeyEnv())
+			if err != nil {
+				return fmt.Errorf("embedding client: %w", err)
+			}
+
+			fmt.Printf("Backfilling embeddings (model=%s, endpoint=%s)...\n", m.Search.EmbeddingModel, endpoint)
+			res, err := cx.EmbedBackfill(cmd.Context(), client, m.Search.EmbeddingModel, cortex.EmbedBackfillOpts{
+				Force:    force,
+				Limit:    limit,
+				MaxChars: m.Search.EffectiveMaxChars(),
+			})
+			if err != nil {
+				return fmt.Errorf("backfill failed after embedding %d: %w", res.Embedded, err)
+			}
+			fmt.Printf("Done: %d considered, %d embedded.\n", res.Considered, res.Embedded)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&force, "force", false, "re-embed all traces, ignoring staleness")
+	cmd.Flags().IntVar(&limit, "limit", 0, "max traces to process (0 = all)")
+	return cmd
+}

--- a/internal/cli/cmd_search.go
+++ b/internal/cli/cmd_search.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/Fail-Safe/Noema/internal/consolidation"
 	"github.com/Fail-Safe/Noema/internal/cortex"
 )
 
@@ -13,6 +14,7 @@ func searchCmd() *cobra.Command {
 		archived bool
 		trashed  bool
 		all      bool
+		semantic bool
 		typ      string
 	)
 
@@ -26,6 +28,10 @@ func searchCmd() *cobra.Command {
 				return err
 			}
 			defer cx.Close()
+
+			if semantic {
+				return runSemanticSearch(cmd, cx, args[0], all || archived)
+			}
 
 			rows, err := cx.Search(args[0], cortex.ListOptions{
 				Archived: archived,
@@ -48,6 +54,45 @@ func searchCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&archived, "archived", false, "search only archived traces")
 	cmd.Flags().BoolVar(&trashed, "trashed", false, "search only trashed traces")
 	cmd.Flags().BoolVar(&all, "all", false, "search active and archived traces")
+	cmd.Flags().BoolVar(&semantic, "semantic", false, "rank by embedding similarity (needs a configured search: block + `noema embeddings backfill`)")
 	cmd.Flags().StringVar(&typ, "type", "", "filter results by type")
 	return cmd
+}
+
+// runSemanticSearch builds the embedder from the cortex manifest and ranks
+// traces by embedding similarity. Kept separate so the lexical path stays
+// untouched. The embedder reuses the consolidation endpoint config.
+func runSemanticSearch(cmd *cobra.Command, cx *cortex.Cortex, query string, includeArchived bool) error {
+	m, err := cortex.ReadManifest(cx.Dir)
+	if err != nil {
+		return err
+	}
+	if m.Search == nil || m.Search.EmbeddingModel == "" {
+		return fmt.Errorf("semantic search needs search.embedding_model in cortex.md (then: noema embeddings backfill)")
+	}
+	endpoint := m.ResolvedEmbeddingEndpoint()
+	if endpoint == "" {
+		return fmt.Errorf("semantic search needs search.embedding_endpoint (or consolidation.local_llm_endpoint) in cortex.md")
+	}
+	client, err := consolidation.NewHTTPLLMClient(endpoint, m.ResolvedEmbeddingAPIKeyEnv())
+	if err != nil {
+		return fmt.Errorf("embedding client: %w", err)
+	}
+	res, err := cx.SemanticSearch(cmd.Context(), client, query, cortex.SemanticOpts{
+		Model:           m.Search.EmbeddingModel,
+		IncludeArchived: includeArchived,
+	})
+	if err != nil {
+		return fmt.Errorf("semantic search failed: %w", err)
+	}
+	if len(res) == 0 {
+		fmt.Println("No matching traces.")
+		return nil
+	}
+	rows := make([]cortex.Row, len(res))
+	for i, r := range res {
+		rows[i] = r.Row
+	}
+	printTable(rows)
+	return nil
 }

--- a/internal/cli/cmd_search.go
+++ b/internal/cli/cmd_search.go
@@ -15,6 +15,7 @@ func searchCmd() *cobra.Command {
 		trashed  bool
 		all      bool
 		semantic bool
+		hybrid   bool
 		typ      string
 	)
 
@@ -29,8 +30,8 @@ func searchCmd() *cobra.Command {
 			}
 			defer cx.Close()
 
-			if semantic {
-				return runSemanticSearch(cmd, cx, args[0], all || archived)
+			if semantic || hybrid {
+				return runVectorSearch(cmd, cx, args[0], all || archived, hybrid)
 			}
 
 			rows, err := cx.Search(args[0], cortex.ListOptions{
@@ -54,15 +55,17 @@ func searchCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&archived, "archived", false, "search only archived traces")
 	cmd.Flags().BoolVar(&trashed, "trashed", false, "search only trashed traces")
 	cmd.Flags().BoolVar(&all, "all", false, "search active and archived traces")
-	cmd.Flags().BoolVar(&semantic, "semantic", false, "rank by embedding similarity (needs a configured search: block + `noema embeddings backfill`)")
+	cmd.Flags().BoolVar(&semantic, "semantic", false, "rank by embedding similarity (needs a configured search: block + backfilled embeddings)")
+	cmd.Flags().BoolVar(&hybrid, "hybrid", false, "fuse lexical (FTS5) + semantic rankings via reciprocal rank fusion")
 	cmd.Flags().StringVar(&typ, "type", "", "filter results by type")
 	return cmd
 }
 
-// runSemanticSearch builds the embedder from the cortex manifest and ranks
-// traces by embedding similarity. Kept separate so the lexical path stays
+// runVectorSearch builds the embedder from the cortex manifest and ranks
+// traces by embedding similarity (hybrid=false) or by RRF fusion of lexical
+// + semantic (hybrid=true). Kept separate so the lexical path stays
 // untouched. The embedder reuses the consolidation endpoint config.
-func runSemanticSearch(cmd *cobra.Command, cx *cortex.Cortex, query string, includeArchived bool) error {
+func runVectorSearch(cmd *cobra.Command, cx *cortex.Cortex, query string, includeArchived, hybrid bool) error {
 	m, err := cortex.ReadManifest(cx.Dir)
 	if err != nil {
 		return err
@@ -78,12 +81,15 @@ func runSemanticSearch(cmd *cobra.Command, cx *cortex.Cortex, query string, incl
 	if err != nil {
 		return fmt.Errorf("embedding client: %w", err)
 	}
-	res, err := cx.SemanticSearch(cmd.Context(), client, query, cortex.SemanticOpts{
-		Model:           m.Search.EmbeddingModel,
-		IncludeArchived: includeArchived,
-	})
+	opts := cortex.SemanticOpts{Model: m.Search.EmbeddingModel, IncludeArchived: includeArchived}
+	var res []cortex.ScoredRow
+	if hybrid {
+		res, err = cx.HybridSearch(cmd.Context(), client, query, opts, m.Search.EffectiveHybridWeight())
+	} else {
+		res, err = cx.SemanticSearch(cmd.Context(), client, query, opts)
+	}
 	if err != nil {
-		return fmt.Errorf("semantic search failed: %w", err)
+		return fmt.Errorf("vector search failed: %w", err)
 	}
 	if len(res) == 0 {
 		fmt.Println("No matching traces.")

--- a/internal/cli/cmd_serve.go
+++ b/internal/cli/cmd_serve.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
@@ -19,6 +20,7 @@ import (
 	"github.com/Fail-Safe/Noema/internal/config"
 	"github.com/Fail-Safe/Noema/internal/consolidation"
 	"github.com/Fail-Safe/Noema/internal/cortex"
+	"github.com/Fail-Safe/Noema/internal/embed"
 	"github.com/Fail-Safe/Noema/internal/federation"
 	"github.com/Fail-Safe/Noema/internal/lock"
 	mcpserver "github.com/Fail-Safe/Noema/internal/mcp"
@@ -29,17 +31,17 @@ import (
 
 func serveCmd() *cobra.Command {
 	var (
-		transport         string
-		hosts             []string
-		port              int
+		transport            string
+		hosts                []string
+		port                 int
 		tlsCert              string
 		tlsKey               string
 		insecureAllowExpired bool
 		logFile              string
-		logStderr         bool
-		printConfig       bool
-		printSystemdUnit  bool
-		printLaunchdPlist bool
+		logStderr            bool
+		printConfig          bool
+		printSystemdUnit     bool
+		printLaunchdPlist    bool
 	)
 
 	cmd := &cobra.Command{
@@ -138,6 +140,7 @@ func serveCmd() *cobra.Command {
 			var eligibility *consolidation.EligibilityLoop
 			var watchdog *consolidation.Watchdog
 			var certMonitor *mcpserver.CertMonitor
+			var embedMaintainer *embed.Maintainer
 
 			// Per-cortex background-work coordination. Concurrent serve
 			// processes on the same cortex (long-lived `--transport http`
@@ -226,6 +229,14 @@ func serveCmd() *cobra.Command {
 			// trash/update event for the same fsnotify trigger.
 			if gotLock && manifestErr == nil && m.Watch.WatchEnabled() {
 				watcher = startWatcher(cx, m.Watch)
+			}
+
+			// Embed maintainer: when semantic search is configured, keep the
+			// embedding index fresh by periodically backfilling new/edited
+			// traces. Gated on the background-work lock so only one serve
+			// process embeds per cortex (backfill is idempotent regardless).
+			if gotLock && manifestErr == nil && m.Search.SemanticOn() {
+				embedMaintainer = startEmbedMaintainer(cx, m)
 			}
 
 			// Consolidation agent: opt-in; drives memory-tier
@@ -434,6 +445,9 @@ func serveCmd() *cobra.Command {
 			if watcher != nil {
 				watcher.Stop()
 			}
+			if embedMaintainer != nil {
+				embedMaintainer.Stop()
+			}
 			if consolidator != nil {
 				consolidator.Stop()
 			}
@@ -499,6 +513,34 @@ func startWatcher(cx *cortex.Cortex, cfg *cortex.WatchConfig) *watch.Watcher {
 		return nil
 	}
 	return w
+}
+
+// startEmbedMaintainer wires the manifest's search config into a background
+// loop that periodically backfills semantic embeddings (idempotent). Returns
+// nil (and logs) when the embedder can't be built, so a misconfigured
+// endpoint degrades to "no auto-embed" rather than taking down serve.
+func startEmbedMaintainer(cx *cortex.Cortex, m cortex.Manifest) *embed.Maintainer {
+	model := ""
+	if m.Search != nil {
+		model = m.Search.EmbeddingModel
+	}
+	endpoint := m.ResolvedEmbeddingEndpoint()
+	if model == "" || endpoint == "" {
+		fmt.Printf("[embed] semantic enabled but model/endpoint unresolved; auto-embed disabled\n")
+		return nil
+	}
+	client, err := consolidation.NewHTTPLLMClient(endpoint, m.ResolvedEmbeddingAPIKeyEnv())
+	if err != nil {
+		fmt.Printf("[embed] client construct failed: %v (auto-embed disabled)\n", err)
+		return nil
+	}
+	maxChars := m.Search.EffectiveMaxChars()
+	mt := embed.New(m.Search.EffectiveEmbedInterval(), func(ctx context.Context) (int, error) {
+		res, err := cx.EmbedBackfill(ctx, client, model, cortex.EmbedBackfillOpts{MaxChars: maxChars})
+		return res.Embedded, err
+	})
+	mt.Start()
+	return mt
 }
 
 // startConsolidator wires the manifest's consolidation config into a

--- a/internal/cli/cmd_similar.go
+++ b/internal/cli/cmd_similar.go
@@ -16,6 +16,7 @@ func similarCmd() *cobra.Command {
 		limit    int
 		archived bool
 		semantic bool
+		hybrid   bool
 	)
 
 	cmd := &cobra.Command{
@@ -33,7 +34,7 @@ func similarCmd() *cobra.Command {
 			}
 			defer cx.Close()
 
-			if semantic {
+			if semantic || hybrid {
 				m, err := cortex.ReadManifest(cx.Dir)
 				if err != nil {
 					return err
@@ -41,13 +42,15 @@ func similarCmd() *cobra.Command {
 				if m.Search == nil || m.Search.EmbeddingModel == "" {
 					return fmt.Errorf("semantic mode needs search.embedding_model in cortex.md (then: noema embeddings backfill)")
 				}
-				res, err := cx.SemanticSimilar(args[0], cortex.SemanticOpts{
-					Model:           m.Search.EmbeddingModel,
-					Limit:           limit,
-					IncludeArchived: archived,
-				})
+				opts := cortex.SemanticOpts{Model: m.Search.EmbeddingModel, Limit: limit, IncludeArchived: archived}
+				var res []cortex.ScoredRow
+				if hybrid {
+					res, err = cx.HybridSimilar(args[0], opts, m.Search.EffectiveHybridWeight())
+				} else {
+					res, err = cx.SemanticSimilar(args[0], opts)
+				}
 				if err != nil {
-					return fmt.Errorf("semantic similar: %w", err)
+					return fmt.Errorf("vector similar: %w", err)
 				}
 				if len(res) == 0 {
 					fmt.Println("No similar traces found.")
@@ -80,6 +83,7 @@ func similarCmd() *cobra.Command {
 	cmd.Flags().IntVar(&limit, "limit", 10, "maximum matches to return")
 	cmd.Flags().BoolVar(&archived, "archived", false, "include archived traces in results")
 	cmd.Flags().BoolVar(&semantic, "semantic", false, "rank by embedding similarity instead of FTS5 (needs backfilled embeddings)")
+	cmd.Flags().BoolVar(&hybrid, "hybrid", false, "fuse lexical + semantic similarity via reciprocal rank fusion")
 	return cmd
 }
 

--- a/internal/cli/cmd_similar.go
+++ b/internal/cli/cmd_similar.go
@@ -15,6 +15,7 @@ func similarCmd() *cobra.Command {
 	var (
 		limit    int
 		archived bool
+		semantic bool
 	)
 
 	cmd := &cobra.Command{
@@ -22,7 +23,8 @@ func similarCmd() *cobra.Command {
 		Short: "Find traces with overlapping vocabulary to a given trace",
 		Long: "Surface related traces by FTS5 BM25 ranking against the source trace's most\n" +
 			"distinctive vocabulary. No embedding model required — pure SQLite full-text\n" +
-			"search.",
+			"search. Use --semantic to rank by embedding similarity instead (needs a\n" +
+			"configured search: block and backfilled embeddings).",
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cx, err := resolveCortex()
@@ -30,6 +32,34 @@ func similarCmd() *cobra.Command {
 				return err
 			}
 			defer cx.Close()
+
+			if semantic {
+				m, err := cortex.ReadManifest(cx.Dir)
+				if err != nil {
+					return err
+				}
+				if m.Search == nil || m.Search.EmbeddingModel == "" {
+					return fmt.Errorf("semantic mode needs search.embedding_model in cortex.md (then: noema embeddings backfill)")
+				}
+				res, err := cx.SemanticSimilar(args[0], cortex.SemanticOpts{
+					Model:           m.Search.EmbeddingModel,
+					Limit:           limit,
+					IncludeArchived: archived,
+				})
+				if err != nil {
+					return fmt.Errorf("semantic similar: %w", err)
+				}
+				if len(res) == 0 {
+					fmt.Println("No similar traces found.")
+					return nil
+				}
+				rows := make([]cortex.Row, len(res))
+				for i, r := range res {
+					rows[i] = r.Row
+				}
+				printTable(rows)
+				return nil
+			}
 
 			matches, err := cx.FindSimilar(args[0], cortex.SimilarOpts{
 				Limit:           limit,
@@ -49,6 +79,7 @@ func similarCmd() *cobra.Command {
 
 	cmd.Flags().IntVar(&limit, "limit", 10, "maximum matches to return")
 	cmd.Flags().BoolVar(&archived, "archived", false, "include archived traces in results")
+	cmd.Flags().BoolVar(&semantic, "semantic", false, "rank by embedding similarity instead of FTS5 (needs backfilled embeddings)")
 	return cmd
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -116,7 +116,7 @@ func init() {
 	addGrouped(groupTrace,
 		addCmd(), listCmd(), getCmd(), editCmd(), appendCmd(), removeCmd(),
 		searchCmd(), similarCmd(), archiveCmd(), unarchiveCmd(), recoverCmd(), purgeCmd(), syncCmd(),
-		eventsCmd(), resolveCmd(), memoryCmd(), consolidateCmd(),
+		eventsCmd(), resolveCmd(), memoryCmd(), consolidateCmd(), embeddingsCmd(),
 	)
 	addGrouped(groupCortex,
 		initCmd(), useCmd(), cortexCmd(), federationCmd(), migrateCmd(),

--- a/internal/consolidation/llm.go
+++ b/internal/consolidation/llm.go
@@ -21,6 +21,14 @@ type LLMClient interface {
 	Complete(ctx context.Context, req CompletionRequest) (string, error)
 }
 
+// Embedder is the narrow interface the semantic-search path uses to turn
+// text into vectors. One method, mirroring LLMClient, so the search layer
+// and its tests can stub it without the HTTP dance. HTTPLLMClient
+// satisfies it, reusing the same endpoint/auth config as completions.
+type Embedder interface {
+	Embed(ctx context.Context, model string, inputs []string) ([][]float32, error)
+}
+
 // Message mirrors the OpenAI chat-completions message shape. All
 // providers this client targets (Ollama, LMStudio, llama.cpp server,
 // vLLM, OpenAI, Azure OpenAI) accept the same three roles.
@@ -192,4 +200,145 @@ func (c *HTTPLLMClient) Complete(ctx context.Context, req CompletionRequest) (st
 		}
 	}
 	return choice.Message.Content, nil
+}
+
+// embedRequestBody / embedResponseBody mirror the OpenAI /embeddings
+// shape, which Ollama, llama.cpp server, vLLM, LMStudio and OpenAI all
+// accept. `input` takes an array; `data` comes back with one entry per
+// input, each carrying an `index` aligning it to the request order.
+type embedRequestBody struct {
+	Model string   `json:"model"`
+	Input []string `json:"input"`
+}
+
+type embedResponseBody struct {
+	Data []struct {
+		Index     int       `json:"index"`
+		Embedding []float32 `json:"embedding"`
+	} `json:"data"`
+	Error *struct {
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+// defaultEmbedBatch caps how many inputs ride in one /embeddings call.
+// Local servers can choke on very large batches; 64 is a safe middle
+// ground that still amortizes the per-request overhead.
+const defaultEmbedBatch = 64
+
+// Embed returns one vector per input, preserving input order, by POSTing
+// to {Endpoint}/embeddings in batches of defaultEmbedBatch. An empty
+// inputs slice returns nil without making a request. Reuses the same
+// endpoint, API key, and HTTP client as Complete.
+func (c *HTTPLLMClient) Embed(ctx context.Context, model string, inputs []string) ([][]float32, error) {
+	if model == "" {
+		return nil, errors.New("embedding model is empty")
+	}
+	if len(inputs) == 0 {
+		return nil, nil
+	}
+	out := make([][]float32, 0, len(inputs))
+	for start := 0; start < len(inputs); start += defaultEmbedBatch {
+		end := min(start+defaultEmbedBatch, len(inputs))
+		vecs, err := c.embedBatch(ctx, model, inputs[start:end])
+		if err != nil {
+			return nil, fmt.Errorf("embedding batch [%d:%d]: %w", start, end, err)
+		}
+		out = append(out, vecs...)
+	}
+	return out, nil
+}
+
+func (c *HTTPLLMClient) embedBatch(ctx context.Context, model string, batch []string) ([][]float32, error) {
+	body, err := json.Marshal(embedRequestBody{Model: model, Input: batch})
+	if err != nil {
+		return nil, fmt.Errorf("encoding embeddings request: %w", err)
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, c.Endpoint+"/embeddings", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("building embeddings request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	if c.APIKey != "" {
+		httpReq.Header.Set("Authorization", "Bearer "+c.APIKey)
+	}
+
+	client := c.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("posting embeddings request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading embeddings response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		var parsed embedResponseBody
+		if json.Unmarshal(respBody, &parsed) == nil && parsed.Error != nil {
+			return nil, fmt.Errorf("embeddings endpoint %d: %s", resp.StatusCode, parsed.Error.Message)
+		}
+		snippet := string(respBody)
+		if len(snippet) > 256 {
+			snippet = snippet[:256] + "..."
+		}
+		return nil, fmt.Errorf("embeddings endpoint %d: %s", resp.StatusCode, snippet)
+	}
+
+	var parsed embedResponseBody
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return nil, fmt.Errorf("parsing embeddings response: %w", err)
+	}
+	if parsed.Error != nil {
+		return nil, fmt.Errorf("embeddings error: %s", parsed.Error.Message)
+	}
+	if len(parsed.Data) != len(batch) {
+		return nil, fmt.Errorf("embeddings response count %d != input count %d", len(parsed.Data), len(batch))
+	}
+
+	// Place by `index` when the provider returns a clean permutation of
+	// [0,len); otherwise fall back to response order (some servers omit or
+	// zero the index field). Either way the result aligns to the inputs.
+	byIndex := indicesArePermutation(parsed.Data, len(batch))
+	vecs := make([][]float32, len(batch))
+	for i, d := range parsed.Data {
+		slot := i
+		if byIndex {
+			slot = d.Index
+		}
+		if len(d.Embedding) == 0 {
+			return nil, fmt.Errorf("embeddings response has an empty vector at slot %d", slot)
+		}
+		// Non-finite guard is unnecessary here: encoding/json rejects NaN
+		// and out-of-range (±Inf) numbers when decoding into []float32, so
+		// vectors that reach this point are already finite. The decode→rank
+		// consumer path (Phase 3) validates finiteness of stored vectors,
+		// where a corrupted BLOB — not the wire — is the real risk.
+		vecs[slot] = d.Embedding
+	}
+	return vecs, nil
+}
+
+// indicesArePermutation reports whether the response's index fields form a
+// distinct, in-range covering of [0,n) — i.e. trustworthy for placement.
+func indicesArePermutation(data []struct {
+	Index     int       `json:"index"`
+	Embedding []float32 `json:"embedding"`
+}, n int) bool {
+	if len(data) != n {
+		return false
+	}
+	seen := make([]bool, n)
+	for _, d := range data {
+		if d.Index < 0 || d.Index >= n || seen[d.Index] {
+			return false
+		}
+		seen[d.Index] = true
+	}
+	return true
 }

--- a/internal/consolidation/llm_test.go
+++ b/internal/consolidation/llm_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -122,5 +123,238 @@ func TestHTTPLLMClient_EmptyChoicesTreatedAsError(t *testing.T) {
 func TestNewHTTPLLMClient_ValidatesEndpoint(t *testing.T) {
 	if _, err := NewHTTPLLMClient("", ""); err == nil {
 		t.Error("empty endpoint should error")
+	}
+}
+
+// TestHTTPLLMClient_Embed verifies the /embeddings envelope: path, auth,
+// model, input-order preservation, and batching across the
+// defaultEmbedBatch boundary. The fake server encodes each input's numeric
+// suffix into the returned vector so alignment is checkable.
+func TestHTTPLLMClient_Embed(t *testing.T) {
+	const wantModel = "nomic-embed-text"
+	const wantToken = "embed-token"
+	batches := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/embeddings" {
+			t.Errorf("endpoint path = %q, want /embeddings", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer "+wantToken {
+			t.Errorf("auth header = %q, want Bearer token", got)
+		}
+		body, _ := io.ReadAll(r.Body)
+		var req embedRequestBody
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Fatalf("decoding request: %v", err)
+		}
+		if req.Model != wantModel {
+			t.Errorf("model = %q, want %q", req.Model, wantModel)
+		}
+		batches++
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("{\"data\":["))
+		for i, in := range req.Input {
+			n := strings.TrimPrefix(in, "t")
+			if i > 0 {
+				w.Write([]byte(","))
+			}
+			// vector = [suffix, 0.0]; index aligns to request order.
+			w.Write([]byte(`{"index":` + itoa(i) + `,"embedding":[` + n + `,0.0]}`))
+		}
+		w.Write([]byte("]}"))
+	}))
+	defer server.Close()
+
+	t.Setenv("TEST_EMBED_KEY", wantToken)
+	client, err := NewHTTPLLMClient(server.URL, "TEST_EMBED_KEY")
+	if err != nil {
+		t.Fatalf("NewHTTPLLMClient: %v", err)
+	}
+
+	// 150 inputs forces 3 batches (64+64+22).
+	inputs := make([]string, 150)
+	for i := range inputs {
+		inputs[i] = "t" + itoa(i)
+	}
+	got, err := client.Embed(context.Background(), wantModel, inputs)
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if len(got) != len(inputs) {
+		t.Fatalf("got %d vectors, want %d", len(got), len(inputs))
+	}
+	if batches != 3 {
+		t.Errorf("server saw %d batches, want 3 (chunking by defaultEmbedBatch)", batches)
+	}
+	for i, v := range got {
+		if len(v) != 2 {
+			t.Fatalf("vector %d has dim %d, want 2", i, len(v))
+		}
+		if int(v[0]) != i {
+			t.Errorf("vector %d carries suffix %v, want %d (order not preserved across batches)", i, v[0], i)
+		}
+	}
+}
+
+// TestHTTPLLMClient_EmbedReindexes verifies that an out-of-order response
+// (data shuffled but carrying correct index fields) is realigned.
+func TestHTTPLLMClient_EmbedReindexes(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// Two inputs returned in reverse, but index fields are correct.
+		w.Write([]byte(`{"data":[{"index":1,"embedding":[1.0]},{"index":0,"embedding":[0.0]}]}`))
+	}))
+	defer server.Close()
+
+	client, err := NewHTTPLLMClient(server.URL, "")
+	if err != nil {
+		t.Fatalf("NewHTTPLLMClient: %v", err)
+	}
+	got, err := client.Embed(context.Background(), "m", []string{"a", "b"})
+	if err != nil {
+		t.Fatalf("Embed: %v", err)
+	}
+	if got[0][0] != 0.0 || got[1][0] != 1.0 {
+		t.Errorf("reindex failed: got[0]=%v got[1]=%v, want [0] then [1]", got[0], got[1])
+	}
+}
+
+func itoa(i int) string { return strconv.Itoa(i) }
+
+// TestHTTPLLMClient_EmbedValidation covers the early-return guards: an
+// empty model errors without a request, and empty/nil inputs return
+// (nil, nil) without hitting the server.
+func TestHTTPLLMClient_EmbedValidation(t *testing.T) {
+	hit := false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		w.Write([]byte(`{"data":[]}`))
+	}))
+	defer server.Close()
+	client, err := NewHTTPLLMClient(server.URL, "")
+	if err != nil {
+		t.Fatalf("NewHTTPLLMClient: %v", err)
+	}
+
+	if _, err := client.Embed(context.Background(), "", []string{"a"}); err == nil {
+		t.Error("empty model should error")
+	}
+	if got, err := client.Embed(context.Background(), "m", nil); err != nil || got != nil {
+		t.Errorf("nil inputs => (nil,nil); got (%v,%v)", got, err)
+	}
+	if got, err := client.Embed(context.Background(), "m", []string{}); err != nil || got != nil {
+		t.Errorf("empty inputs => (nil,nil); got (%v,%v)", got, err)
+	}
+	if hit {
+		t.Error("server must not be hit for invalid/empty input")
+	}
+}
+
+// TestHTTPLLMClient_EmbedCountMismatch: a short response (fewer vectors
+// than inputs) must error rather than silently mis-aligning vectors to
+// traces.
+func TestHTTPLLMClient_EmbedCountMismatch(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"data":[{"index":0,"embedding":[1.0]}]}`)) // 1 vector for 2 inputs
+	}))
+	defer server.Close()
+	client, _ := NewHTTPLLMClient(server.URL, "")
+	_, err := client.Embed(context.Background(), "m", []string{"a", "b"})
+	if err == nil || !strings.Contains(err.Error(), "count") {
+		t.Errorf("expected count-mismatch error, got %v", err)
+	}
+}
+
+// TestHTTPLLMClient_EmbedErrorStatus covers the non-200 branch in
+// embedBatch (separate from Complete's): structured error message and the
+// truncated raw-body fallback.
+func TestHTTPLLMClient_EmbedErrorStatus(t *testing.T) {
+	structured := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error":{"message":"bad model name"}}`))
+	}))
+	defer structured.Close()
+	c1, _ := NewHTTPLLMClient(structured.URL, "")
+	if _, err := c1.Embed(context.Background(), "m", []string{"a"}); err == nil || !strings.Contains(err.Error(), "bad model name") {
+		t.Errorf("expected structured error surfaced, got %v", err)
+	}
+
+	raw := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(strings.Repeat("X", 600))) // > 256, must be truncated
+	}))
+	defer raw.Close()
+	c2, _ := NewHTTPLLMClient(raw.URL, "")
+	_, err := c2.Embed(context.Background(), "m", []string{"a"})
+	if err == nil || !strings.Contains(err.Error(), "...") {
+		t.Errorf("expected truncated raw-body error, got %v", err)
+	}
+}
+
+// TestHTTPLLMClient_EmbedEmptyVectorSlot: a datum with an empty embedding
+// array must error.
+func TestHTTPLLMClient_EmbedEmptyVectorSlot(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"data":[{"index":0,"embedding":[]}]}`))
+	}))
+	defer server.Close()
+	client, _ := NewHTTPLLMClient(server.URL, "")
+	_, err := client.Embed(context.Background(), "m", []string{"a"})
+	if err == nil || !strings.Contains(err.Error(), "empty vector") {
+		t.Errorf("expected empty-vector error, got %v", err)
+	}
+}
+
+// TestHTTPLLMClient_EmbedNonFiniteRejectedByJSON documents the actual
+// safeguard: encoding/json rejects out-of-range (±Inf) and NaN numbers when
+// decoding into []float32, so a non-finite vector can never arrive over the
+// wire — it surfaces as a parse error rather than a poisoned vector.
+func TestHTTPLLMClient_EmbedNonFiniteRejectedByJSON(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"data":[{"index":0,"embedding":[1e999, 0.5]}]}`))
+	}))
+	defer server.Close()
+	client, _ := NewHTTPLLMClient(server.URL, "")
+	if _, err := client.Embed(context.Background(), "m", []string{"a"}); err == nil {
+		t.Error("expected the JSON decoder to reject an out-of-range (±Inf) number")
+	}
+}
+
+// TestHTTPLLMClient_EmbedMultiBatchOneFails: when a later batch fails, the
+// whole call aborts with a wrapped error rather than returning a short
+// slice.
+func TestHTTPLLMClient_EmbedMultiBatchOneFails(t *testing.T) {
+	calls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls >= 2 {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write([]byte(`{"error":{"message":"boom"}}`))
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		var req embedRequestBody
+		_ = json.Unmarshal(body, &req)
+		w.Write([]byte("{\"data\":["))
+		for i := range req.Input {
+			if i > 0 {
+				w.Write([]byte(","))
+			}
+			w.Write([]byte(`{"index":` + itoa(i) + `,"embedding":[0.1]}`))
+		}
+		w.Write([]byte("]}"))
+	}))
+	defer server.Close()
+	client, _ := NewHTTPLLMClient(server.URL, "")
+	inputs := make([]string, 100) // forces 2 batches
+	for i := range inputs {
+		inputs[i] = "t" + itoa(i)
+	}
+	got, err := client.Embed(context.Background(), "m", inputs)
+	if err == nil || !strings.Contains(err.Error(), "[64:100]") {
+		t.Errorf("expected wrapped second-batch error, got %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil result on batch failure, got len %d", len(got))
 	}
 }

--- a/internal/cortex/actor.go
+++ b/internal/cortex/actor.go
@@ -162,6 +162,30 @@ func (c *Cortex) SemanticSimilarAs(traceID string, opts SemanticOpts, actor Read
 	return res, nil
 }
 
+// HybridSearchAs is the actor-aware counterpart to HybridSearch.
+func (c *Cortex) HybridSearchAs(ctx context.Context, e Embedder, query string, opts SemanticOpts, weight float64, actor ReadActor, topN int) ([]ScoredRow, error) {
+	res, err := c.HybridSearch(ctx, e, query, opts, weight)
+	if err != nil {
+		return nil, err
+	}
+	if actor == ActorAgent && len(res) > 0 {
+		c.bumpSearchHitsForScored(res, topN)
+	}
+	return res, nil
+}
+
+// HybridSimilarAs is the actor-aware counterpart to HybridSimilar.
+func (c *Cortex) HybridSimilarAs(traceID string, opts SemanticOpts, weight float64, actor ReadActor, topN int) ([]ScoredRow, error) {
+	res, err := c.HybridSimilar(traceID, opts, weight)
+	if err != nil {
+		return nil, err
+	}
+	if actor == ActorAgent && len(res) > 0 {
+		c.bumpSearchHitsForScored(res, topN)
+	}
+	return res, nil
+}
+
 // bumpSearchHitsForScored adapts []ScoredRow to the shared bump path.
 func (c *Cortex) bumpSearchHitsForScored(res []ScoredRow, topN int) {
 	ids := make([]string, 0, len(res))

--- a/internal/cortex/actor.go
+++ b/internal/cortex/actor.go
@@ -1,6 +1,7 @@
 package cortex
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"time"
@@ -134,6 +135,42 @@ func (c *Cortex) FindSimilarAs(traceID string, opts SimilarOpts, actor ReadActor
 	}
 	c.bumpSearchHitsForIDs(ids, tiers, topN)
 	return matches, nil
+}
+
+// SemanticSearchAs is the actor-aware counterpart to SemanticSearch: same
+// top-N search_hit_count bump for ActorAgent as SearchAs.
+func (c *Cortex) SemanticSearchAs(ctx context.Context, e Embedder, query string, opts SemanticOpts, actor ReadActor, topN int) ([]ScoredRow, error) {
+	res, err := c.SemanticSearch(ctx, e, query, opts)
+	if err != nil {
+		return nil, err
+	}
+	if actor == ActorAgent && len(res) > 0 {
+		c.bumpSearchHitsForScored(res, topN)
+	}
+	return res, nil
+}
+
+// SemanticSimilarAs is the actor-aware counterpart to SemanticSimilar.
+func (c *Cortex) SemanticSimilarAs(traceID string, opts SemanticOpts, actor ReadActor, topN int) ([]ScoredRow, error) {
+	res, err := c.SemanticSimilar(traceID, opts)
+	if err != nil {
+		return nil, err
+	}
+	if actor == ActorAgent && len(res) > 0 {
+		c.bumpSearchHitsForScored(res, topN)
+	}
+	return res, nil
+}
+
+// bumpSearchHitsForScored adapts []ScoredRow to the shared bump path.
+func (c *Cortex) bumpSearchHitsForScored(res []ScoredRow, topN int) {
+	ids := make([]string, 0, len(res))
+	tiers := make([]string, 0, len(res))
+	for _, r := range res {
+		ids = append(ids, r.ID)
+		tiers = append(tiers, r.Tier)
+	}
+	c.bumpSearchHitsForIDs(ids, tiers, topN)
 }
 
 // bumpSearchHitsForRows is the slice-of-Row entry point used by SearchAs.

--- a/internal/cortex/cortex.go
+++ b/internal/cortex/cortex.go
@@ -601,8 +601,9 @@ const (
 	SearchModeSemantic = "semantic"
 	SearchModeHybrid   = "hybrid"
 
-	defaultHybridWeight  = 0.5
-	defaultEmbedMaxChars = 32000
+	defaultHybridWeight         = 0.5
+	defaultEmbedMaxChars        = 32000
+	defaultEmbedIntervalSeconds = 300
 )
 
 // SearchConfig is the optional `search:` block in cortex.md. It is off by
@@ -641,6 +642,11 @@ type SearchConfig struct {
 	// MaxChars caps the trace text sent to the embedding model, to stay
 	// within model input limits. Zero/unset means defaultEmbedMaxChars.
 	MaxChars int `yaml:"max_chars,omitempty"`
+
+	// EmbedIntervalSeconds is how often the serve-time embed maintainer
+	// runs a backfill pass to embed new/edited traces. Zero/unset means
+	// defaultEmbedIntervalSeconds. Only used under `noema serve`.
+	EmbedIntervalSeconds int `yaml:"embed_interval_seconds,omitempty"`
 }
 
 // SemanticOn reports whether semantic search is enabled. Nil-safe.
@@ -678,6 +684,15 @@ func (sc *SearchConfig) EffectiveMaxChars() int {
 		return defaultEmbedMaxChars
 	}
 	return sc.MaxChars
+}
+
+// EffectiveEmbedInterval returns the serve-time backfill cadence, defaulting
+// to 5 minutes.
+func (sc *SearchConfig) EffectiveEmbedInterval() time.Duration {
+	if sc == nil || sc.EmbedIntervalSeconds <= 0 {
+		return defaultEmbedIntervalSeconds * time.Second
+	}
+	return time.Duration(sc.EmbedIntervalSeconds) * time.Second
 }
 
 // ResolvedEmbeddingEndpoint returns the embedding endpoint, falling back to

--- a/internal/cortex/cortex.go
+++ b/internal/cortex/cortex.go
@@ -1078,8 +1078,8 @@ they keep the database in sync automatically:
 | ` + "`create_trace`" + ` | Create a new trace (supports derived_from, origin) |
 | ` + "`update_trace`" + ` | Update fields of an existing trace |
 | ` + "`append_trace`" + ` | Append content to a trace body (fire-and-forget) |
-| ` + "`search_traces`" + ` | Full-text search across titles and bodies |
-| ` + "`find_similar_traces`" + ` | Surface traces with overlapping vocabulary (BM25-ranked) — useful when you have a trace in hand and want related ones without crafting a query |
+| ` + "`search_traces`" + ` | Search across titles and bodies. ` + "`mode`" + `: ` + "`lexical`" + ` (FTS5, default), ` + "`semantic`" + ` (embedding similarity), or ` + "`hybrid`" + ` (RRF fusion). Semantic/hybrid need a configured ` + "`search:`" + ` block; they fall back to lexical otherwise |
+| ` + "`find_similar_traces`" + ` | Surface traces related to one you have in hand. Default ranks by BM25 vocabulary overlap; ` + "`mode=semantic`" + `/` + "`hybrid`" + ` ranks by embedding similarity to the source trace's own vector |
 | ` + "`archive_trace`" + ` | Archive a trace |
 | ` + "`unarchive_trace`" + ` | Restore an archived trace |
 | ` + "`delete_trace`" + ` | Move a trace to trash (soft-delete, recoverable) |

--- a/internal/cortex/cortex.go
+++ b/internal/cortex/cortex.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -40,6 +41,7 @@ type Manifest struct {
 	Federation    *FederationConfig    `yaml:"federation,omitempty"`
 	Watch         *WatchConfig         `yaml:"watch,omitempty"`
 	Consolidation *ConsolidationConfig `yaml:"consolidation,omitempty"`
+	Search        *SearchConfig        `yaml:"search,omitempty"`
 
 	// Body is the free-form markdown content that follows the YAML
 	// frontmatter in cortex.md. Never serialized through YAML; populated
@@ -592,6 +594,154 @@ func (m Manifest) ValidateConsolidation() error {
 	return nil
 }
 
+// Search-mode identifiers. These string values are part of the frozen v1.0
+// surface (the MCP `mode` param and cortex.md `default_mode`); don't rename.
+const (
+	SearchModeLexical  = "lexical"
+	SearchModeSemantic = "semantic"
+	SearchModeHybrid   = "hybrid"
+
+	defaultHybridWeight  = 0.5
+	defaultEmbedMaxChars = 32000
+)
+
+// SearchConfig is the optional `search:` block in cortex.md. It is off by
+// default; semantic search requires SemanticEnabled plus a resolvable
+// embedding endpoint and an explicit embedding model. There is no
+// baked-in default model — we never imply a model we don't ship. The
+// embedding endpoint and API-key env-var fall back to the consolidation
+// block when left empty, so a single local-LLM host can serve both
+// distillation and embeddings from one configuration.
+type SearchConfig struct {
+	// SemanticEnabled is the master opt-in for embedding-based search.
+	// When false (the default), only lexical FTS5 search is available.
+	SemanticEnabled bool `yaml:"semantic_enabled,omitempty"`
+
+	// EmbeddingEndpoint is the OpenAI-compatible base URL for the
+	// /embeddings call. Empty inherits consolidation.local_llm_endpoint.
+	EmbeddingEndpoint string `yaml:"embedding_endpoint,omitempty"`
+
+	// EmbeddingModel is the embedding model identifier. Required when
+	// SemanticEnabled — there is no default.
+	EmbeddingModel string `yaml:"embedding_model,omitempty"`
+
+	// APIKeyEnv names an env var holding the bearer token for the
+	// embedding endpoint. Empty inherits consolidation.api_key_env.
+	APIKeyEnv string `yaml:"api_key_env,omitempty"`
+
+	// DefaultMode is the search mode used when a caller doesn't specify
+	// one: lexical|semantic|hybrid. Empty means lexical, which keeps
+	// existing callers byte-for-byte unchanged.
+	DefaultMode string `yaml:"default_mode,omitempty"`
+
+	// HybridWeight is the vector weight (0..1) in hybrid rank fusion.
+	// Zero/unset means the default 0.5 (equal lexical/semantic).
+	HybridWeight float64 `yaml:"hybrid_weight,omitempty"`
+
+	// MaxChars caps the trace text sent to the embedding model, to stay
+	// within model input limits. Zero/unset means defaultEmbedMaxChars.
+	MaxChars int `yaml:"max_chars,omitempty"`
+}
+
+// SemanticOn reports whether semantic search is enabled. Nil-safe.
+func (sc *SearchConfig) SemanticOn() bool { return sc != nil && sc.SemanticEnabled }
+
+// EffectiveDefaultMode returns the configured default mode or "lexical"
+// when unset.
+func (sc *SearchConfig) EffectiveDefaultMode() string {
+	if sc == nil || sc.DefaultMode == "" {
+		return SearchModeLexical
+	}
+	return sc.DefaultMode
+}
+
+// EffectiveHybridWeight returns the hybrid vector weight, defaulting to
+// 0.5 when unset and clamping to [0,1] otherwise. (An explicit 0 reads as
+// unset and yields the default; use mode=lexical for pure lexical.)
+func (sc *SearchConfig) EffectiveHybridWeight() float64 {
+	if sc == nil || sc.HybridWeight == 0 {
+		return defaultHybridWeight
+	}
+	if sc.HybridWeight < 0 {
+		return 0
+	}
+	if sc.HybridWeight > 1 {
+		return 1
+	}
+	return sc.HybridWeight
+}
+
+// EffectiveMaxChars returns the per-trace embedding text budget, defaulting
+// to 32k characters.
+func (sc *SearchConfig) EffectiveMaxChars() int {
+	if sc == nil || sc.MaxChars <= 0 {
+		return defaultEmbedMaxChars
+	}
+	return sc.MaxChars
+}
+
+// ResolvedEmbeddingEndpoint returns the embedding endpoint, falling back to
+// consolidation.local_llm_endpoint when the search block leaves it empty.
+func (m Manifest) ResolvedEmbeddingEndpoint() string {
+	if m.Search != nil && m.Search.EmbeddingEndpoint != "" {
+		return m.Search.EmbeddingEndpoint
+	}
+	if m.Consolidation != nil {
+		return m.Consolidation.LocalLLMEndpoint
+	}
+	return ""
+}
+
+// ResolvedEmbeddingAPIKeyEnv mirrors ResolvedEmbeddingEndpoint for the
+// API-key env-var name.
+func (m Manifest) ResolvedEmbeddingAPIKeyEnv() string {
+	if m.Search != nil && m.Search.APIKeyEnv != "" {
+		return m.Search.APIKeyEnv
+	}
+	if m.Consolidation != nil {
+		return m.Consolidation.APIKeyEnv
+	}
+	return ""
+}
+
+// ValidateSearch enforces the search block's cross-field rules: an
+// invalid default_mode is rejected even when semantic search is off (so a
+// typo surfaces early), and enabling semantic search requires an explicit
+// embedding model plus a resolvable, well-formed endpoint. Returns nil
+// when the block is absent and no mode override is set.
+func (m Manifest) ValidateSearch() error {
+	sc := m.Search
+	if sc != nil && sc.DefaultMode != "" && !validSearchMode(sc.DefaultMode) {
+		return fmt.Errorf("search.default_mode %q is not one of lexical|semantic|hybrid", sc.DefaultMode)
+	}
+	if !sc.SemanticOn() {
+		return nil
+	}
+	if sc.HybridWeight < 0 || sc.HybridWeight > 1 {
+		return fmt.Errorf("search.hybrid_weight must be in [0,1], got %v", sc.HybridWeight)
+	}
+	if sc.EmbeddingModel == "" {
+		return fmt.Errorf("search.semantic_enabled requires search.embedding_model to be set (no default embedding model is assumed)")
+	}
+	endpoint := m.ResolvedEmbeddingEndpoint()
+	if endpoint == "" {
+		return fmt.Errorf("search.semantic_enabled requires search.embedding_endpoint (or consolidation.local_llm_endpoint) to be set")
+	}
+	if _, err := url.Parse(endpoint); err != nil {
+		return fmt.Errorf("search.embedding_endpoint %q is not a valid URL: %w", endpoint, err)
+	}
+	return nil
+}
+
+func validSearchMode(mode string) bool {
+	switch mode {
+	case SearchModeLexical, SearchModeSemantic, SearchModeHybrid:
+		return true
+	default:
+		return false
+	}
+}
+
 // ReadManifest parses the cortex.md manifest in the given cortex directory.
 // cortex.md is a markdown file with YAML frontmatter: a `---` fence, the
 // manifest YAML, a closing `---` fence, and an optional free-form body.
@@ -614,6 +764,9 @@ func ReadManifest(dir string) (Manifest, error) {
 		return Manifest{}, err
 	}
 	if err := m.ValidateConsolidation(); err != nil {
+		return Manifest{}, err
+	}
+	if err := m.ValidateSearch(); err != nil {
 		return Manifest{}, err
 	}
 	return m, nil

--- a/internal/cortex/embedding.go
+++ b/internal/cortex/embedding.go
@@ -1,0 +1,63 @@
+package cortex
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"math"
+)
+
+// embeddingCodecVersion prefixes every stored embedding BLOB so a future
+// encoding (e.g. int8 quantization) can be introduced without ambiguity:
+// the decoder branches on this first byte.
+const embeddingCodecVersion byte = 1
+
+// encodeEmbedding serializes a float32 vector to the BLOB layout stored in
+// trace_embeddings.embedding: a 1-byte version tag followed by little-
+// endian float32 elements. Pure Go, no extension required — similarity is
+// computed in Go over the decoded slices.
+func encodeEmbedding(v []float32) []byte {
+	buf := make([]byte, 1+4*len(v))
+	buf[0] = embeddingCodecVersion
+	for i, f := range v {
+		binary.LittleEndian.PutUint32(buf[1+4*i:], math.Float32bits(f))
+	}
+	return buf
+}
+
+// decodeEmbedding reverses encodeEmbedding. It rejects an unknown version
+// tag and a payload whose length isn't a whole number of float32s.
+func decodeEmbedding(b []byte) ([]float32, error) {
+	if len(b) == 0 {
+		return nil, errors.New("empty embedding blob")
+	}
+	if b[0] != embeddingCodecVersion {
+		return nil, fmt.Errorf("unknown embedding codec version %d", b[0])
+	}
+	payload := b[1:]
+	if len(payload)%4 != 0 {
+		return nil, fmt.Errorf("embedding blob payload length %d is not a multiple of 4", len(payload))
+	}
+	out := make([]float32, len(payload)/4)
+	for i := range out {
+		out[i] = math.Float32frombits(binary.LittleEndian.Uint32(payload[4*i:]))
+	}
+	return out, nil
+}
+
+// normalizeEmbedding scales v to unit L2 norm in place so that cosine
+// similarity reduces to a plain dot product at query time. A zero vector
+// is left unchanged (no division by zero).
+func normalizeEmbedding(v []float32) {
+	var ss float64
+	for _, f := range v {
+		ss += float64(f) * float64(f)
+	}
+	if ss == 0 {
+		return
+	}
+	inv := float32(1 / math.Sqrt(ss))
+	for i := range v {
+		v[i] *= inv
+	}
+}

--- a/internal/cortex/embedding.go
+++ b/internal/cortex/embedding.go
@@ -1,11 +1,46 @@
 package cortex
 
 import (
+	"context"
 	"encoding/binary"
 	"errors"
 	"fmt"
 	"math"
+	"strings"
 )
+
+// Embedder turns text into vectors. Defined here (not imported from
+// consolidation) so the cortex package stays free of an import cycle —
+// consolidation.HTTPLLMClient satisfies this structurally and is injected
+// by the CLI/serve layer, which may import both packages.
+type Embedder interface {
+	Embed(ctx context.Context, model string, inputs []string) ([][]float32, error)
+}
+
+// embeddingText builds the string sent to the embedding model for a trace:
+// title and body joined, trimmed, and truncated to maxChars runes to stay
+// within model input limits. A blank body embeds the title alone (and vice
+// versa). Truncation is on a rune boundary so a multibyte character is
+// never split.
+func embeddingText(title, body string, maxChars int) string {
+	title = strings.TrimSpace(title)
+	body = strings.TrimSpace(body)
+	var s string
+	switch {
+	case body == "":
+		s = title
+	case title == "":
+		s = body
+	default:
+		s = title + "\n\n" + body
+	}
+	if maxChars > 0 {
+		if r := []rune(s); len(r) > maxChars {
+			s = string(r[:maxChars])
+		}
+	}
+	return s
+}
 
 // embeddingCodecVersion prefixes every stored embedding BLOB so a future
 // encoding (e.g. int8 quantization) can be introduced without ambiguity:

--- a/internal/cortex/embedding_backfill_test.go
+++ b/internal/cortex/embedding_backfill_test.go
@@ -1,0 +1,218 @@
+package cortex_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/Fail-Safe/Noema/internal/consolidation"
+	"github.com/Fail-Safe/Noema/internal/cortex"
+	"github.com/Fail-Safe/Noema/internal/trace"
+)
+
+// stubEmbedder is a deterministic cortex.Embedder for tests: no network,
+// returns one fixed-dim vector per input and records call/input counts.
+type stubEmbedder struct {
+	calls  int
+	inputs int
+	model  string
+	dim    int
+}
+
+func (s *stubEmbedder) Embed(ctx context.Context, model string, inputs []string) ([][]float32, error) {
+	s.calls++
+	s.model = model
+	s.inputs += len(inputs)
+	d := s.dim
+	if d == 0 {
+		d = 4
+	}
+	out := make([][]float32, len(inputs))
+	for i, in := range inputs {
+		v := make([]float32, d)
+		for j := range v {
+			v[j] = float32(len(in)%7 + j + 1)
+		}
+		out[i] = v
+	}
+	return out, nil
+}
+
+func seedTraces(t *testing.T, cx *cortex.Cortex, n int) []string {
+	t.Helper()
+	ids := make([]string, 0, n)
+	titles := []string{"alpha doc", "beta note", "gamma idea", "delta plan", "epsilon log"}
+	for i := range n {
+		tr := trace.New(titles[i%len(titles)], "note", "tester", nil, fmt.Sprintf("body number %d", i))
+		if err := cx.Add(tr); err != nil {
+			t.Fatalf("Add: %v", err)
+		}
+		ids = append(ids, tr.ID)
+	}
+	return ids
+}
+
+func TestEmbedBackfill_Lifecycle(t *testing.T) {
+	cx := setup(t)
+	ctx := context.Background()
+	ids := seedTraces(t, cx, 3)
+
+	// Initially everything is missing.
+	st, err := cx.EmbeddingStatus("m1")
+	if err != nil {
+		t.Fatalf("EmbeddingStatus: %v", err)
+	}
+	if st.Embeddable != 3 || st.Missing != 3 || st.Embedded != 0 {
+		t.Fatalf("initial status = %+v, want embeddable=3 missing=3 embedded=0", st)
+	}
+
+	emb := &stubEmbedder{dim: 4}
+	res, err := cx.EmbedBackfill(ctx, emb, "m1", cortex.EmbedBackfillOpts{})
+	if err != nil {
+		t.Fatalf("EmbedBackfill: %v", err)
+	}
+	if res.Considered != 3 || res.Embedded != 3 {
+		t.Fatalf("backfill result = %+v, want considered=3 embedded=3", res)
+	}
+	if emb.model != "m1" {
+		t.Errorf("embedder saw model %q, want m1", emb.model)
+	}
+
+	st, _ = cx.EmbeddingStatus("m1")
+	if st.Embedded != 3 || st.Missing != 0 || st.Stale != 0 {
+		t.Fatalf("post-backfill status = %+v, want embedded=3", st)
+	}
+
+	// Idempotent: nothing stale, so a second run does no work.
+	res2, _ := cx.EmbedBackfill(ctx, emb, "m1", cortex.EmbedBackfillOpts{})
+	if res2.Considered != 0 || res2.Embedded != 0 {
+		t.Errorf("second run = %+v, want no work (idempotent)", res2)
+	}
+
+	// Stored row: dim correct and source_hash == content_hash.
+	var dim int
+	var sh, ch string
+	if err := cx.DB.QueryRow(`SELECT dim, source_hash FROM trace_embeddings WHERE trace_id=?`, ids[0]).Scan(&dim, &sh); err != nil {
+		t.Fatalf("read embedding row: %v", err)
+	}
+	if err := cx.DB.QueryRow(`SELECT content_hash FROM traces WHERE id=?`, ids[0]).Scan(&ch); err != nil {
+		t.Fatalf("read content_hash: %v", err)
+	}
+	if dim != 4 {
+		t.Errorf("stored dim = %d, want 4", dim)
+	}
+	if sh != ch || sh == "" {
+		t.Errorf("source_hash %q != content_hash %q", sh, ch)
+	}
+
+	// A body edit makes that trace stale again.
+	if err := cx.Append(ids[0], "appended content changes the body hash"); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	st, _ = cx.EmbeddingStatus("m1")
+	if st.Stale != 1 {
+		t.Fatalf("after body edit, stale = %d, want 1", st.Stale)
+	}
+	res3, _ := cx.EmbedBackfill(ctx, emb, "m1", cortex.EmbedBackfillOpts{})
+	if res3.Considered != 1 || res3.Embedded != 1 {
+		t.Errorf("re-embed after edit = %+v, want considered=1 embedded=1", res3)
+	}
+
+	// Switching models invalidates every row for the new model.
+	res4, _ := cx.EmbedBackfill(ctx, emb, "m2", cortex.EmbedBackfillOpts{})
+	if res4.Considered != 3 {
+		t.Errorf("model change considered = %d, want 3", res4.Considered)
+	}
+	if newSt, _ := cx.EmbeddingStatus("m2"); newSt.Embedded != 3 {
+		t.Errorf("m2 embedded = %d, want 3", newSt.Embedded)
+	}
+	if oldSt, _ := cx.EmbeddingStatus("m1"); oldSt.Embedded != 0 || oldSt.Stale != 3 {
+		t.Errorf("m1 status after switch = %+v, want embedded=0 stale=3", oldSt)
+	}
+}
+
+func TestEmbedBackfill_ForceAndLimit(t *testing.T) {
+	cx := setup(t)
+	ctx := context.Background()
+	seedTraces(t, cx, 3)
+	emb := &stubEmbedder{dim: 4}
+
+	if _, err := cx.EmbedBackfill(ctx, emb, "m", cortex.EmbedBackfillOpts{}); err != nil {
+		t.Fatalf("initial backfill: %v", err)
+	}
+	// Force re-embeds even up-to-date rows.
+	r, _ := cx.EmbedBackfill(ctx, emb, "m", cortex.EmbedBackfillOpts{Force: true})
+	if r.Considered != 3 || r.Embedded != 3 {
+		t.Errorf("force = %+v, want considered=3 embedded=3", r)
+	}
+	// Limit caps the run.
+	r2, _ := cx.EmbedBackfill(ctx, emb, "m", cortex.EmbedBackfillOpts{Force: true, Limit: 2})
+	if r2.Considered != 2 || r2.Embedded != 2 {
+		t.Errorf("limit=2 => %+v, want considered=2 embedded=2", r2)
+	}
+}
+
+// TestEmbedBackfill_WithRealHTTPClient runs the backfill through the actual
+// consolidation.HTTPLLMClient against an httptest /embeddings server,
+// proving the real client satisfies cortex.Embedder and the end-to-end
+// wiring stores vectors of the served dimension.
+func TestEmbedBackfill_WithRealHTTPClient(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			Input []string `json:"input"`
+		}
+		_ = json.Unmarshal(body, &req)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("{\"data\":["))
+		for i := range req.Input {
+			if i > 0 {
+				w.Write([]byte(","))
+			}
+			// 3-dim vector per input
+			w.Write([]byte(`{"index":` + strconv.Itoa(i) + `,"embedding":[0.1,0.2,0.3]}`))
+		}
+		w.Write([]byte("]}"))
+	}))
+	defer server.Close()
+
+	cx := setup(t)
+	ids := seedTraces(t, cx, 2)
+	client, err := consolidation.NewHTTPLLMClient(server.URL, "")
+	if err != nil {
+		t.Fatalf("NewHTTPLLMClient: %v", err)
+	}
+	res, err := cx.EmbedBackfill(context.Background(), client, "real-model", cortex.EmbedBackfillOpts{})
+	if err != nil {
+		t.Fatalf("EmbedBackfill: %v", err)
+	}
+	if res.Embedded != 2 {
+		t.Fatalf("embedded = %d, want 2", res.Embedded)
+	}
+	var dim int
+	if err := cx.DB.QueryRow(`SELECT dim FROM trace_embeddings WHERE trace_id=?`, ids[0]).Scan(&dim); err != nil {
+		t.Fatalf("read dim: %v", err)
+	}
+	if dim != 3 {
+		t.Errorf("stored dim = %d, want 3 (from server)", dim)
+	}
+	if st, _ := cx.EmbeddingStatus("real-model"); st.Embedded != 2 {
+		t.Errorf("status embedded = %d, want 2", st.Embedded)
+	}
+}
+
+func TestEmbedBackfill_Guards(t *testing.T) {
+	cx := setup(t)
+	ctx := context.Background()
+	if _, err := cx.EmbedBackfill(ctx, nil, "m", cortex.EmbedBackfillOpts{}); err == nil {
+		t.Error("nil embedder should error")
+	}
+	if _, err := cx.EmbedBackfill(ctx, &stubEmbedder{}, "", cortex.EmbedBackfillOpts{}); err == nil {
+		t.Error("empty model should error")
+	}
+}

--- a/internal/cortex/embedding_store.go
+++ b/internal/cortex/embedding_store.go
@@ -1,0 +1,187 @@
+package cortex
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/Fail-Safe/Noema/internal/trace"
+)
+
+// EmbeddingStatus summarizes semantic-search embedding coverage for a given
+// embedding model. "Embeddable" is every non-trashed trace (active +
+// archived); trashed traces are excluded by design. A trace is "embedded"
+// only when it has a row for the active model whose source_hash still
+// matches the trace's content_hash — otherwise it is "stale" (body changed
+// or a different model) or "missing" (no row at all).
+type EmbeddingStatus struct {
+	Model      string
+	Embeddable int
+	Embedded   int
+	Stale      int
+	Missing    int
+}
+
+// EmbeddingStatus computes coverage counts for model. A model of "" reports
+// everything as stale/missing (nothing matches an empty model), which is
+// the correct signal for a cortex that hasn't configured semantic search.
+func (c *Cortex) EmbeddingStatus(model string) (EmbeddingStatus, error) {
+	st := EmbeddingStatus{Model: model}
+	if err := c.DB.QueryRow(`SELECT COUNT(*) FROM traces WHERE trashed_at IS NULL`).Scan(&st.Embeddable); err != nil {
+		return st, fmt.Errorf("count embeddable: %w", err)
+	}
+	var withRow int
+	if err := c.DB.QueryRow(
+		`SELECT COUNT(*) FROM traces t JOIN trace_embeddings te ON te.trace_id = t.id WHERE t.trashed_at IS NULL`,
+	).Scan(&withRow); err != nil {
+		return st, fmt.Errorf("count embedding rows: %w", err)
+	}
+	if err := c.DB.QueryRow(
+		`SELECT COUNT(*) FROM traces t JOIN trace_embeddings te ON te.trace_id = t.id
+		 WHERE t.trashed_at IS NULL AND te.embedding_model = ? AND te.source_hash = t.content_hash`,
+		model,
+	).Scan(&st.Embedded); err != nil {
+		return st, fmt.Errorf("count embedded: %w", err)
+	}
+	st.Missing = st.Embeddable - withRow
+	st.Stale = withRow - st.Embedded
+	return st, nil
+}
+
+// EmbedBackfillOpts tunes a backfill run.
+type EmbedBackfillOpts struct {
+	Force     bool // re-embed every embeddable trace, ignoring staleness
+	Limit     int  // cap traces processed this run (0 = no cap)
+	MaxChars  int  // per-trace text budget (0 = default)
+	BatchSize int  // traces per Embed call (0 = 64)
+}
+
+// EmbedBackfillResult reports what a run did.
+type EmbedBackfillResult struct {
+	Considered int // candidates selected
+	Embedded   int // vectors computed and stored
+}
+
+// EmbedBackfill computes and stores embeddings for traces that are missing
+// or stale for model (or all embeddable traces when Force). It is
+// idempotent (a second run with no changes does nothing), resumable (each
+// batch is committed before the next, so a mid-run failure keeps prior
+// progress), and safe to run while serving (WAL). It never blocks a
+// mutation — callers invoke it explicitly (CLI) or on a schedule.
+//
+// Body text is read from each trace's markdown file (the source of truth);
+// the stored source_hash is the trace's content_hash at selection time, so
+// a later body edit re-marks the row stale.
+func (c *Cortex) EmbedBackfill(ctx context.Context, e Embedder, model string, opts EmbedBackfillOpts) (EmbedBackfillResult, error) {
+	var res EmbedBackfillResult
+	if e == nil {
+		return res, fmt.Errorf("embedder is nil")
+	}
+	if model == "" {
+		return res, fmt.Errorf("embedding model is empty")
+	}
+	batch := opts.BatchSize
+	if batch <= 0 {
+		batch = 64
+	}
+	maxChars := opts.MaxChars
+	if maxChars <= 0 {
+		maxChars = defaultEmbedMaxChars
+	}
+
+	q := `SELECT t.id, t.content_hash FROM traces t
+	      LEFT JOIN trace_embeddings te ON te.trace_id = t.id
+	      WHERE t.trashed_at IS NULL`
+	var args []any
+	if !opts.Force {
+		q += ` AND (te.trace_id IS NULL OR te.embedding_model != ? OR te.source_hash != t.content_hash)`
+		args = append(args, model)
+	}
+	q += ` ORDER BY t.created_at`
+	if opts.Limit > 0 {
+		q += ` LIMIT ?`
+		args = append(args, opts.Limit)
+	}
+
+	rows, err := c.DB.Query(q, args...)
+	if err != nil {
+		return res, fmt.Errorf("query candidates: %w", err)
+	}
+	type cand struct{ id, contentHash string }
+	var cands []cand
+	for rows.Next() {
+		var ce cand
+		if err := rows.Scan(&ce.id, &ce.contentHash); err != nil {
+			rows.Close()
+			return res, fmt.Errorf("scan candidate: %w", err)
+		}
+		cands = append(cands, ce)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return res, fmt.Errorf("iterate candidates: %w", err)
+	}
+	res.Considered = len(cands)
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	for start := 0; start < len(cands); start += batch {
+		if err := ctx.Err(); err != nil {
+			return res, err
+		}
+		end := min(start+batch, len(cands))
+		chunk := cands[start:end]
+
+		texts := make([]string, 0, len(chunk))
+		ids := make([]string, 0, len(chunk))
+		hashes := make([]string, 0, len(chunk))
+		for _, ce := range chunk {
+			r, err := c.Get(ce.id)
+			if err != nil {
+				continue // vanished mid-run; skip
+			}
+			t, err := trace.ParseFile(c.filePath(r))
+			if err != nil {
+				continue // unreadable/malformed; skip
+			}
+			texts = append(texts, embeddingText(r.Title, t.Body, maxChars))
+			ids = append(ids, ce.id)
+			hashes = append(hashes, ce.contentHash)
+		}
+		if len(texts) == 0 {
+			continue
+		}
+
+		vecs, err := e.Embed(ctx, model, texts)
+		if err != nil {
+			return res, fmt.Errorf("embed batch: %w", err)
+		}
+		if len(vecs) != len(texts) {
+			return res, fmt.Errorf("embedder returned %d vectors for %d inputs", len(vecs), len(texts))
+		}
+		for i := range ids {
+			v := vecs[i]
+			normalizeEmbedding(v)
+			if err := c.upsertEmbedding(ids[i], model, len(v), encodeEmbedding(v), hashes[i], now); err != nil {
+				return res, fmt.Errorf("store embedding for %s: %w", ids[i], err)
+			}
+			res.Embedded++
+		}
+	}
+	return res, nil
+}
+
+// upsertEmbedding inserts or replaces the embedding row for a trace.
+func (c *Cortex) upsertEmbedding(id, model string, dim int, blob []byte, sourceHash, updatedAt string) error {
+	_, err := c.DB.Exec(
+		`INSERT INTO trace_embeddings (trace_id, embedding_model, dim, embedding, source_hash, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?)
+		 ON CONFLICT(trace_id) DO UPDATE SET
+		   embedding_model = excluded.embedding_model,
+		   dim             = excluded.dim,
+		   embedding       = excluded.embedding,
+		   source_hash     = excluded.source_hash,
+		   updated_at      = excluded.updated_at`,
+		id, model, dim, blob, sourceHash, updatedAt,
+	)
+	return err
+}

--- a/internal/cortex/embedding_test.go
+++ b/internal/cortex/embedding_test.go
@@ -1,0 +1,133 @@
+package cortex
+
+import (
+	"math"
+	"testing"
+)
+
+func TestEmbeddingCodec_RoundTrip(t *testing.T) {
+	cases := [][]float32{
+		{},
+		{0},
+		{1.5, -2.25, 0, 3.0e-8, 1234.5},
+	}
+	for _, want := range cases {
+		blob := encodeEmbedding(want)
+		if len(blob) != 1+4*len(want) {
+			t.Fatalf("blob len = %d, want %d", len(blob), 1+4*len(want))
+		}
+		if blob[0] != embeddingCodecVersion {
+			t.Fatalf("version byte = %d, want %d", blob[0], embeddingCodecVersion)
+		}
+		got, err := decodeEmbedding(blob)
+		if err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if len(got) != len(want) {
+			t.Fatalf("decoded len = %d, want %d", len(got), len(want))
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("elem %d = %v, want %v", i, got[i], want[i])
+			}
+		}
+	}
+}
+
+func TestDecodeEmbedding_Errors(t *testing.T) {
+	if _, err := decodeEmbedding(nil); err == nil {
+		t.Error("empty blob should error")
+	}
+	if _, err := decodeEmbedding([]byte{0x02, 0, 0, 0, 0}); err == nil {
+		t.Error("unknown version byte should error")
+	}
+	if _, err := decodeEmbedding([]byte{embeddingCodecVersion, 0, 0, 0}); err == nil {
+		t.Error("payload not a multiple of 4 should error")
+	}
+}
+
+func TestNormalizeEmbedding(t *testing.T) {
+	v := []float32{3, 4} // norm 5
+	normalizeEmbedding(v)
+	var ss float64
+	for _, f := range v {
+		ss += float64(f) * float64(f)
+	}
+	if math.Abs(math.Sqrt(ss)-1) > 1e-6 {
+		t.Errorf("normalized norm = %v, want 1", math.Sqrt(ss))
+	}
+
+	zero := []float32{0, 0, 0}
+	normalizeEmbedding(zero) // must not divide by zero
+	for i, f := range zero {
+		if f != 0 {
+			t.Errorf("zero vector elem %d changed to %v", i, f)
+		}
+	}
+}
+
+// TestEmbeddingCodec_LargeVectorAndSpecials exercises a realistic 1536-dim
+// vector and confirms the bit-exact path preserves non-finite and signed-
+// zero values (a naive codec could corrupt these). Storage must be
+// faithful even if such values are later rejected at ingest.
+func TestEmbeddingCodec_LargeVectorAndSpecials(t *testing.T) {
+	const dim = 1536
+	v := make([]float32, dim)
+	for i := range v {
+		v[i] = float32(i)*0.001 - 0.5
+	}
+	v[0] = float32(math.NaN())
+	v[1] = float32(math.Inf(1))
+	v[2] = float32(math.Inf(-1))
+	v[3] = float32(math.Copysign(0, -1)) // -0.0
+
+	blob := encodeEmbedding(v)
+	if len(blob) != 1+4*dim {
+		t.Fatalf("blob len = %d, want %d", len(blob), 1+4*dim)
+	}
+	got, err := decodeEmbedding(blob)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got) != dim {
+		t.Fatalf("decoded len = %d, want %d", len(got), dim)
+	}
+	if !math.IsNaN(float64(got[0])) {
+		t.Errorf("NaN not preserved: %v", got[0])
+	}
+	if !math.IsInf(float64(got[1]), 1) || !math.IsInf(float64(got[2]), -1) {
+		t.Errorf("Inf not preserved: %v %v", got[1], got[2])
+	}
+	// bit-exact check for -0.0 and the rest
+	for i := 4; i < dim; i++ {
+		if math.Float32bits(got[i]) != math.Float32bits(v[i]) {
+			t.Fatalf("elem %d bits differ: got %x want %x", i, math.Float32bits(got[i]), math.Float32bits(v[i]))
+		}
+	}
+	if math.Float32bits(got[3]) != math.Float32bits(v[3]) {
+		t.Errorf("-0.0 not preserved: bits %x", math.Float32bits(got[3]))
+	}
+}
+
+// FuzzDecodeEmbedding guards the decoder against arbitrary bytes (a
+// corrupted or foreign-written trace_embeddings row). It must never panic;
+// on success the length/version invariants must hold.
+func FuzzDecodeEmbedding(f *testing.F) {
+	f.Add(encodeEmbedding([]float32{1, 2, 3}))
+	f.Add(encodeEmbedding(nil))
+	f.Add([]byte{})
+	f.Add([]byte{embeddingCodecVersion})
+	f.Add([]byte{0x02, 0, 0, 0, 0})
+	f.Fuzz(func(t *testing.T, b []byte) {
+		out, err := decodeEmbedding(b)
+		if err != nil {
+			return
+		}
+		if len(b) == 0 || b[0] != embeddingCodecVersion {
+			t.Fatalf("decode accepted invalid header: %v", b)
+		}
+		if len(b) != 1+4*len(out) {
+			t.Fatalf("len invariant broken: blob %d, out %d", len(b), len(out))
+		}
+	})
+}

--- a/internal/cortex/embedding_text_test.go
+++ b/internal/cortex/embedding_text_test.go
@@ -1,0 +1,35 @@
+package cortex
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestEmbeddingText(t *testing.T) {
+	if got := embeddingText("Title", "Body", 0); got != "Title\n\nBody" {
+		t.Errorf("title+body = %q", got)
+	}
+	if got := embeddingText("  Title  ", "  Body  ", 0); got != "Title\n\nBody" {
+		t.Errorf("trim = %q", got)
+	}
+	if got := embeddingText("Only title", "   ", 0); got != "Only title" {
+		t.Errorf("empty body => title only, got %q", got)
+	}
+	if got := embeddingText("", "Only body", 0); got != "Only body" {
+		t.Errorf("empty title => body only, got %q", got)
+	}
+	if got := embeddingText("  ", "  ", 0); got != "" {
+		t.Errorf("both empty => empty, got %q", got)
+	}
+
+	// Truncation is rune-bounded and never splits a multibyte character.
+	multi := strings.Repeat("héllo ", 100) // 'é' is 2 bytes
+	got := embeddingText(multi, "", 10)
+	if utf8.RuneCountInString(got) != 10 {
+		t.Errorf("truncated rune count = %d, want 10", utf8.RuneCountInString(got))
+	}
+	if !utf8.ValidString(got) {
+		t.Error("truncation produced invalid UTF-8")
+	}
+}

--- a/internal/cortex/manifest_search_test.go
+++ b/internal/cortex/manifest_search_test.go
@@ -1,0 +1,85 @@
+package cortex_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Fail-Safe/Noema/internal/cortex"
+)
+
+// TestManifest_SearchBlockRoundTrip is the highest-value Phase 1 serialization
+// guard: a populated `search:` block must survive WriteManifest -> ReadManifest
+// with every field intact. Catches a wrong/missing yaml tag, float drift on
+// hybrid_weight, or ValidateSearch (called inside ReadManifest) rejecting a
+// valid block.
+func TestManifest_SearchBlockRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := cortex.Create("searchcfg", dir); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cdir := filepath.Join(dir, "searchcfg")
+
+	m, err := cortex.ReadManifest(cdir)
+	if err != nil {
+		t.Fatalf("ReadManifest: %v", err)
+	}
+	want := &cortex.SearchConfig{
+		SemanticEnabled:   true,
+		EmbeddingEndpoint: "http://localhost:11434/v1",
+		EmbeddingModel:    "nomic-embed-text",
+		APIKeyEnv:         "EMB_KEY",
+		DefaultMode:       cortex.SearchModeHybrid,
+		HybridWeight:      0.7,
+		MaxChars:          16000,
+	}
+	m.Search = want
+	if err := cortex.WriteManifest(cdir, m); err != nil {
+		t.Fatalf("WriteManifest: %v", err)
+	}
+
+	m2, err := cortex.ReadManifest(cdir)
+	if err != nil {
+		t.Fatalf("ReadManifest (2): %v", err)
+	}
+	if m2.Search == nil {
+		t.Fatal("Search block lost on round-trip")
+	}
+	got := m2.Search
+	if got.SemanticEnabled != want.SemanticEnabled ||
+		got.EmbeddingEndpoint != want.EmbeddingEndpoint ||
+		got.EmbeddingModel != want.EmbeddingModel ||
+		got.APIKeyEnv != want.APIKeyEnv ||
+		got.DefaultMode != want.DefaultMode ||
+		got.HybridWeight != want.HybridWeight ||
+		got.MaxChars != want.MaxChars {
+		t.Errorf("round-trip mismatch:\n got  %+v\n want %+v", got, want)
+	}
+}
+
+// TestManifest_SearchBlockOmittedWhenNil confirms the back-compat promise:
+// a cortex with no search config writes no `search:` key, so older binaries
+// and lexical-only cortexes are unaffected.
+func TestManifest_SearchBlockOmittedWhenNil(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := cortex.Create("plaincfg", dir); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	cdir := filepath.Join(dir, "plaincfg")
+
+	m, err := cortex.ReadManifest(cdir)
+	if err != nil {
+		t.Fatalf("ReadManifest: %v", err)
+	}
+	if err := cortex.WriteManifest(cdir, m); err != nil {
+		t.Fatalf("WriteManifest: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(cdir, "cortex.md"))
+	if err != nil {
+		t.Fatalf("read cortex.md: %v", err)
+	}
+	if bytes.Contains(data, []byte("search:")) {
+		t.Errorf("cortex.md unexpectedly contains a search: block:\n%s", data)
+	}
+}

--- a/internal/cortex/search_config_test.go
+++ b/internal/cortex/search_config_test.go
@@ -1,0 +1,154 @@
+package cortex_test
+
+import (
+	"testing"
+
+	"github.com/Fail-Safe/Noema/internal/cortex"
+)
+
+func TestValidateSearch(t *testing.T) {
+	tests := []struct {
+		name    string
+		m       cortex.Manifest
+		wantErr bool
+	}{
+		{
+			name: "absent block is fine",
+			m:    cortex.Manifest{},
+		},
+		{
+			name:    "disabled but bad default_mode is rejected",
+			m:       cortex.Manifest{Search: &cortex.SearchConfig{DefaultMode: "fuzzy"}},
+			wantErr: true,
+		},
+		{
+			name: "disabled with valid default_mode is fine",
+			m:    cortex.Manifest{Search: &cortex.SearchConfig{DefaultMode: cortex.SearchModeHybrid}},
+		},
+		{
+			name:    "enabled without model is rejected",
+			m:       cortex.Manifest{Search: &cortex.SearchConfig{SemanticEnabled: true, EmbeddingEndpoint: "http://localhost:11434/v1"}},
+			wantErr: true,
+		},
+		{
+			name:    "enabled without any endpoint is rejected",
+			m:       cortex.Manifest{Search: &cortex.SearchConfig{SemanticEnabled: true, EmbeddingModel: "nomic-embed-text"}},
+			wantErr: true,
+		},
+		{
+			name: "enabled, endpoint inherited from consolidation, is fine",
+			m: cortex.Manifest{
+				Consolidation: &cortex.ConsolidationConfig{LocalLLMEndpoint: "http://localhost:11434/v1"},
+				Search:        &cortex.SearchConfig{SemanticEnabled: true, EmbeddingModel: "nomic-embed-text"},
+			},
+		},
+		{
+			name: "enabled with own endpoint + model is fine",
+			m: cortex.Manifest{Search: &cortex.SearchConfig{
+				SemanticEnabled:   true,
+				EmbeddingEndpoint: "http://localhost:11434/v1",
+				EmbeddingModel:    "nomic-embed-text",
+			}},
+		},
+		{
+			name: "hybrid_weight out of range is rejected",
+			m: cortex.Manifest{Search: &cortex.SearchConfig{
+				SemanticEnabled:   true,
+				EmbeddingEndpoint: "http://localhost:11434/v1",
+				EmbeddingModel:    "nomic-embed-text",
+				HybridWeight:      1.5,
+			}},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.m.ValidateSearch()
+			if tt.wantErr != (err != nil) {
+				t.Errorf("ValidateSearch() err = %v, wantErr = %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSearchConfigAccessors(t *testing.T) {
+	var nilCfg *cortex.SearchConfig
+	if nilCfg.SemanticOn() {
+		t.Error("nil config should report semantic off")
+	}
+	if nilCfg.EffectiveDefaultMode() != cortex.SearchModeLexical {
+		t.Error("nil config default mode should be lexical")
+	}
+	if nilCfg.EffectiveHybridWeight() != 0.5 {
+		t.Errorf("nil config hybrid weight = %v, want 0.5", nilCfg.EffectiveHybridWeight())
+	}
+	if nilCfg.EffectiveMaxChars() != 32000 {
+		t.Errorf("nil config max chars = %d, want 32000", nilCfg.EffectiveMaxChars())
+	}
+
+	// Clamp above 1.
+	hi := &cortex.SearchConfig{HybridWeight: 2}
+	if hi.EffectiveHybridWeight() != 1 {
+		t.Errorf("hybrid weight clamp = %v, want 1", hi.EffectiveHybridWeight())
+	}
+}
+
+func TestEffectiveBoundaries(t *testing.T) {
+	hw := []struct {
+		in   float64
+		want float64
+	}{
+		{1, 1},    // exactly 1 passes through
+		{0, 0.5},  // explicit-0 reads as unset -> default (documented quirk)
+		{-0.3, 0}, // negative clamps to 0
+		{0.25, 0.25},
+	}
+	for _, c := range hw {
+		got := (&cortex.SearchConfig{HybridWeight: c.in}).EffectiveHybridWeight()
+		if got != c.want {
+			t.Errorf("EffectiveHybridWeight(%v) = %v, want %v", c.in, got, c.want)
+		}
+	}
+
+	mc := []struct {
+		in   int
+		want int
+	}{
+		{0, 32000},  // unset -> default
+		{-5, 32000}, // negative -> default
+		{1, 1},      // positive passes through
+		{16000, 16000},
+	}
+	for _, c := range mc {
+		got := (&cortex.SearchConfig{MaxChars: c.in}).EffectiveMaxChars()
+		if got != c.want {
+			t.Errorf("EffectiveMaxChars(%d) = %d, want %d", c.in, got, c.want)
+		}
+	}
+}
+
+func TestResolvedEmbeddingEndpoint_Inheritance(t *testing.T) {
+	// Search block wins when set.
+	m := cortex.Manifest{
+		Consolidation: &cortex.ConsolidationConfig{LocalLLMEndpoint: "http://consolidation:1", APIKeyEnv: "C_KEY"},
+		Search:        &cortex.SearchConfig{EmbeddingEndpoint: "http://search:2", APIKeyEnv: "S_KEY"},
+	}
+	if got := m.ResolvedEmbeddingEndpoint(); got != "http://search:2" {
+		t.Errorf("endpoint = %q, want search override", got)
+	}
+	if got := m.ResolvedEmbeddingAPIKeyEnv(); got != "S_KEY" {
+		t.Errorf("apikeyenv = %q, want search override", got)
+	}
+
+	// Falls back to consolidation when search leaves them empty.
+	m2 := cortex.Manifest{
+		Consolidation: &cortex.ConsolidationConfig{LocalLLMEndpoint: "http://consolidation:1", APIKeyEnv: "C_KEY"},
+		Search:        &cortex.SearchConfig{SemanticEnabled: true, EmbeddingModel: "m"},
+	}
+	if got := m2.ResolvedEmbeddingEndpoint(); got != "http://consolidation:1" {
+		t.Errorf("endpoint = %q, want consolidation fallback", got)
+	}
+	if got := m2.ResolvedEmbeddingAPIKeyEnv(); got != "C_KEY" {
+		t.Errorf("apikeyenv = %q, want consolidation fallback", got)
+	}
+}

--- a/internal/cortex/semantic.go
+++ b/internal/cortex/semantic.go
@@ -127,6 +127,9 @@ func (c *Cortex) embedQuery(ctx context.Context, e Embedder, model, query string
 	if q == "" {
 		return nil, nil
 	}
+	if len(q) > MaxSearchQueryLen {
+		return nil, fmt.Errorf("query too long (%d chars, max %d)", len(q), MaxSearchQueryLen)
+	}
 	vecs, err := e.Embed(ctx, model, []string{q})
 	if err != nil {
 		return nil, fmt.Errorf("embedding query: %w", err)
@@ -240,6 +243,9 @@ func rrfFuse(lex []Row, sem []ScoredRow, weight float64, limit int) []ScoredRow 
 // BM25 relevance order (best first) — the lexical input to hybrid fusion.
 // Trashed excluded; archived excluded unless includeArchived.
 func (c *Cortex) lexicalRanked(query string, includeArchived bool) ([]Row, error) {
+	if len(query) > MaxSearchQueryLen {
+		return nil, fmt.Errorf("query too long (%d chars, max %d)", len(query), MaxSearchQueryLen)
+	}
 	ftsQuery := SanitizeFTS5Query(query)
 	if strings.TrimSpace(ftsQuery) == "" {
 		return nil, nil

--- a/internal/cortex/semantic.go
+++ b/internal/cortex/semantic.go
@@ -10,47 +10,41 @@ import (
 	"strings"
 )
 
-// ScoredRow is one semantic-search result: a trace row plus its cosine
-// similarity to the query (higher is closer; vectors are unit-normalized
-// so cosine equals the dot product).
+// ScoredRow is one ranked result: a trace row plus a score. For semantic
+// search the score is cosine similarity (higher is closer); for hybrid it
+// is the fused reciprocal-rank score (also higher-is-better, but on a
+// different scale — treat it as opaque ordering).
 type ScoredRow struct {
 	Row
 	Score float64
 }
 
-// SemanticOpts tunes a semantic query.
+// SemanticOpts tunes a semantic or hybrid query.
 type SemanticOpts struct {
 	Model           string // embedding model whose vectors to search
 	Limit           int    // max results (default 10)
 	IncludeArchived bool   // include archived traces (default false)
 }
 
-// SemanticSearch embeds the query string with e and ranks the cortex's
-// stored vectors (for opts.Model) by cosine similarity. Trashed traces are
-// always excluded; archived traces are excluded unless opts.IncludeArchived.
-// An empty query returns no results. The caller supplies the embedder so
-// the cortex package stays free of an import cycle.
-func (c *Cortex) SemanticSearch(ctx context.Context, e Embedder, query string, opts SemanticOpts) ([]ScoredRow, error) {
-	if e == nil {
-		return nil, errors.New("embedder is nil")
-	}
-	if opts.Model == "" {
-		return nil, errors.New("embedding model is empty")
-	}
-	q := strings.TrimSpace(query)
-	if q == "" {
-		return nil, nil
-	}
-	vecs, err := e.Embed(ctx, opts.Model, []string{q})
-	if err != nil {
-		return nil, fmt.Errorf("embedding query: %w", err)
-	}
-	if len(vecs) != 1 || len(vecs[0]) == 0 {
-		return nil, errors.New("embedder returned no query vector")
-	}
-	qv := vecs[0]
-	normalizeEmbedding(qv)
+// rrfK is the Reciprocal Rank Fusion constant. 60 is the value from the
+// original RRF paper and the de-facto default; it damps the contribution
+// of low-ranked items without a tuning knob.
+const rrfK = 60.0
 
+// hybridLexicalPool bounds how many lexical (FindSimilar) candidates feed
+// hybrid similarity fusion. Semantic contributes all embedded candidates;
+// the lexical BM25 side is naturally top-k, so we request a generous pool.
+const hybridLexicalPool = 50
+
+// SemanticSearch embeds the query with e and ranks the cortex's stored
+// vectors (for opts.Model) by cosine similarity. Trashed traces are always
+// excluded; archived traces are excluded unless opts.IncludeArchived. An
+// empty query returns no results.
+func (c *Cortex) SemanticSearch(ctx context.Context, e Embedder, query string, opts SemanticOpts) ([]ScoredRow, error) {
+	qv, err := c.embedQuery(ctx, e, opts.Model, query)
+	if err != nil || qv == nil {
+		return nil, err
+	}
 	cands, err := c.loadEmbeddedCandidates(opts.Model, opts.IncludeArchived, "")
 	if err != nil {
 		return nil, err
@@ -59,34 +53,111 @@ func (c *Cortex) SemanticSearch(ctx context.Context, e Embedder, query string, o
 }
 
 // SemanticSimilar ranks other traces against the stored vector of traceID
-// (no query embedding needed — it reuses the source trace's own vector, a
-// strictly better signal than the lexical FindSimilar's top-term proxy).
-// The source trace must already be embedded for opts.Model.
+// (no query embedding — it reuses the source trace's own vector). The
+// source trace must already be embedded for opts.Model.
 func (c *Cortex) SemanticSimilar(traceID string, opts SemanticOpts) ([]ScoredRow, error) {
-	if opts.Model == "" {
-		return nil, errors.New("embedding model is empty")
-	}
-	var blob []byte
-	err := c.DB.QueryRow(
-		`SELECT embedding FROM trace_embeddings WHERE trace_id = ? AND embedding_model = ?`,
-		traceID, opts.Model,
-	).Scan(&blob)
-	if errors.Is(err, sql.ErrNoRows) {
-		return nil, fmt.Errorf("trace %s has no %s embedding yet (run: noema embeddings backfill)", traceID, opts.Model)
-	}
+	qv, err := c.sourceVector(traceID, opts.Model)
 	if err != nil {
-		return nil, fmt.Errorf("loading source vector: %w", err)
+		return nil, err
 	}
-	qv, err := decodeEmbedding(blob)
-	if err != nil {
-		return nil, fmt.Errorf("decoding source vector: %w", err)
-	}
-	// Stored vectors are already normalized; no need to re-normalize.
 	cands, err := c.loadEmbeddedCandidates(opts.Model, opts.IncludeArchived, traceID)
 	if err != nil {
 		return nil, err
 	}
 	return topKCosine(qv, cands, effLimit(opts.Limit)), nil
+}
+
+// HybridSearch fuses lexical (FTS5 BM25) and semantic (embedding cosine)
+// rankings of the query via Reciprocal Rank Fusion, weighted by weight
+// (0 = pure lexical, 1 = pure semantic; clamped). Both rankers contribute
+// their full ranked lists; the fused top opts.Limit is returned.
+func (c *Cortex) HybridSearch(ctx context.Context, e Embedder, query string, opts SemanticOpts, weight float64) ([]ScoredRow, error) {
+	qv, err := c.embedQuery(ctx, e, opts.Model, query)
+	if err != nil || qv == nil {
+		return nil, err
+	}
+	cands, err := c.loadEmbeddedCandidates(opts.Model, opts.IncludeArchived, "")
+	if err != nil {
+		return nil, err
+	}
+	sem := topKCosine(qv, cands, 0)
+	lex, err := c.lexicalRanked(query, opts.IncludeArchived)
+	if err != nil {
+		return nil, err
+	}
+	return rrfFuse(lex, sem, weight, effLimit(opts.Limit)), nil
+}
+
+// HybridSimilar fuses lexical FindSimilar and SemanticSimilar rankings for
+// a source trace. Like HybridSearch, weight blends the two (0 = lexical,
+// 1 = semantic).
+func (c *Cortex) HybridSimilar(traceID string, opts SemanticOpts, weight float64) ([]ScoredRow, error) {
+	qv, err := c.sourceVector(traceID, opts.Model)
+	if err != nil {
+		return nil, err
+	}
+	cands, err := c.loadEmbeddedCandidates(opts.Model, opts.IncludeArchived, traceID)
+	if err != nil {
+		return nil, err
+	}
+	sem := topKCosine(qv, cands, 0)
+	lexMatches, err := c.FindSimilar(traceID, SimilarOpts{Limit: hybridLexicalPool, IncludeArchived: opts.IncludeArchived})
+	if err != nil {
+		return nil, err
+	}
+	lex := make([]Row, len(lexMatches))
+	for i := range lexMatches {
+		lex[i] = lexMatches[i].Row
+	}
+	return rrfFuse(lex, sem, weight, effLimit(opts.Limit)), nil
+}
+
+// embedQuery embeds and unit-normalizes a single query string. Returns
+// (nil, nil) for a blank query so callers can short-circuit to empty
+// results. The embedder/model guards live here so every query path shares
+// them.
+func (c *Cortex) embedQuery(ctx context.Context, e Embedder, model, query string) ([]float32, error) {
+	if e == nil {
+		return nil, errors.New("embedder is nil")
+	}
+	if model == "" {
+		return nil, errors.New("embedding model is empty")
+	}
+	q := strings.TrimSpace(query)
+	if q == "" {
+		return nil, nil
+	}
+	vecs, err := e.Embed(ctx, model, []string{q})
+	if err != nil {
+		return nil, fmt.Errorf("embedding query: %w", err)
+	}
+	if len(vecs) != 1 || len(vecs[0]) == 0 {
+		return nil, errors.New("embedder returned no query vector")
+	}
+	qv := vecs[0]
+	normalizeEmbedding(qv)
+	return qv, nil
+}
+
+// sourceVector loads and decodes the stored embedding for traceID under
+// model (already normalized at store time). Returns a clear error if the
+// trace isn't embedded yet.
+func (c *Cortex) sourceVector(traceID, model string) ([]float32, error) {
+	if model == "" {
+		return nil, errors.New("embedding model is empty")
+	}
+	var blob []byte
+	err := c.DB.QueryRow(
+		`SELECT embedding FROM trace_embeddings WHERE trace_id = ? AND embedding_model = ?`,
+		traceID, model,
+	).Scan(&blob)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("trace %s has no %s embedding yet (run: noema embeddings backfill)", traceID, model)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("loading source vector: %w", err)
+	}
+	return decodeEmbedding(blob)
 }
 
 func effLimit(l int) int {
@@ -103,9 +174,8 @@ type vectorCand struct {
 }
 
 // topKCosine ranks candidates by dot product against query (== cosine for
-// unit vectors), descending, and returns the top limit. Candidates whose
-// dimension differs from the query (e.g. a stale row from another model
-// that slipped through) are skipped rather than mis-scored.
+// unit vectors), descending, and returns the top limit (0 = all).
+// Candidates whose dimension differs from the query are skipped.
 func topKCosine(query []float32, cands []vectorCand, limit int) []ScoredRow {
 	out := make([]ScoredRow, 0, len(cands))
 	for _, c := range cands {
@@ -125,12 +195,88 @@ func topKCosine(query []float32, cands []vectorCand, limit int) []ScoredRow {
 	return out
 }
 
+// rrfFuse combines a lexical ranking (Rows in relevance order) and a
+// semantic ranking (ScoredRows in cosine order) by Reciprocal Rank Fusion:
+// each item gets sum over rankers of w_r / (rrfK + rank), with rank 1-based
+// and w split by weight (semantic) vs 1-weight (lexical). Items appearing
+// in both rankers accumulate from both. Ties break on ID for deterministic
+// output regardless of map/scan order. Returns the fused top limit.
+func rrfFuse(lex []Row, sem []ScoredRow, weight float64, limit int) []ScoredRow {
+	if weight < 0 {
+		weight = 0
+	}
+	if weight > 1 {
+		weight = 1
+	}
+	pos := make(map[string]int, len(lex)+len(sem))
+	var out []ScoredRow
+	add := func(r Row, contrib float64) {
+		if p, ok := pos[r.ID]; ok {
+			out[p].Score += contrib
+			return
+		}
+		pos[r.ID] = len(out)
+		out = append(out, ScoredRow{Row: r, Score: contrib})
+	}
+	for i, r := range lex {
+		add(r, (1-weight)/(rrfK+float64(i+1)))
+	}
+	for i, s := range sem {
+		add(s.Row, weight/(rrfK+float64(i+1)))
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Score != out[j].Score {
+			return out[i].Score > out[j].Score
+		}
+		return out[i].ID < out[j].ID
+	})
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}
+
+// lexicalRanked runs the query through FTS5 and returns matching rows in
+// BM25 relevance order (best first) — the lexical input to hybrid fusion.
+// Trashed excluded; archived excluded unless includeArchived.
+func (c *Cortex) lexicalRanked(query string, includeArchived bool) ([]Row, error) {
+	ftsQuery := SanitizeFTS5Query(query)
+	if strings.TrimSpace(ftsQuery) == "" {
+		return nil, nil
+	}
+	q := `SELECT t.id, t.title, t.type, t.tier, t.author, t.origin,
+	             t.archived_at, t.trashed_at, t.created_at, t.updated_at,
+	             t.content_hash, t.source_locked, t.source_hash
+	      FROM traces t
+	      JOIN traces_fts ON traces_fts.id = t.id
+	      WHERE traces_fts MATCH ? AND t.trashed_at IS NULL`
+	if !includeArchived {
+		q += ` AND t.archived_at IS NULL`
+	}
+	q += ` ORDER BY bm25(traces_fts)`
+
+	rows, err := c.DB.Query(q, ftsQuery)
+	if err != nil {
+		return nil, fmt.Errorf("lexical ranking query: %w", err)
+	}
+	defer rows.Close()
+	var out []Row
+	for rows.Next() {
+		r, err := scanRowWithNullable(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
 // loadEmbeddedCandidates returns every embedded, ranking-eligible trace for
 // model: non-trashed (archived excluded unless includeArchived), optionally
 // excluding excludeID (the source trace in a similarity query). Vectors
 // containing non-finite values (a corrupted BLOB) are skipped so they can't
-// poison ranking — the finiteness check the Phase-1 review flagged, applied
-// here at the consumer where stored vectors are actually read.
+// poison ranking — the finiteness check applied at the consumer where
+// stored vectors are read.
 func (c *Cortex) loadEmbeddedCandidates(model string, includeArchived bool, excludeID string) ([]vectorCand, error) {
 	q := `SELECT t.id, t.title, t.type, t.tier, t.author, t.origin,
 	             t.archived_at, t.trashed_at, t.created_at, t.updated_at,
@@ -167,30 +313,47 @@ func (c *Cortex) loadEmbeddedCandidates(model string, includeArchived bool, excl
 		); err != nil {
 			return nil, err
 		}
-		if archivedAt != nil {
-			r.ArchivedAt = *archivedAt
-		}
-		if trashedAt != nil {
-			r.TrashedAt = *trashedAt
-		}
-		if contentHash != nil {
-			r.ContentHash = *contentHash
-		}
-		if sourceHash != nil {
-			r.SourceHash = *sourceHash
-		}
-		r.SourceLocked = sourceLocked != 0
-
+		applyNullable(&r, archivedAt, trashedAt, contentHash, sourceHash, sourceLocked)
 		vec, err := decodeEmbedding(blob)
 		if err != nil || !allFinite(vec) {
 			continue // skip corrupted/non-finite vectors
 		}
 		out = append(out, vectorCand{row: r, vec: vec})
 	}
-	if err := rows.Err(); err != nil {
-		return nil, err
+	return out, rows.Err()
+}
+
+// scanRowWithNullable scans the standard 13-column trace projection (no
+// embedding) into a Row, handling the nullable columns.
+func scanRowWithNullable(rows *sql.Rows) (Row, error) {
+	var r Row
+	var archivedAt, trashedAt, contentHash, sourceHash *string
+	var sourceLocked int
+	if err := rows.Scan(
+		&r.ID, &r.Title, &r.Type, &r.Tier, &r.Author, &r.Origin,
+		&archivedAt, &trashedAt, &r.CreatedAt, &r.UpdatedAt,
+		&contentHash, &sourceLocked, &sourceHash,
+	); err != nil {
+		return r, err
 	}
-	return out, nil
+	applyNullable(&r, archivedAt, trashedAt, contentHash, sourceHash, sourceLocked)
+	return r, nil
+}
+
+func applyNullable(r *Row, archivedAt, trashedAt, contentHash, sourceHash *string, sourceLocked int) {
+	if archivedAt != nil {
+		r.ArchivedAt = *archivedAt
+	}
+	if trashedAt != nil {
+		r.TrashedAt = *trashedAt
+	}
+	if contentHash != nil {
+		r.ContentHash = *contentHash
+	}
+	if sourceHash != nil {
+		r.SourceHash = *sourceHash
+	}
+	r.SourceLocked = sourceLocked != 0
 }
 
 // allFinite reports whether every element of v is a finite number.

--- a/internal/cortex/semantic.go
+++ b/internal/cortex/semantic.go
@@ -1,0 +1,204 @@
+package cortex
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+)
+
+// ScoredRow is one semantic-search result: a trace row plus its cosine
+// similarity to the query (higher is closer; vectors are unit-normalized
+// so cosine equals the dot product).
+type ScoredRow struct {
+	Row
+	Score float64
+}
+
+// SemanticOpts tunes a semantic query.
+type SemanticOpts struct {
+	Model           string // embedding model whose vectors to search
+	Limit           int    // max results (default 10)
+	IncludeArchived bool   // include archived traces (default false)
+}
+
+// SemanticSearch embeds the query string with e and ranks the cortex's
+// stored vectors (for opts.Model) by cosine similarity. Trashed traces are
+// always excluded; archived traces are excluded unless opts.IncludeArchived.
+// An empty query returns no results. The caller supplies the embedder so
+// the cortex package stays free of an import cycle.
+func (c *Cortex) SemanticSearch(ctx context.Context, e Embedder, query string, opts SemanticOpts) ([]ScoredRow, error) {
+	if e == nil {
+		return nil, errors.New("embedder is nil")
+	}
+	if opts.Model == "" {
+		return nil, errors.New("embedding model is empty")
+	}
+	q := strings.TrimSpace(query)
+	if q == "" {
+		return nil, nil
+	}
+	vecs, err := e.Embed(ctx, opts.Model, []string{q})
+	if err != nil {
+		return nil, fmt.Errorf("embedding query: %w", err)
+	}
+	if len(vecs) != 1 || len(vecs[0]) == 0 {
+		return nil, errors.New("embedder returned no query vector")
+	}
+	qv := vecs[0]
+	normalizeEmbedding(qv)
+
+	cands, err := c.loadEmbeddedCandidates(opts.Model, opts.IncludeArchived, "")
+	if err != nil {
+		return nil, err
+	}
+	return topKCosine(qv, cands, effLimit(opts.Limit)), nil
+}
+
+// SemanticSimilar ranks other traces against the stored vector of traceID
+// (no query embedding needed — it reuses the source trace's own vector, a
+// strictly better signal than the lexical FindSimilar's top-term proxy).
+// The source trace must already be embedded for opts.Model.
+func (c *Cortex) SemanticSimilar(traceID string, opts SemanticOpts) ([]ScoredRow, error) {
+	if opts.Model == "" {
+		return nil, errors.New("embedding model is empty")
+	}
+	var blob []byte
+	err := c.DB.QueryRow(
+		`SELECT embedding FROM trace_embeddings WHERE trace_id = ? AND embedding_model = ?`,
+		traceID, opts.Model,
+	).Scan(&blob)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, fmt.Errorf("trace %s has no %s embedding yet (run: noema embeddings backfill)", traceID, opts.Model)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("loading source vector: %w", err)
+	}
+	qv, err := decodeEmbedding(blob)
+	if err != nil {
+		return nil, fmt.Errorf("decoding source vector: %w", err)
+	}
+	// Stored vectors are already normalized; no need to re-normalize.
+	cands, err := c.loadEmbeddedCandidates(opts.Model, opts.IncludeArchived, traceID)
+	if err != nil {
+		return nil, err
+	}
+	return topKCosine(qv, cands, effLimit(opts.Limit)), nil
+}
+
+func effLimit(l int) int {
+	if l <= 0 {
+		return 10
+	}
+	return l
+}
+
+// vectorCand pairs a row with its decoded embedding for ranking.
+type vectorCand struct {
+	row Row
+	vec []float32
+}
+
+// topKCosine ranks candidates by dot product against query (== cosine for
+// unit vectors), descending, and returns the top limit. Candidates whose
+// dimension differs from the query (e.g. a stale row from another model
+// that slipped through) are skipped rather than mis-scored.
+func topKCosine(query []float32, cands []vectorCand, limit int) []ScoredRow {
+	out := make([]ScoredRow, 0, len(cands))
+	for _, c := range cands {
+		if len(c.vec) != len(query) {
+			continue
+		}
+		var dot float64
+		for i := range query {
+			dot += float64(query[i]) * float64(c.vec[i])
+		}
+		out = append(out, ScoredRow{Row: c.row, Score: dot})
+	}
+	sort.SliceStable(out, func(a, b int) bool { return out[a].Score > out[b].Score })
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}
+
+// loadEmbeddedCandidates returns every embedded, ranking-eligible trace for
+// model: non-trashed (archived excluded unless includeArchived), optionally
+// excluding excludeID (the source trace in a similarity query). Vectors
+// containing non-finite values (a corrupted BLOB) are skipped so they can't
+// poison ranking — the finiteness check the Phase-1 review flagged, applied
+// here at the consumer where stored vectors are actually read.
+func (c *Cortex) loadEmbeddedCandidates(model string, includeArchived bool, excludeID string) ([]vectorCand, error) {
+	q := `SELECT t.id, t.title, t.type, t.tier, t.author, t.origin,
+	             t.archived_at, t.trashed_at, t.created_at, t.updated_at,
+	             t.content_hash, t.source_locked, t.source_hash,
+	             te.embedding
+	      FROM trace_embeddings te
+	      JOIN traces t ON t.id = te.trace_id
+	      WHERE te.embedding_model = ? AND t.trashed_at IS NULL`
+	args := []any{model}
+	if !includeArchived {
+		q += ` AND t.archived_at IS NULL`
+	}
+	if excludeID != "" {
+		q += ` AND t.id != ?`
+		args = append(args, excludeID)
+	}
+
+	rows, err := c.DB.Query(q, args...)
+	if err != nil {
+		return nil, fmt.Errorf("loading embedded candidates: %w", err)
+	}
+	defer rows.Close()
+
+	var out []vectorCand
+	for rows.Next() {
+		var r Row
+		var archivedAt, trashedAt, contentHash, sourceHash *string
+		var sourceLocked int
+		var blob []byte
+		if err := rows.Scan(
+			&r.ID, &r.Title, &r.Type, &r.Tier, &r.Author, &r.Origin,
+			&archivedAt, &trashedAt, &r.CreatedAt, &r.UpdatedAt,
+			&contentHash, &sourceLocked, &sourceHash, &blob,
+		); err != nil {
+			return nil, err
+		}
+		if archivedAt != nil {
+			r.ArchivedAt = *archivedAt
+		}
+		if trashedAt != nil {
+			r.TrashedAt = *trashedAt
+		}
+		if contentHash != nil {
+			r.ContentHash = *contentHash
+		}
+		if sourceHash != nil {
+			r.SourceHash = *sourceHash
+		}
+		r.SourceLocked = sourceLocked != 0
+
+		vec, err := decodeEmbedding(blob)
+		if err != nil || !allFinite(vec) {
+			continue // skip corrupted/non-finite vectors
+		}
+		out = append(out, vectorCand{row: r, vec: vec})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// allFinite reports whether every element of v is a finite number.
+func allFinite(v []float32) bool {
+	for _, f := range v {
+		if math.IsNaN(float64(f)) || math.IsInf(float64(f), 0) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/cortex/semantic_internal_test.go
+++ b/internal/cortex/semantic_internal_test.go
@@ -1,0 +1,40 @@
+package cortex
+
+import (
+	"math"
+	"testing"
+)
+
+func TestTopKCosine(t *testing.T) {
+	q := []float32{1, 0, 0}
+	cands := []vectorCand{
+		{row: Row{ID: "a"}, vec: []float32{1, 0, 0}},     // dot 1.0
+		{row: Row{ID: "b"}, vec: []float32{0, 1, 0}},     // dot 0.0
+		{row: Row{ID: "c"}, vec: []float32{0.7, 0.7, 0}}, // dot 0.7
+		{row: Row{ID: "d"}, vec: []float32{1, 0}},        // dim mismatch -> skipped
+	}
+	res := topKCosine(q, cands, 2)
+	if len(res) != 2 {
+		t.Fatalf("got %d results, want 2 (limit)", len(res))
+	}
+	if res[0].ID != "a" || res[1].ID != "c" {
+		t.Errorf("order = [%s %s], want [a c]", res[0].ID, res[1].ID)
+	}
+	// Limit 0 returns all rankable (dim-mismatch still excluded).
+	all := topKCosine(q, cands, 0)
+	if len(all) != 3 {
+		t.Errorf("limit 0 returned %d, want 3", len(all))
+	}
+}
+
+func TestAllFinite(t *testing.T) {
+	if !allFinite([]float32{1, -2, 0.5}) {
+		t.Error("finite vector reported non-finite")
+	}
+	if allFinite([]float32{1, float32(math.Inf(1)), 3}) {
+		t.Error("+Inf not detected")
+	}
+	if allFinite([]float32{float32(math.NaN())}) {
+		t.Error("NaN not detected")
+	}
+}

--- a/internal/cortex/semantic_internal_test.go
+++ b/internal/cortex/semantic_internal_test.go
@@ -27,6 +27,39 @@ func TestTopKCosine(t *testing.T) {
 	}
 }
 
+func TestRRFFuse(t *testing.T) {
+	lex := []Row{{ID: "a"}, {ID: "b"}, {ID: "c"}}                                     // lexical order a,b,c
+	sem := []ScoredRow{{Row: Row{ID: "c"}}, {Row: Row{ID: "d"}}, {Row: Row{ID: "a"}}} // semantic order c,d,a
+	ids := func(rs []ScoredRow) []string {
+		out := make([]string, len(rs))
+		for i := range rs {
+			out[i] = rs[i].ID
+		}
+		return out
+	}
+
+	// weight 0 => pure lexical order (items only in semantic get score 0, sink).
+	if got := ids(rrfFuse(lex, sem, 0, 0)); got[0] != "a" || got[1] != "b" || got[2] != "c" {
+		t.Errorf("weight 0 top3 = %v, want [a b c]", got[:3])
+	}
+	// weight 1 => pure semantic order.
+	if got := ids(rrfFuse(lex, sem, 1, 0)); got[0] != "c" || got[1] != "d" || got[2] != "a" {
+		t.Errorf("weight 1 top3 = %v, want [c d a]", got[:3])
+	}
+	// weight .5 => a & c tie (symmetric), b & d tie; ID breaks ties.
+	if got := ids(rrfFuse(lex, sem, 0.5, 0)); got[0] != "a" || got[1] != "c" || got[2] != "b" || got[3] != "d" {
+		t.Errorf("weight .5 = %v, want [a c b d]", got)
+	}
+	// limit truncates.
+	if l := rrfFuse(lex, sem, 0.5, 2); len(l) != 2 {
+		t.Errorf("limit 2 returned %d", len(l))
+	}
+	// weight > 1 clamps to 1 (same as semantic order).
+	if got := ids(rrfFuse(lex, sem, 5, 0)); got[0] != "c" {
+		t.Errorf("weight 5 should clamp to 1; top = %s, want c", got[0])
+	}
+}
+
 func TestAllFinite(t *testing.T) {
 	if !allFinite([]float32{1, -2, 0.5}) {
 		t.Error("finite vector reported non-finite")

--- a/internal/cortex/semantic_test.go
+++ b/internal/cortex/semantic_test.go
@@ -140,6 +140,49 @@ func TestSemanticSearch_SkipsNonFiniteVectors(t *testing.T) {
 	}
 }
 
+func TestHybridSearch_FusesAndRanks(t *testing.T) {
+	cx, ids := setupSemantic(t)
+	ctx := context.Background()
+
+	// "alpha" matches the alpha trace both lexically (title token) and
+	// semantically (topic vector), so it must rank first; semantic
+	// contributes the other topics, so all 3 appear.
+	res, err := cx.HybridSearch(ctx, topicEmbedder{}, "alpha alpha", cortex.SemanticOpts{Model: "tm"}, 0.5)
+	if err != nil {
+		t.Fatalf("HybridSearch: %v", err)
+	}
+	if len(res) != 3 {
+		t.Fatalf("got %d fused results, want 3", len(res))
+	}
+	if res[0].ID != ids[0] {
+		t.Errorf("top fused result = %s, want alpha trace %s", res[0].ID, ids[0])
+	}
+
+	// Blank query short-circuits; nil embedder errors.
+	if r, err := cx.HybridSearch(ctx, topicEmbedder{}, "  ", cortex.SemanticOpts{Model: "tm"}, 0.5); err != nil || r != nil {
+		t.Errorf("blank query => (nil,nil); got (%v,%v)", r, err)
+	}
+	if _, err := cx.HybridSearch(ctx, nil, "x", cortex.SemanticOpts{Model: "tm"}, 0.5); err == nil {
+		t.Error("nil embedder should error")
+	}
+}
+
+func TestHybridSimilar_ExcludesSource(t *testing.T) {
+	cx, ids := setupSemantic(t)
+	res, err := cx.HybridSimilar(ids[0], cortex.SemanticOpts{Model: "tm"}, 0.5)
+	if err != nil {
+		t.Fatalf("HybridSimilar: %v", err)
+	}
+	for _, r := range res {
+		if r.ID == ids[0] {
+			t.Error("source trace must be excluded from its own hybrid similarity")
+		}
+	}
+	if len(res) == 0 {
+		t.Error("expected fused similar results")
+	}
+}
+
 func TestSemanticSearch_Guards(t *testing.T) {
 	cx := setup(t)
 	ctx := context.Background()

--- a/internal/cortex/semantic_test.go
+++ b/internal/cortex/semantic_test.go
@@ -183,6 +183,18 @@ func TestHybridSimilar_ExcludesSource(t *testing.T) {
 	}
 }
 
+func TestSemanticSearch_QueryTooLong(t *testing.T) {
+	cx, _ := setupSemantic(t)
+	ctx := context.Background()
+	long := strings.Repeat("x", 1001) // > MaxSearchQueryLen (1000)
+	if _, err := cx.SemanticSearch(ctx, topicEmbedder{}, long, cortex.SemanticOpts{Model: "tm"}); err == nil {
+		t.Error("over-long semantic query should be rejected (DoS guard)")
+	}
+	if _, err := cx.HybridSearch(ctx, topicEmbedder{}, long, cortex.SemanticOpts{Model: "tm"}, 0.5); err == nil {
+		t.Error("over-long hybrid query should be rejected (DoS guard)")
+	}
+}
+
 func TestSemanticSearch_Guards(t *testing.T) {
 	cx := setup(t)
 	ctx := context.Background()

--- a/internal/cortex/semantic_test.go
+++ b/internal/cortex/semantic_test.go
@@ -1,0 +1,155 @@
+package cortex_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/Fail-Safe/Noema/internal/cortex"
+)
+
+// topicEmbedder maps text to a 3-dim "topic" vector by counting occurrences
+// of alpha/beta/gamma, so rankings are deterministic and assertable. (The
+// shared seedTraces helper makes trace i about alpha/beta/gamma by title.)
+type topicEmbedder struct{}
+
+func (topicEmbedder) Embed(ctx context.Context, model string, inputs []string) ([][]float32, error) {
+	out := make([][]float32, len(inputs))
+	for i, in := range inputs {
+		v := []float32{0.01, 0.01, 0.01}
+		for w := range strings.FieldsSeq(strings.ToLower(in)) {
+			switch {
+			case strings.Contains(w, "alpha"):
+				v[0]++
+			case strings.Contains(w, "beta"):
+				v[1]++
+			case strings.Contains(w, "gamma"):
+				v[2]++
+			}
+		}
+		out[i] = v
+	}
+	return out, nil
+}
+
+func setupSemantic(t *testing.T) (*cortex.Cortex, []string) {
+	t.Helper()
+	cx := setup(t)
+	ids := seedTraces(t, cx, 3) // 0=alpha, 1=beta, 2=gamma (by title)
+	if _, err := cx.EmbedBackfill(context.Background(), topicEmbedder{}, "tm", cortex.EmbedBackfillOpts{}); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+	return cx, ids
+}
+
+func TestSemanticSearch_RanksByTopic(t *testing.T) {
+	cx, ids := setupSemantic(t)
+	ctx := context.Background()
+
+	res, err := cx.SemanticSearch(ctx, topicEmbedder{}, "alpha alpha alpha", cortex.SemanticOpts{Model: "tm"})
+	if err != nil {
+		t.Fatalf("SemanticSearch: %v", err)
+	}
+	if len(res) != 3 {
+		t.Fatalf("got %d results, want 3", len(res))
+	}
+	if res[0].ID != ids[0] {
+		t.Errorf("top result = %s, want alpha trace %s", res[0].ID, ids[0])
+	}
+
+	res, _ = cx.SemanticSearch(ctx, topicEmbedder{}, "gamma gamma", cortex.SemanticOpts{Model: "tm"})
+	if res[0].ID != ids[2] {
+		t.Errorf("gamma query top = %s, want %s", res[0].ID, ids[2])
+	}
+}
+
+func TestSemanticSearch_LimitAndArchived(t *testing.T) {
+	cx, ids := setupSemantic(t)
+	ctx := context.Background()
+
+	res, _ := cx.SemanticSearch(ctx, topicEmbedder{}, "alpha", cortex.SemanticOpts{Model: "tm", Limit: 1})
+	if len(res) != 1 {
+		t.Fatalf("limit=1 returned %d", len(res))
+	}
+
+	// Archive the beta trace; default search must exclude it.
+	if err := cx.Archive(ids[1]); err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	res, _ = cx.SemanticSearch(ctx, topicEmbedder{}, "beta", cortex.SemanticOpts{Model: "tm"})
+	for _, r := range res {
+		if r.ID == ids[1] {
+			t.Error("archived trace returned without IncludeArchived")
+		}
+	}
+	res, _ = cx.SemanticSearch(ctx, topicEmbedder{}, "beta", cortex.SemanticOpts{Model: "tm", IncludeArchived: true})
+	found := false
+	for _, r := range res {
+		if r.ID == ids[1] {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("archived trace missing with IncludeArchived=true")
+	}
+}
+
+func TestSemanticSimilar_ExcludesSource(t *testing.T) {
+	cx, ids := setupSemantic(t)
+
+	res, err := cx.SemanticSimilar(ids[0], cortex.SemanticOpts{Model: "tm"})
+	if err != nil {
+		t.Fatalf("SemanticSimilar: %v", err)
+	}
+	if len(res) != 2 {
+		t.Fatalf("got %d, want 2 (source excluded)", len(res))
+	}
+	for _, r := range res {
+		if r.ID == ids[0] {
+			t.Error("source trace must be excluded from its own similarity")
+		}
+	}
+
+	// A trace with no embedding for the model errors clearly.
+	if _, err := cx.SemanticSimilar(ids[0], cortex.SemanticOpts{Model: "other-model"}); err == nil {
+		t.Error("expected error for un-embedded model")
+	}
+}
+
+func TestSemanticSearch_SkipsNonFiniteVectors(t *testing.T) {
+	cx, ids := setupSemantic(t)
+	ctx := context.Background()
+
+	// Corrupt the gamma trace's stored vector to all +Inf (codec v1: 1-byte
+	// version + little-endian float32 bits; +Inf = 0x7F800000).
+	infBlob := []byte{1, 0x00, 0x00, 0x80, 0x7f, 0x00, 0x00, 0x80, 0x7f, 0x00, 0x00, 0x80, 0x7f}
+	if _, err := cx.DB.Exec(
+		`UPDATE trace_embeddings SET embedding=?, dim=3 WHERE trace_id=?`, infBlob, ids[2],
+	); err != nil {
+		t.Fatalf("corrupt vector: %v", err)
+	}
+
+	res, err := cx.SemanticSearch(ctx, topicEmbedder{}, "gamma", cortex.SemanticOpts{Model: "tm"})
+	if err != nil {
+		t.Fatalf("SemanticSearch: %v", err)
+	}
+	for _, r := range res {
+		if r.ID == ids[2] {
+			t.Error("non-finite (corrupted) vector must be skipped, not ranked")
+		}
+	}
+}
+
+func TestSemanticSearch_Guards(t *testing.T) {
+	cx := setup(t)
+	ctx := context.Background()
+	if _, err := cx.SemanticSearch(ctx, nil, "q", cortex.SemanticOpts{Model: "tm"}); err == nil {
+		t.Error("nil embedder should error")
+	}
+	if _, err := cx.SemanticSearch(ctx, topicEmbedder{}, "q", cortex.SemanticOpts{}); err == nil {
+		t.Error("empty model should error")
+	}
+	if res, err := cx.SemanticSearch(ctx, topicEmbedder{}, "   ", cortex.SemanticOpts{Model: "tm"}); err != nil || res != nil {
+		t.Errorf("blank query => (nil,nil); got (%v,%v)", res, err)
+	}
+}

--- a/internal/db/migration016_test.go
+++ b/internal/db/migration016_test.go
@@ -1,0 +1,109 @@
+package db_test
+
+import (
+	"testing"
+
+	"github.com/Fail-Safe/Noema/internal/db"
+)
+
+// ---- Migration 016: trace_embeddings ----
+
+func TestMigration016_ColumnsAndSchema(t *testing.T) {
+	conn, err := db.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer conn.Close()
+
+	rows, err := conn.Query(`PRAGMA table_info(trace_embeddings)`)
+	if err != nil {
+		t.Fatalf("PRAGMA table_info: %v", err)
+	}
+	defer rows.Close()
+	cols := map[string]struct {
+		notnull int
+		pk      int
+	}{}
+	for rows.Next() {
+		var cid, notnull, pk int
+		var name, ctype string
+		var dflt *string
+		if err := rows.Scan(&cid, &name, &ctype, &notnull, &dflt, &pk); err != nil {
+			t.Fatalf("Scan: %v", err)
+		}
+		cols[name] = struct {
+			notnull int
+			pk      int
+		}{notnull, pk}
+	}
+	for _, c := range []string{"trace_id", "embedding_model", "dim", "embedding", "source_hash", "updated_at"} {
+		if _, ok := cols[c]; !ok {
+			t.Errorf("trace_embeddings.%s missing after migration 016", c)
+		}
+	}
+	if cols["trace_id"].pk != 1 {
+		t.Error("trace_id should be the primary key")
+	}
+	if cols["embedding"].notnull != 1 {
+		t.Error("embedding should be NOT NULL")
+	}
+}
+
+// TestMigration016_EmbeddingFKCascade locks in ON DELETE CASCADE: deleting a
+// trace removes its embedding row (foreign_keys is enabled per the DSN).
+func TestMigration016_EmbeddingFKCascade(t *testing.T) {
+	conn, err := db.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer conn.Close()
+
+	if _, err := conn.Exec(
+		`INSERT INTO traces (id, title, type, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`,
+		"20260603-emb", "embed me", "note", "2026-06-03T00:00:00Z", "2026-06-03T00:00:00Z",
+	); err != nil {
+		t.Fatalf("seed trace: %v", err)
+	}
+	if _, err := conn.Exec(
+		`INSERT INTO trace_embeddings (trace_id, embedding_model, dim, embedding, source_hash, updated_at) VALUES (?, ?, ?, ?, ?, ?)`,
+		"20260603-emb", "nomic-embed-text", 3, []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13}, "sha256:abc", "2026-06-03T00:00:00Z",
+	); err != nil {
+		t.Fatalf("seed embedding: %v", err)
+	}
+
+	if _, err := conn.Exec(`DELETE FROM traces WHERE id = ?`, "20260603-emb"); err != nil {
+		t.Fatalf("delete trace: %v", err)
+	}
+
+	var n int
+	if err := conn.QueryRow(`SELECT COUNT(*) FROM trace_embeddings WHERE trace_id = ?`, "20260603-emb").Scan(&n); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("embedding row not cascade-deleted; %d remain", n)
+	}
+}
+
+// TestMigration016_RejectsNullEmbedding confirms the NOT NULL constraint on
+// the embedding BLOB column.
+func TestMigration016_RejectsNullEmbedding(t *testing.T) {
+	conn, err := db.Open(t.TempDir())
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	defer conn.Close()
+
+	if _, err := conn.Exec(
+		`INSERT INTO traces (id, title, type, created_at, updated_at) VALUES (?, ?, ?, ?, ?)`,
+		"20260603-x", "x", "note", "2026-06-03T00:00:00Z", "2026-06-03T00:00:00Z",
+	); err != nil {
+		t.Fatalf("seed trace: %v", err)
+	}
+	_, err = conn.Exec(
+		`INSERT INTO trace_embeddings (trace_id, embedding_model, dim, embedding, source_hash, updated_at) VALUES (?, ?, ?, NULL, ?, ?)`,
+		"20260603-x", "m", 3, "sha256:x", "2026-06-03T00:00:00Z",
+	)
+	if err == nil {
+		t.Error("NULL embedding should be rejected by NOT NULL")
+	}
+}

--- a/internal/db/migrations/016_trace_embeddings.sql
+++ b/internal/db/migrations/016_trace_embeddings.sql
@@ -1,0 +1,32 @@
+-- trace_embeddings stores one semantic embedding vector per trace for the
+-- opt-in semantic-search path. It is a LOCAL derived index, like the FTS5
+-- table: vectors are computed by each cortex from its own configured
+-- embedding model and are never federated (vectors from different models
+-- aren't comparable, and trace bodies + content_hash already sync). Older
+-- peers and cortexes without a `search:` config simply lack this table and
+-- serve lexical search only, so a mixed-version ring degrades gracefully
+-- with no wire-format change.
+--
+-- Storage is pure-Go-friendly: `embedding` is a BLOB (1-byte codec version
+-- + little-endian float32[dim]); modernc.org/sqlite can't load the
+-- sqlite-vec C extension, so cosine similarity is computed in Go over these
+-- blobs. A feasibility spike confirmed brute-force is interactive at the
+-- target scale (single-digit ms for ~10k traces). See
+-- docs/plans/semantic-search-plan.md in the Noema-design repo.
+--
+-- `source_hash` records the trace's content_hash at embed time; when a
+-- body edit changes content_hash the row is stale and gets re-embedded on
+-- the next backfill or write hook. `embedding_model` lets a model change be
+-- detected and trigger a full recompute. ON DELETE CASCADE drops the vector
+-- when the trace row is hard-removed.
+CREATE TABLE trace_embeddings (
+    trace_id        TEXT    NOT NULL PRIMARY KEY,
+    embedding_model TEXT    NOT NULL,
+    dim             INTEGER NOT NULL,
+    embedding       BLOB    NOT NULL,
+    source_hash     TEXT    NOT NULL,
+    updated_at      TEXT    NOT NULL,
+    FOREIGN KEY (trace_id) REFERENCES traces(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_trace_embeddings_model ON trace_embeddings(embedding_model);

--- a/internal/embed/maintainer.go
+++ b/internal/embed/maintainer.go
@@ -1,0 +1,84 @@
+// Package embed runs a background maintainer that keeps a cortex's semantic
+// embedding index fresh under `noema serve`. Traces created or edited while
+// the server runs get embedded automatically, without a manual `noema
+// embeddings backfill`.
+//
+// It is deliberately NOT a per-mutation hook: embedding an external endpoint
+// must never block or fail a trace write. Instead the maintainer runs an
+// idempotent backfill pass on an interval (only missing/stale traces are
+// embedded), mirroring the lifecycle of the filesystem watcher and
+// federation syncer — construct, Start, Stop. Freshness is eventual, bounded
+// by the interval.
+package embed
+
+import (
+	"context"
+	"log"
+	"sync"
+	"time"
+)
+
+// Maintainer periodically runs a backfill pass. The pass function is
+// injected (the serve layer wires it to Cortex.EmbedBackfill) so the loop
+// stays free of cortex/embedder dependencies and is trivially testable.
+type Maintainer struct {
+	backfill func(context.Context) (int, error)
+	interval time.Duration
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+// New builds a Maintainer that runs backfill every interval. backfill
+// returns the number of traces embedded and an error; both are for logging
+// only — a failing pass is retried on the next tick.
+func New(interval time.Duration, backfill func(context.Context) (int, error)) *Maintainer {
+	if interval <= 0 {
+		interval = 5 * time.Minute
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	return &Maintainer{backfill: backfill, interval: interval, ctx: ctx, cancel: cancel}
+}
+
+// Start launches the background loop. It runs one pass immediately (so a
+// freshly-started server catches up on anything written while it was down),
+// then once per interval until Stop.
+func (m *Maintainer) Start() {
+	log.Printf("[embed] maintainer active, interval=%s", m.interval)
+	m.wg.Add(1)
+	go m.run()
+}
+
+func (m *Maintainer) run() {
+	defer m.wg.Done()
+	m.pass()
+	t := time.NewTicker(m.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-m.ctx.Done():
+			return
+		case <-t.C:
+			m.pass()
+		}
+	}
+}
+
+func (m *Maintainer) pass() {
+	n, err := m.backfill(m.ctx)
+	switch {
+	case m.ctx.Err() != nil:
+		return // shutting down — swallow any partial-pass error
+	case err != nil:
+		log.Printf("[embed] backfill pass failed: %v", err)
+	case n > 0:
+		log.Printf("[embed] embedded %d trace(s)", n)
+	}
+}
+
+// Stop cancels the loop and blocks until the goroutine drains.
+func (m *Maintainer) Stop() {
+	m.cancel()
+	m.wg.Wait()
+}

--- a/internal/embed/maintainer_test.go
+++ b/internal/embed/maintainer_test.go
@@ -1,0 +1,76 @@
+package embed
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// waitFor receives n times from ch within the timeout or fails.
+func waitFor(t *testing.T, ch <-chan struct{}, n int) {
+	t.Helper()
+	for i := range n {
+		select {
+		case <-ch:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for pass %d/%d", i+1, n)
+		}
+	}
+}
+
+func TestMaintainer_RunsInitialAndPeriodic(t *testing.T) {
+	var calls int32
+	ran := make(chan struct{}, 64)
+	m := New(15*time.Millisecond, func(ctx context.Context) (int, error) {
+		atomic.AddInt32(&calls, 1)
+		ran <- struct{}{}
+		return 0, nil
+	})
+	m.Start()
+	// Initial pass + at least two ticks.
+	waitFor(t, ran, 3)
+	m.Stop()
+
+	// After Stop, no further passes.
+	settled := atomic.LoadInt32(&calls)
+	time.Sleep(60 * time.Millisecond)
+	if got := atomic.LoadInt32(&calls); got != settled {
+		t.Errorf("maintainer ran %d more pass(es) after Stop", got-settled)
+	}
+}
+
+func TestMaintainer_ErrorsAreNonFatal(t *testing.T) {
+	ran := make(chan struct{}, 64)
+	m := New(15*time.Millisecond, func(ctx context.Context) (int, error) {
+		ran <- struct{}{}
+		return 0, errors.New("boom")
+	})
+	m.Start()
+	// A failing pass must not stop the loop — expect repeated passes.
+	waitFor(t, ran, 3)
+	m.Stop()
+}
+
+func TestMaintainer_StopIsIdempotentAndDrains(t *testing.T) {
+	m := New(10*time.Millisecond, func(ctx context.Context) (int, error) {
+		// Respect cancellation so Stop drains promptly.
+		select {
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		default:
+			return 1, nil
+		}
+	})
+	m.Start()
+	time.Sleep(25 * time.Millisecond)
+	m.Stop() // must return (drain) without hanging
+}
+
+func TestNew_DefaultsZeroInterval(t *testing.T) {
+	m := New(0, func(ctx context.Context) (int, error) { return 0, nil })
+	if m.interval != 5*time.Minute {
+		t.Errorf("zero interval = %s, want 5m default", m.interval)
+	}
+}

--- a/internal/mcp/semantic_test.go
+++ b/internal/mcp/semantic_test.go
@@ -158,6 +158,32 @@ func TestSearchTraces_SemanticEndToEnd(t *testing.T) {
 	}
 }
 
+func TestSearchTraces_SemanticEndpointDownGenericNote(t *testing.T) {
+	cx := newTestCortex(t)
+	// Configured but unreachable endpoint with a recognizable host:port.
+	writeSearchConfig(t, cx, "http://127.0.0.1:1/v1", "tm")
+	tr := trace.New("lexical findable widget", "note", "agent", nil, "body about widgets")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	s := NewServer(cx, "test", "")
+	text, isErr := callTool(t, s, "search_traces", map[string]any{"query": "findable", "mode": "semantic"})
+	if isErr {
+		t.Fatalf("search_traces errored: %s", text)
+	}
+	if !strings.Contains(text, "temporarily unavailable") {
+		t.Errorf("expected generic degradation note, got:\n%s", text)
+	}
+	// The endpoint host must NOT leak into client-facing output.
+	if strings.Contains(text, "127.0.0.1") {
+		t.Errorf("degradation note leaked the endpoint host:\n%s", text)
+	}
+	// Lexical fallback still returns the matching trace.
+	if !strings.Contains(text, tr.ID) {
+		t.Errorf("expected lexical fallback result %s, got:\n%s", tr.ID, text)
+	}
+}
+
 func TestSearchTraces_HybridEndToEnd(t *testing.T) {
 	server := topicEmbedServer(t)
 	defer server.Close()

--- a/internal/mcp/semantic_test.go
+++ b/internal/mcp/semantic_test.go
@@ -1,0 +1,191 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/Fail-Safe/Noema/internal/consolidation"
+	"github.com/Fail-Safe/Noema/internal/cortex"
+	"github.com/Fail-Safe/Noema/internal/trace"
+)
+
+func topicVec(s string) [3]float32 {
+	v := [3]float32{0.01, 0.01, 0.01}
+	for w := range strings.FieldsSeq(strings.ToLower(s)) {
+		switch {
+		case strings.Contains(w, "alpha"):
+			v[0]++
+		case strings.Contains(w, "beta"):
+			v[1]++
+		case strings.Contains(w, "gamma"):
+			v[2]++
+		}
+	}
+	return v
+}
+
+// topicEmbedServer is an OpenAI-compatible /embeddings endpoint returning a
+// deterministic 3-dim topic vector per input, so MCP semantic ranking is
+// assertable end-to-end without a real model.
+func topicEmbedServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			Input []string `json:"input"`
+		}
+		_ = json.Unmarshal(body, &req)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("{\"data\":["))
+		for i, in := range req.Input {
+			if i > 0 {
+				w.Write([]byte(","))
+			}
+			v := topicVec(in)
+			fmt.Fprintf(w, `{"index":%d,"embedding":[%v,%v,%v]}`, i, v[0], v[1], v[2])
+		}
+		w.Write([]byte("]}"))
+	}))
+}
+
+func writeSearchConfig(t *testing.T, cx *cortex.Cortex, endpoint, model string) {
+	t.Helper()
+	m, err := cortex.ReadManifest(cx.Dir)
+	if err != nil {
+		t.Fatalf("ReadManifest: %v", err)
+	}
+	m.Search = &cortex.SearchConfig{
+		SemanticEnabled:   true,
+		EmbeddingEndpoint: endpoint,
+		EmbeddingModel:    model,
+	}
+	if err := cortex.WriteManifest(cx.Dir, m); err != nil {
+		t.Fatalf("WriteManifest: %v", err)
+	}
+}
+
+func TestResolveSearchMode(t *testing.T) {
+	cx := newTestCortex(t)
+
+	// Unconfigured: default is lexical; explicit semantic yields no embedder.
+	if mode, e, _ := resolveSearchMode(cx, ""); mode != cortex.SearchModeLexical || e != nil {
+		t.Errorf("unconfigured default = (%s, embedder!=nil:%v), want lexical/nil", mode, e != nil)
+	}
+	if mode, e, _ := resolveSearchMode(cx, "semantic"); mode != cortex.SearchModeSemantic || e != nil {
+		t.Errorf("semantic-unconfigured = (%s, embedder!=nil:%v), want semantic/nil-embedder", mode, e != nil)
+	}
+
+	// Configured: semantic yields an embedder + model.
+	writeSearchConfig(t, cx, "http://localhost:1", "tm")
+	mode, e, model := resolveSearchMode(cx, "semantic")
+	if mode != cortex.SearchModeSemantic || e == nil || model != "tm" {
+		t.Errorf("configured semantic = (%s, embedder!=nil:%v, model=%q), want semantic/embedder/tm", mode, e != nil, model)
+	}
+}
+
+func TestSearchTraces_SemanticFallsBackToLexical(t *testing.T) {
+	cx := newTestCortex(t)
+	tr := trace.New("findable thing", "note", "agent", nil, "body about widgets")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	s := NewServer(cx, "test", "")
+
+	// Semantic requested but unconfigured -> note + lexical results.
+	text, isErr := callTool(t, s, "search_traces", map[string]any{"query": "findable", "mode": "semantic"})
+	if isErr {
+		t.Fatalf("search_traces errored: %s", text)
+	}
+	if !strings.Contains(text, "not configured") {
+		t.Errorf("expected fallback note, got:\n%s", text)
+	}
+	if !strings.Contains(text, tr.ID) {
+		t.Errorf("expected lexical result for %s, got:\n%s", tr.ID, text)
+	}
+}
+
+func TestSearchTraces_SemanticEndToEnd(t *testing.T) {
+	server := topicEmbedServer(t)
+	defer server.Close()
+
+	cx := newTestCortex(t)
+	writeSearchConfig(t, cx, server.URL, "tm")
+	add := func(title, body string) string {
+		tr := trace.New(title, "note", "agent", nil, body)
+		if err := cx.Add(tr); err != nil {
+			t.Fatalf("Add: %v", err)
+		}
+		return tr.ID
+	}
+	alphaID := add("alpha topic", "alpha alpha content")
+	add("beta topic", "beta beta content")
+	gammaID := add("gamma topic", "gamma gamma content")
+
+	// Backfill embeddings through the same endpoint the handler will use.
+	client, err := consolidation.NewHTTPLLMClient(server.URL, "")
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	if _, err := cx.EmbedBackfill(context.Background(), client, "tm", cortex.EmbedBackfillOpts{}); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+
+	s := NewServer(cx, "test", "")
+	text, isErr := callTool(t, s, "search_traces", map[string]any{"query": "alpha alpha alpha", "mode": "semantic"})
+	if isErr {
+		t.Fatalf("search_traces errored: %s", text)
+	}
+	if strings.Contains(text, "not configured") || strings.Contains(text, "unavailable") {
+		t.Fatalf("unexpected fallback note in semantic result:\n%s", text)
+	}
+	// The alpha trace should rank above the gamma trace in the output.
+	ai := strings.Index(text, alphaID)
+	gi := strings.Index(text, gammaID)
+	if ai < 0 {
+		t.Fatalf("alpha trace %s missing from results:\n%s", alphaID, text)
+	}
+	if gi >= 0 && ai > gi {
+		t.Errorf("alpha (%d) should rank before gamma (%d) for an alpha query:\n%s", ai, gi, text)
+	}
+}
+
+func TestFindSimilar_SemanticEndToEnd(t *testing.T) {
+	server := topicEmbedServer(t)
+	defer server.Close()
+
+	cx := newTestCortex(t)
+	writeSearchConfig(t, cx, server.URL, "tm")
+	mk := func(title, body string) string {
+		tr := trace.New(title, "note", "agent", nil, body)
+		if err := cx.Add(tr); err != nil {
+			t.Fatalf("Add: %v", err)
+		}
+		return tr.ID
+	}
+	src := mk("alpha source", "alpha alpha alpha")
+	mk("beta other", "beta beta")
+	mk("alpha cousin", "alpha alpha")
+
+	client, _ := consolidation.NewHTTPLLMClient(server.URL, "")
+	if _, err := cx.EmbedBackfill(context.Background(), client, "tm", cortex.EmbedBackfillOpts{}); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+
+	s := NewServer(cx, "test", "")
+	text, isErr := callTool(t, s, "find_similar_traces", map[string]any{"trace_id": src, "mode": "semantic"})
+	if isErr {
+		t.Fatalf("find_similar_traces errored: %s", text)
+	}
+	if strings.Contains(text, "unavailable") || strings.Contains(text, "not configured") {
+		t.Fatalf("unexpected fallback note:\n%s", text)
+	}
+	if strings.Contains(text, src) {
+		t.Errorf("source trace must be excluded from its own similarity:\n%s", text)
+	}
+}

--- a/internal/mcp/semantic_test.go
+++ b/internal/mcp/semantic_test.go
@@ -74,18 +74,21 @@ func TestResolveSearchMode(t *testing.T) {
 	cx := newTestCortex(t)
 
 	// Unconfigured: default is lexical; explicit semantic yields no embedder.
-	if mode, e, _ := resolveSearchMode(cx, ""); mode != cortex.SearchModeLexical || e != nil {
+	if mode, e, _, _ := resolveSearchMode(cx, ""); mode != cortex.SearchModeLexical || e != nil {
 		t.Errorf("unconfigured default = (%s, embedder!=nil:%v), want lexical/nil", mode, e != nil)
 	}
-	if mode, e, _ := resolveSearchMode(cx, "semantic"); mode != cortex.SearchModeSemantic || e != nil {
+	if mode, e, _, _ := resolveSearchMode(cx, "semantic"); mode != cortex.SearchModeSemantic || e != nil {
 		t.Errorf("semantic-unconfigured = (%s, embedder!=nil:%v), want semantic/nil-embedder", mode, e != nil)
 	}
 
-	// Configured: semantic yields an embedder + model.
+	// Configured: semantic yields an embedder + model + default weight.
 	writeSearchConfig(t, cx, "http://localhost:1", "tm")
-	mode, e, model := resolveSearchMode(cx, "semantic")
+	mode, e, model, weight := resolveSearchMode(cx, "semantic")
 	if mode != cortex.SearchModeSemantic || e == nil || model != "tm" {
 		t.Errorf("configured semantic = (%s, embedder!=nil:%v, model=%q), want semantic/embedder/tm", mode, e != nil, model)
+	}
+	if weight != 0.5 {
+		t.Errorf("default hybrid weight = %v, want 0.5", weight)
 	}
 }
 
@@ -152,6 +155,41 @@ func TestSearchTraces_SemanticEndToEnd(t *testing.T) {
 	}
 	if gi >= 0 && ai > gi {
 		t.Errorf("alpha (%d) should rank before gamma (%d) for an alpha query:\n%s", ai, gi, text)
+	}
+}
+
+func TestSearchTraces_HybridEndToEnd(t *testing.T) {
+	server := topicEmbedServer(t)
+	defer server.Close()
+
+	cx := newTestCortex(t)
+	writeSearchConfig(t, cx, server.URL, "tm")
+	add := func(title, body string) string {
+		tr := trace.New(title, "note", "agent", nil, body)
+		if err := cx.Add(tr); err != nil {
+			t.Fatalf("Add: %v", err)
+		}
+		return tr.ID
+	}
+	alphaID := add("alpha topic", "alpha alpha content")
+	add("beta topic", "beta beta content")
+
+	client, _ := consolidation.NewHTTPLLMClient(server.URL, "")
+	if _, err := cx.EmbedBackfill(context.Background(), client, "tm", cortex.EmbedBackfillOpts{}); err != nil {
+		t.Fatalf("backfill: %v", err)
+	}
+
+	s := NewServer(cx, "test", "")
+	text, isErr := callTool(t, s, "search_traces", map[string]any{"query": "alpha alpha", "mode": "hybrid"})
+	if isErr {
+		t.Fatalf("search_traces hybrid errored: %s", text)
+	}
+	// Real RRF fusion now — no "not yet available" or fallback note.
+	if strings.Contains(text, "not yet") || strings.Contains(text, "unavailable") || strings.Contains(text, "not configured") {
+		t.Fatalf("unexpected note in hybrid result:\n%s", text)
+	}
+	if !strings.Contains(text, alphaID) {
+		t.Errorf("alpha trace %s missing from hybrid results:\n%s", alphaID, text)
 	}
 }
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net/url"
 	"strings"
 
@@ -265,7 +266,11 @@ func NewServer(cx *cortex.Cortex, noemaVersion string, federationMode string) *s
 					res, serr = cx.SemanticSearchAs(ctx, emb, query, opts, cortex.ActorAgent, cortex.DefaultSearchHitTopN)
 				}
 				if serr != nil {
-					note = "[" + mode + " search unavailable (" + serr.Error() + "); showing lexical results]\n"
+					// Log the detailed error server-side; surface only a generic
+					// note to the client so endpoint URLs / internal hostnames in
+					// the error don't leak into MCP output.
+					log.Printf("[mcp] %s search failed, falling back to lexical: %v", mode, serr)
+					note = "[" + mode + " search temporarily unavailable; showing lexical results]\n"
 				} else {
 					return mcp.NewToolResultText(formatRows(scoredToRows(res))), nil
 				}
@@ -315,7 +320,8 @@ func NewServer(cx *cortex.Cortex, noemaVersion string, federationMode string) *s
 					res, serr = cx.SemanticSimilarAs(traceID, opts, cortex.ActorAgent, cortex.DefaultSearchHitTopN)
 				}
 				if serr != nil {
-					note = "[" + mode + " similar unavailable (" + serr.Error() + "); showing lexical results]\n"
+					log.Printf("[mcp] %s similar failed, falling back to lexical: %v", mode, serr)
+					note = "[" + mode + " similar temporarily unavailable; showing lexical results]\n"
 				} else {
 					return mcp.NewToolResultText(formatSimilarMatches(scoredToMatches(res))), nil
 				}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1310,6 +1310,10 @@ runs.
 - author should be your agent name so traces are attributable in multi-agent systems.
 - Use derived_from when creating traces based on other traces — it builds a knowledge graph.
 - search_traces supports FTS5 syntax: quoted phrases, AND/OR/NOT, prefix* matching.
+- search_traces / find_similar_traces accept mode=semantic or mode=hybrid for
+  embedding-based ranking when this cortex has a search: block configured and
+  embeddings backfilled (noema embeddings backfill); they fall back to lexical
+  otherwise. Use semantic when a query matches by concept rather than wording.
 `, m.Name, noemaVersion, m.Version, purposeLine, ownerLine, m.Name)
 }
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -20,34 +20,35 @@ import (
 
 // resolveSearchMode determines the effective search mode for a request and,
 // for semantic/hybrid modes, builds the embedder from the cortex manifest.
-// It returns (mode, embedder, model): the embedder is nil when semantic
-// search isn't configured (no model/endpoint) so callers degrade to lexical.
-// reqMode is the caller-supplied "mode" arg ("" means use the manifest
-// default, which is lexical unless configured otherwise).
-func resolveSearchMode(cx *cortex.Cortex, reqMode string) (string, cortex.Embedder, string) {
+// It returns (mode, embedder, model, hybridWeight): the embedder is nil when
+// semantic search isn't configured (no model/endpoint) so callers degrade to
+// lexical. reqMode is the caller-supplied "mode" arg ("" means use the
+// manifest default, which is lexical unless configured otherwise).
+func resolveSearchMode(cx *cortex.Cortex, reqMode string) (string, cortex.Embedder, string, float64) {
 	m, err := cortex.ReadManifest(cx.Dir)
 	if err != nil {
-		return cortex.SearchModeLexical, nil, ""
+		return cortex.SearchModeLexical, nil, "", 0
 	}
+	weight := m.Search.EffectiveHybridWeight()
 	mode := reqMode
 	if mode == "" {
 		mode = m.Search.EffectiveDefaultMode()
 	}
 	if mode == cortex.SearchModeLexical {
-		return cortex.SearchModeLexical, nil, ""
+		return cortex.SearchModeLexical, nil, "", weight
 	}
 	if m.Search == nil || m.Search.EmbeddingModel == "" {
-		return mode, nil, ""
+		return mode, nil, "", weight
 	}
 	endpoint := m.ResolvedEmbeddingEndpoint()
 	if endpoint == "" {
-		return mode, nil, ""
+		return mode, nil, "", weight
 	}
 	client, err := consolidation.NewHTTPLLMClient(endpoint, m.ResolvedEmbeddingAPIKeyEnv())
 	if err != nil {
-		return mode, nil, ""
+		return mode, nil, "", weight
 	}
-	return mode, client, m.Search.EmbeddingModel
+	return mode, client, m.Search.EmbeddingModel, weight
 }
 
 func scoredToRows(s []cortex.ScoredRow) []cortex.Row {
@@ -245,7 +246,7 @@ func NewServer(cx *cortex.Cortex, noemaVersion string, federationMode string) *s
 			return nil, err
 		}
 		includeArchived := req.GetBool("all", false)
-		mode, emb, model := resolveSearchMode(cx, req.GetString("mode", ""))
+		mode, emb, model, weight := resolveSearchMode(cx, req.GetString("mode", ""))
 
 		// Semantic/hybrid path with graceful degradation to lexical: a
 		// missing config or an unreachable endpoint should still return
@@ -254,17 +255,20 @@ func NewServer(cx *cortex.Cortex, noemaVersion string, federationMode string) *s
 		if mode == cortex.SearchModeSemantic || mode == cortex.SearchModeHybrid {
 			if emb == nil {
 				note = "[semantic search not configured; showing lexical results]\n"
-			} else if res, serr := cx.SemanticSearchAs(ctx, emb, query, cortex.SemanticOpts{
-				Model:           model,
-				IncludeArchived: includeArchived,
-			}, cortex.ActorAgent, cortex.DefaultSearchHitTopN); serr != nil {
-				note = "[semantic search unavailable (" + serr.Error() + "); showing lexical results]\n"
 			} else {
-				out := formatRows(scoredToRows(res))
+				opts := cortex.SemanticOpts{Model: model, IncludeArchived: includeArchived}
+				var res []cortex.ScoredRow
+				var serr error
 				if mode == cortex.SearchModeHybrid {
-					out = "[hybrid fusion not yet available; showing semantic results]\n" + out
+					res, serr = cx.HybridSearchAs(ctx, emb, query, opts, weight, cortex.ActorAgent, cortex.DefaultSearchHitTopN)
+				} else {
+					res, serr = cx.SemanticSearchAs(ctx, emb, query, opts, cortex.ActorAgent, cortex.DefaultSearchHitTopN)
 				}
-				return mcp.NewToolResultText(out), nil
+				if serr != nil {
+					note = "[" + mode + " search unavailable (" + serr.Error() + "); showing lexical results]\n"
+				} else {
+					return mcp.NewToolResultText(formatRows(scoredToRows(res))), nil
+				}
 			}
 		}
 
@@ -292,26 +296,29 @@ func NewServer(cx *cortex.Cortex, noemaVersion string, federationMode string) *s
 		}
 		limit := int(req.GetFloat("limit", 0))
 		includeArchived := req.GetBool("include_archived", false)
-		// Semantic similarity uses the source's stored vector — no embedder
-		// needed — so we only require the configured model from the manifest.
-		mode, _, model := resolveSearchMode(cx, req.GetString("mode", ""))
+		// Similarity uses the source's stored vector (semantic) and/or
+		// FindSimilar (lexical) — no query embedder needed — so we only
+		// require the configured model from the manifest.
+		mode, _, model, weight := resolveSearchMode(cx, req.GetString("mode", ""))
 
 		note := ""
 		if mode == cortex.SearchModeSemantic || mode == cortex.SearchModeHybrid {
 			if model == "" {
 				note = "[semantic search not configured; showing lexical results]\n"
-			} else if res, serr := cx.SemanticSimilarAs(traceID, cortex.SemanticOpts{
-				Model:           model,
-				Limit:           limit,
-				IncludeArchived: includeArchived,
-			}, cortex.ActorAgent, cortex.DefaultSearchHitTopN); serr != nil {
-				note = "[semantic similar unavailable (" + serr.Error() + "); showing lexical results]\n"
 			} else {
-				out := formatSimilarMatches(scoredToMatches(res))
+				opts := cortex.SemanticOpts{Model: model, Limit: limit, IncludeArchived: includeArchived}
+				var res []cortex.ScoredRow
+				var serr error
 				if mode == cortex.SearchModeHybrid {
-					out = "[hybrid fusion not yet available; showing semantic results]\n" + out
+					res, serr = cx.HybridSimilarAs(traceID, opts, weight, cortex.ActorAgent, cortex.DefaultSearchHitTopN)
+				} else {
+					res, serr = cx.SemanticSimilarAs(traceID, opts, cortex.ActorAgent, cortex.DefaultSearchHitTopN)
 				}
-				return mcp.NewToolResultText(out), nil
+				if serr != nil {
+					note = "[" + mode + " similar unavailable (" + serr.Error() + "); showing lexical results]\n"
+				} else {
+					return mcp.NewToolResultText(formatSimilarMatches(scoredToMatches(res))), nil
+				}
 			}
 		}
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -11,11 +11,60 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 
+	"github.com/Fail-Safe/Noema/internal/consolidation"
 	"github.com/Fail-Safe/Noema/internal/cortex"
 	"github.com/Fail-Safe/Noema/internal/event"
 	"github.com/Fail-Safe/Noema/internal/federation"
 	"github.com/Fail-Safe/Noema/internal/trace"
 )
+
+// resolveSearchMode determines the effective search mode for a request and,
+// for semantic/hybrid modes, builds the embedder from the cortex manifest.
+// It returns (mode, embedder, model): the embedder is nil when semantic
+// search isn't configured (no model/endpoint) so callers degrade to lexical.
+// reqMode is the caller-supplied "mode" arg ("" means use the manifest
+// default, which is lexical unless configured otherwise).
+func resolveSearchMode(cx *cortex.Cortex, reqMode string) (string, cortex.Embedder, string) {
+	m, err := cortex.ReadManifest(cx.Dir)
+	if err != nil {
+		return cortex.SearchModeLexical, nil, ""
+	}
+	mode := reqMode
+	if mode == "" {
+		mode = m.Search.EffectiveDefaultMode()
+	}
+	if mode == cortex.SearchModeLexical {
+		return cortex.SearchModeLexical, nil, ""
+	}
+	if m.Search == nil || m.Search.EmbeddingModel == "" {
+		return mode, nil, ""
+	}
+	endpoint := m.ResolvedEmbeddingEndpoint()
+	if endpoint == "" {
+		return mode, nil, ""
+	}
+	client, err := consolidation.NewHTTPLLMClient(endpoint, m.ResolvedEmbeddingAPIKeyEnv())
+	if err != nil {
+		return mode, nil, ""
+	}
+	return mode, client, m.Search.EmbeddingModel
+}
+
+func scoredToRows(s []cortex.ScoredRow) []cortex.Row {
+	rows := make([]cortex.Row, len(s))
+	for i := range s {
+		rows[i] = s[i].Row
+	}
+	return rows
+}
+
+func scoredToMatches(s []cortex.ScoredRow) []cortex.SimilarMatch {
+	out := make([]cortex.SimilarMatch, len(s))
+	for i := range s {
+		out[i] = cortex.SimilarMatch{Row: s[i].Row, Score: s[i].Score}
+	}
+	return out
+}
 
 // NewServer builds an MCP server exposing all Cortex operations. The
 // version string is plumbed through to the MCP protocol's serverInfo
@@ -189,45 +238,92 @@ func NewServer(cx *cortex.Cortex, noemaVersion string, federationMode string) *s
 		mcp.WithDescription("Full-text search across traces"),
 		mcp.WithString("query", mcp.Description("Search query"), mcp.Required()),
 		mcp.WithBoolean("all", mcp.Description("Include archived traces")),
+		mcp.WithString("mode", mcp.Description("Search mode: 'lexical' (FTS5, default), 'semantic' (embedding similarity), or 'hybrid'. Semantic/hybrid need a configured search: block; if unavailable, falls back to lexical.")),
 	), func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		query, err := req.RequireString("query")
 		if err != nil {
 			return nil, err
 		}
-		// Agent-initiated searches bump search_hit_count on the top-N
-		// results. Auto-injection providers (Hermes, etc.) consume search
-		// output without ever calling get_trace, so without this bump the
-		// graduation gate never sees signal from those reads. See
-		// internal/cortex/actor.go SearchAs for the rationale.
+		includeArchived := req.GetBool("all", false)
+		mode, emb, model := resolveSearchMode(cx, req.GetString("mode", ""))
+
+		// Semantic/hybrid path with graceful degradation to lexical: a
+		// missing config or an unreachable endpoint should still return
+		// useful (lexical) results with a note, never an error.
+		note := ""
+		if mode == cortex.SearchModeSemantic || mode == cortex.SearchModeHybrid {
+			if emb == nil {
+				note = "[semantic search not configured; showing lexical results]\n"
+			} else if res, serr := cx.SemanticSearchAs(ctx, emb, query, cortex.SemanticOpts{
+				Model:           model,
+				IncludeArchived: includeArchived,
+			}, cortex.ActorAgent, cortex.DefaultSearchHitTopN); serr != nil {
+				note = "[semantic search unavailable (" + serr.Error() + "); showing lexical results]\n"
+			} else {
+				out := formatRows(scoredToRows(res))
+				if mode == cortex.SearchModeHybrid {
+					out = "[hybrid fusion not yet available; showing semantic results]\n" + out
+				}
+				return mcp.NewToolResultText(out), nil
+			}
+		}
+
+		// Lexical (default or fallback). Agent-initiated searches bump
+		// search_hit_count on the top-N results — see actor.go SearchAs.
 		rows, err := cx.SearchAs(query, cortex.ListOptions{
-			All: req.GetBool("all", false),
+			All: includeArchived,
 		}, cortex.ActorAgent, cortex.DefaultSearchHitTopN)
 		if err != nil {
 			return nil, err
 		}
-		return mcp.NewToolResultText(formatRows(rows)), nil
+		return mcp.NewToolResultText(note + formatRows(rows)), nil
 	})
 
 	s.AddTool(mcp.NewTool("find_similar_traces",
-		mcp.WithDescription("Find traces with overlapping vocabulary to a given trace, ranked by FTS5 BM25. Useful when you have one trace and want to surface related ones without crafting a search query."),
+		mcp.WithDescription("Find traces related to a given trace. Default mode ranks by FTS5 BM25 vocabulary overlap; 'semantic' mode ranks by embedding similarity to the source trace's own vector (needs a configured search: block + backfilled embeddings). Useful when you have one trace and want related ones without crafting a query."),
 		mcp.WithString("trace_id", mcp.Description("ID of the source trace"), mcp.Required()),
 		mcp.WithNumber("limit", mcp.Description("Maximum matches to return (default 10)")),
 		mcp.WithBoolean("include_archived", mcp.Description("Include archived traces (default false)")),
+		mcp.WithString("mode", mcp.Description("'lexical' (FTS5, default) or 'semantic'/'hybrid' (embedding similarity). Falls back to lexical if semantic isn't configured or the source isn't embedded.")),
 	), func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		traceID, err := req.RequireString("trace_id")
 		if err != nil {
 			return nil, err
 		}
-		opts := cortex.SimilarOpts{
-			Limit:           int(req.GetFloat("limit", 0)),
-			IncludeArchived: req.GetBool("include_archived", false),
+		limit := int(req.GetFloat("limit", 0))
+		includeArchived := req.GetBool("include_archived", false)
+		// Semantic similarity uses the source's stored vector — no embedder
+		// needed — so we only require the configured model from the manifest.
+		mode, _, model := resolveSearchMode(cx, req.GetString("mode", ""))
+
+		note := ""
+		if mode == cortex.SearchModeSemantic || mode == cortex.SearchModeHybrid {
+			if model == "" {
+				note = "[semantic search not configured; showing lexical results]\n"
+			} else if res, serr := cx.SemanticSimilarAs(traceID, cortex.SemanticOpts{
+				Model:           model,
+				Limit:           limit,
+				IncludeArchived: includeArchived,
+			}, cortex.ActorAgent, cortex.DefaultSearchHitTopN); serr != nil {
+				note = "[semantic similar unavailable (" + serr.Error() + "); showing lexical results]\n"
+			} else {
+				out := formatSimilarMatches(scoredToMatches(res))
+				if mode == cortex.SearchModeHybrid {
+					out = "[hybrid fusion not yet available; showing semantic results]\n" + out
+				}
+				return mcp.NewToolResultText(out), nil
+			}
 		}
-		// Same actor-aware bump as search_traces; see SearchAs for why.
-		matches, err := cx.FindSimilarAs(traceID, opts, cortex.ActorAgent, cortex.DefaultSearchHitTopN)
+
+		// Lexical (default or fallback). Same actor-aware bump as search_traces.
+		matches, err := cx.FindSimilarAs(traceID, cortex.SimilarOpts{
+			Limit:           limit,
+			IncludeArchived: includeArchived,
+		}, cortex.ActorAgent, cortex.DefaultSearchHitTopN)
 		if err != nil {
 			return nil, err
 		}
-		return mcp.NewToolResultText(formatSimilarMatches(matches)), nil
+		return mcp.NewToolResultText(note + formatSimilarMatches(matches)), nil
 	})
 
 	s.AddTool(mcp.NewTool("delete_trace",
@@ -986,10 +1082,13 @@ Choose the type that best reflects the intent of the memory:
   append_trace id content        → append content to an existing trace's body
                                    without reading the full trace first; ideal
                                    for running logs and fire-and-forget writes
-  search_traces query [all]      → FTS5 full-text search
-  find_similar_traces trace_id [limit] [include_archived]
-                                 → traces with overlapping vocabulary,
-                                   ranked by BM25 (lower score = closer
+  search_traces query [all] [mode]
+                                 → full-text (lexical, default) or embedding
+                                   (mode=semantic) search; semantic needs a
+                                   configured search: block, else falls back
+  find_similar_traces trace_id [limit] [include_archived] [mode]
+                                 → related traces by BM25 vocabulary overlap,
+                                   or mode=semantic for embedding similarity
                                    match). Useful when you have one
                                    trace in hand and want to surface
                                    related ones without crafting a query


### PR DESCRIPTION
## Release v0.14.0 — semantic & hybrid search

`next` is a clean 7-ahead / 0-behind of `main`; squash-merge as one release commit, then tag `v0.14.0`.

Adds an **opt-in semantic search layer** alongside lexical FTS5 — pure-Go (BLOB-stored embeddings + in-Go cosine; no CGo, no vector extension, no external DB), local-only (never federated), and degrade-safe (falls back to lexical when unconfigured/unreachable).

### Highlights
- `search:` config block in `cortex.md` (off by default; reuses the consolidation LLM endpoint config).
- `noema embeddings status|backfill`; `noema search/similar --semantic|--hybrid`.
- MCP `search_traces` / `find_similar_traces` gain a `mode` arg (lexical | semantic | hybrid) with graceful lexical fallback.
- **Hybrid** = Reciprocal Rank Fusion of BM25 + cosine (`hybrid_weight`).
- Serve-time **embed maintainer** keeps the index fresh automatically (periodic idempotent backfill; never blocks writes).
- Migration `016_trace_embeddings` (new table; non-destructive, not federated).

### Validation
Extensively tested incl. `-race` and fuzz; validated end-to-end on a live local embedding model (semantic returned results where lexical returned none). Docs updated across README, CLAUDE.md, AGENTS.md, and `get_instructions`.

Deferred (non-blocking): in-memory vector cache (speed at scale), `max_chars` graceful degradation polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)