### PR TITLE
fix(release): authenticate Homebrew tap pushes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,6 +154,7 @@ jobs:
         shell: bash
         run: |
           version="${GITHUB_REF_NAME#v}"
+          gh auth setup-git --hostname github.com
           gh repo clone Fail-Safe/homebrew-tap .release-homebrew
           python3 scripts/render-homebrew.py \
             --version "$version" --dist dist --tap .release-homebrew


### PR DESCRIPTION
## Summary

- configure GitHub CLI as the Git credential helper before cloning the Homebrew tap
- allow the existing `HOMEBREW_TAP_TOKEN` to authenticate the subsequent `git push` without embedding credentials in the remote URL

## Validation

- `make test`
- `python3 -m unittest tests/render_homebrew_test.py`
- `git diff --check`
- v0.20.0 release workflow rerun completed successfully after the tap was brought current
