### PR TITLE
fix(search): cap query length + generic MCP degradation note (v0.14.0 security review)

### DIFF
--- a/internal/cortex/semantic.go
+++ b/internal/cortex/semantic.go
@@ -127,6 +127,9 @@ func (c *Cortex) embedQuery(ctx context.Context, e Embedder, model, query string
 	if q == "" {
 		return nil, nil
 	}
+	if len(q) > MaxSearchQueryLen {
+		return nil, fmt.Errorf("query too long (%d chars, max %d)", len(q), MaxSearchQueryLen)
+	}
 	vecs, err := e.Embed(ctx, model, []string{q})
 	if err != nil {
 		return nil, fmt.Errorf("embedding query: %w", err)
@@ -240,6 +243,9 @@ func rrfFuse(lex []Row, sem []ScoredRow, weight float64, limit int) []ScoredRow 
 // BM25 relevance order (best first) — the lexical input to hybrid fusion.
 // Trashed excluded; archived excluded unless includeArchived.
 func (c *Cortex) lexicalRanked(query string, includeArchived bool) ([]Row, error) {
+	if len(query) > MaxSearchQueryLen {
+		return nil, fmt.Errorf("query too long (%d chars, max %d)", len(query), MaxSearchQueryLen)
+	}
 	ftsQuery := SanitizeFTS5Query(query)
 	if strings.TrimSpace(ftsQuery) == "" {
 		return nil, nil

--- a/internal/cortex/semantic_test.go
+++ b/internal/cortex/semantic_test.go
@@ -183,6 +183,18 @@ func TestHybridSimilar_ExcludesSource(t *testing.T) {
 	}
 }
 
+func TestSemanticSearch_QueryTooLong(t *testing.T) {
+	cx, _ := setupSemantic(t)
+	ctx := context.Background()
+	long := strings.Repeat("x", 1001) // > MaxSearchQueryLen (1000)
+	if _, err := cx.SemanticSearch(ctx, topicEmbedder{}, long, cortex.SemanticOpts{Model: "tm"}); err == nil {
+		t.Error("over-long semantic query should be rejected (DoS guard)")
+	}
+	if _, err := cx.HybridSearch(ctx, topicEmbedder{}, long, cortex.SemanticOpts{Model: "tm"}, 0.5); err == nil {
+		t.Error("over-long hybrid query should be rejected (DoS guard)")
+	}
+}
+
 func TestSemanticSearch_Guards(t *testing.T) {
 	cx := setup(t)
 	ctx := context.Background()

--- a/internal/mcp/semantic_test.go
+++ b/internal/mcp/semantic_test.go
@@ -158,6 +158,32 @@ func TestSearchTraces_SemanticEndToEnd(t *testing.T) {
 	}
 }
 
+func TestSearchTraces_SemanticEndpointDownGenericNote(t *testing.T) {
+	cx := newTestCortex(t)
+	// Configured but unreachable endpoint with a recognizable host:port.
+	writeSearchConfig(t, cx, "http://127.0.0.1:1/v1", "tm")
+	tr := trace.New("lexical findable widget", "note", "agent", nil, "body about widgets")
+	if err := cx.Add(tr); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	s := NewServer(cx, "test", "")
+	text, isErr := callTool(t, s, "search_traces", map[string]any{"query": "findable", "mode": "semantic"})
+	if isErr {
+		t.Fatalf("search_traces errored: %s", text)
+	}
+	if !strings.Contains(text, "temporarily unavailable") {
+		t.Errorf("expected generic degradation note, got:\n%s", text)
+	}
+	// The endpoint host must NOT leak into client-facing output.
+	if strings.Contains(text, "127.0.0.1") {
+		t.Errorf("degradation note leaked the endpoint host:\n%s", text)
+	}
+	// Lexical fallback still returns the matching trace.
+	if !strings.Contains(text, tr.ID) {
+		t.Errorf("expected lexical fallback result %s, got:\n%s", tr.ID, text)
+	}
+}
+
 func TestSearchTraces_HybridEndToEnd(t *testing.T) {
 	server := topicEmbedServer(t)
 	defer server.Close()

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net/url"
 	"strings"
 
@@ -265,7 +266,11 @@ func NewServer(cx *cortex.Cortex, noemaVersion string, federationMode string) *s
 					res, serr = cx.SemanticSearchAs(ctx, emb, query, opts, cortex.ActorAgent, cortex.DefaultSearchHitTopN)
 				}
 				if serr != nil {
-					note = "[" + mode + " search unavailable (" + serr.Error() + "); showing lexical results]\n"
+					// Log the detailed error server-side; surface only a generic
+					// note to the client so endpoint URLs / internal hostnames in
+					// the error don't leak into MCP output.
+					log.Printf("[mcp] %s search failed, falling back to lexical: %v", mode, serr)
+					note = "[" + mode + " search temporarily unavailable; showing lexical results]\n"
 				} else {
 					return mcp.NewToolResultText(formatRows(scoredToRows(res))), nil
 				}
@@ -315,7 +320,8 @@ func NewServer(cx *cortex.Cortex, noemaVersion string, federationMode string) *s
 					res, serr = cx.SemanticSimilarAs(traceID, opts, cortex.ActorAgent, cortex.DefaultSearchHitTopN)
 				}
 				if serr != nil {
-					note = "[" + mode + " similar unavailable (" + serr.Error() + "); showing lexical results]\n"
+					log.Printf("[mcp] %s similar failed, falling back to lexical: %v", mode, serr)
+					note = "[" + mode + " similar temporarily unavailable; showing lexical results]\n"
 				} else {
 					return mcp.NewToolResultText(formatSimilarMatches(scoredToMatches(res))), nil
 				}


### PR DESCRIPTION
Pre-release hardening from the v0.14.0 security review (govulncheck clean; no high-severity findings).

- **MEDIUM** — `lexicalRanked` (hybrid path) and `embedQuery` bypassed the `MaxSearchQueryLen` (1000) DoS guard the normal `Search` enforces. Now capped in both.
- **LOW** — the MCP degradation note interpolated `serr.Error()`, which can leak the embedding endpoint URL / internal hostname into client output. Now a generic note to the client; detail logged server-side.

Tests: over-long query rejected (semantic + hybrid); endpoint-down note generic + no host leak + lexical fallback intact. Full build/vet/test/-race green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)