### PR TITLE
chore: remove Go runtime remnants

### DIFF
--- a/plugins/hermes/tests/test_unit.py
+++ b/plugins/hermes/tests/test_unit.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -11,6 +12,7 @@ from plugins.hermes.transport import (
     _jsonrpc_request,
     _parse_jsonrpc_response,
     _extract_text,
+    _well_known_binary_paths,
     find_binary,
     reset_binary_cache,
     StdioTransport,
@@ -140,6 +142,16 @@ class TestFindBinary:
             with patch("plugins.hermes.transport.shutil.which", return_value=str(binary)):
                 result = find_binary()
                 assert result == str(binary)
+
+    def test_well_known_locations_cover_rust_install_paths(self):
+        home = Path("/home/example-user")
+        assert _well_known_binary_paths(home) == [
+            Path("/opt/homebrew/bin/noema"),
+            Path("/home/linuxbrew/.linuxbrew/bin/noema"),
+            Path("/usr/local/bin/noema"),
+            home / ".cargo" / "bin" / "noema",
+            home / ".local" / "bin" / "noema",
+        ]
 
     def test_cache_persists(self, tmp_path):
         binary = tmp_path / "noema"

--- a/plugins/hermes/transport.py
+++ b/plugins/hermes/transport.py
@@ -31,6 +31,16 @@ _binary_cache: Optional[str] = None
 _binary_lock = threading.Lock()
 
 
+def _well_known_binary_paths(home: Path) -> list[Path]:
+    return [
+        Path("/opt/homebrew/bin/noema"),
+        Path("/home/linuxbrew/.linuxbrew/bin/noema"),
+        Path("/usr/local/bin/noema"),
+        home / ".cargo" / "bin" / "noema",
+        home / ".local" / "bin" / "noema",
+    ]
+
+
 def find_binary(override: Optional[str] = None) -> Optional[str]:
     """Locate the noema binary. Resolution order:
     1. Explicit override (config or NOEMA_BINARY env)
@@ -63,12 +73,7 @@ def find_binary(override: Optional[str] = None) -> Optional[str]:
 
     # Well-known locations.
     home = Path.home()
-    candidates = [
-        home / "go" / "bin" / "noema",
-        Path("/usr/local/bin/noema"),
-        home / ".local" / "bin" / "noema",
-    ]
-    for c in candidates:
+    for c in _well_known_binary_paths(home):
         if c.is_file() and os.access(str(c), os.X_OK):
             with _binary_lock:
                 _binary_cache = str(c)

--- a/src/restore.rs
+++ b/src/restore.rs
@@ -209,9 +209,9 @@ fn append_backup_entry(
     } else if metadata.file_type().is_symlink()
         && is_legacy_trash_alias(archive_path, &fs::read_link(source)?)
     {
-        // Go backups included this Obsidian-facing convenience alias, while Go
-        // restore ignored it. The managed trash contents are already archived
-        // under trash/traces, so omit the alias without accepting general links.
+        // Legacy Noema backups included this Obsidian-facing convenience alias.
+        // The managed trash contents are already archived under trash/traces,
+        // so omit the alias without accepting general links.
     } else {
         bail!("refusing to back up non-regular entry {}", source.display())
     }
@@ -1006,9 +1006,9 @@ fn extract_archive(tarball: &Path, destination: &Path) -> Result<PathBuf> {
                 .as_deref()
                 .is_none_or(|link| link.as_os_str().is_empty() || link == Path::new("trash/traces"))
         {
-            // Go wrote the legacy Obsidian-facing .trash alias into archives
-            // and ignored it on restore. Preserve that behavior without
-            // creating a link or accepting any other archive link type.
+            // Legacy Noema archives may contain the Obsidian-facing .trash
+            // alias. Preserve compatibility without creating a link or
+            // accepting any other archive link type.
         } else {
             bail!(
                 "tar entry {} has unsupported type {:?}",

--- a/tests/rust-rewrite/README.md
+++ b/tests/rust-rewrite/README.md
@@ -145,7 +145,8 @@ and Rust benchmark trees after verifying both. Every mixed run finishes with
 
 Rust defaults to the `standard` direct-write and single-transaction profile,
 which matches Go's mutation posture. Set `NOEMA_DURABILITY=strong` to measure
-the enhanced per-mutation recovery protocol:
+the enhanced per-mutation recovery protocol. On the signed baseline tag, the
+convenience target was:
 
 ```sh
 NOEMA_DURABILITY=strong make benchmark-scale-rust
@@ -208,6 +209,8 @@ PYTHONPATH=tests/rust-rewrite \
   python3 -m unittest -v qualitative_distillation_test
 ```
 
+The experiment branch also exposed these convenience targets:
+
 ```sh
 make compare-rust
 make benchmark-rust
@@ -216,6 +219,6 @@ make benchmark-scale-rust
 make soak-rust
 ```
 
-The Go implementation remains the release baseline. Benchmark results are
-evidence for the rewrite decision, not a replacement for the compatibility
-gate.
+When these comparisons were run, the Go implementation was the release
+baseline. The retained results document the rewrite decision and the
+compatibility gate used for the completed cutover.

--- a/tests/security-mcp-pentest-playbook.md
+++ b/tests/security-mcp-pentest-playbook.md
@@ -290,7 +290,7 @@ Expected: 404
 CODE=$(curl $K -s -o /dev/null -w "%{http_code}" -X GET "$URL" \
   -H "$AUTH")
 echo "S24: HTTP $CODE (GET without session)"
-# mcp-go may return 400 or 405 for GET without Mcp-Session-Id
+# A sessionless GET may return a client error or an SSE stream.
 [ "$CODE" != "200" ] && echo "[PASS] S24" || echo "[INFO] S24 returned 200 (check if streaming)"
 ```
 Expected: non-200 or SSE stream


### PR DESCRIPTION
## Summary

- stop the Hermes plugin from discovering an obsolete binary under `~/go/bin`
- add well-known Homebrew, Linuxbrew, Cargo, and user-local Rust binary locations
- retain legacy `.trash` archive compatibility while removing implementation-specific comments
- update stale MCP and historical cutover documentation to describe the current Rust-only state accurately

## Why

The Go implementation has been removed, but the Hermes runtime could still discover and launch an old Go-era installation. A few current-tense comments also made the completed cutover look unfinished. Legacy archive behavior remains necessary for upgrades and is preserved unchanged.

## Validation

- `cd plugins/hermes && pytest -q` — 101 passed
- `make test` — formatting, strict Clippy, 130 Rust unit tests, and all crash/recovery integration tests passed
- targeted repository scan found no remaining Go binary lookup or stale `mcp-go`/release-baseline wording
