### PR TITLE
feat(tags): add cortex-wide tag management

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,6 +154,7 @@ jobs:
         shell: bash
         run: |
           version="${GITHUB_REF_NAME#v}"
+          gh auth setup-git --hostname github.com
           gh repo clone Fail-Safe/homebrew-tap .release-homebrew
           python3 scripts/render-homebrew.py \
             --version "$version" --dist dist --tap .release-homebrew

--- a/README.md
+++ b/README.md
@@ -212,8 +212,10 @@ noema list [flags]                        List Traces
 noema get <id>                            Show a Trace
 noema edit <id>                           Edit a Trace in $EDITOR
 noema append <id> [--content <text>]      Append to a Trace body (pipe-friendly: `echo X | noema append <id>`)
-noema remove <id>                         Move a Trace to trash (--force to hard-delete)
-noema recover <id>                        Restore a Trace from trash
+noema remove <id> [--force]               Move a Trace to recoverable trash
+                                          (--force only overrides source-lock protection)
+noema recover <id> [--force]              Restore a Trace from trash
+                                          (--force overrides source-lock protection)
 noema purge [--days N]                    Permanently delete all trashed Traces older than N days
 noema search <query> [flags]              Full-text search (FTS5). --semantic / --hybrid
                                           rank by embedding similarity (needs a search: block + backfill)
@@ -257,6 +259,15 @@ noema memory purge <id> --tier <t> --reason "..." --confirm [--hard]
                                           Ceremoniously destroy a trace with audit trail (GDPR path)
 noema consolidate [flags]                 Run an LLM-backed consolidation pass
 noema migrate cortex-id [--reset] [--yes] Assign or deliberately replace a Cortex federation identity
+
+noema tags stats [--limit 50] [--output text|json]
+                                          Show cortex-wide tag, visibility, tier, and engagement counts
+noema tags rename <old> <new> [-i] [--dry-run] [-y]
+                                          Rename a tag across active and archived traces
+noema tags delete <tag> [-i] [--dry-run] [-y]
+                                          Remove a tag across active and archived traces
+noema tags doctor [--fix] [-y] [--output text|json]
+                                          Diagnose tag hygiene and optionally apply deterministic fixes
 
 noema federation status                   Show federation config, MCP access posture, peer sync state, and vector clock
 noema federation peers                    List configured federation peers
@@ -355,6 +366,10 @@ Noema can run as an [MCP](https://modelcontextprotocol.io) server, giving any MC
 | `append_trace` | Append content to an existing trace without reading it first (fire-and-forget logging) |
 | `set_trace_tags` | Replace a trace's retrieval tags without touching title, body, type, or lineage |
 | `append_trace_tags` | Add retrieval tags idempotently without touching title, body, type, or lineage |
+| `tag_stats` | Cortex-wide tag assignment, visibility, tier, and engagement statistics |
+| `tag_doctor` | Diagnose tag hygiene; optionally preview or apply deterministic repairs |
+| `rename_tag` | Preview or apply a cortex-wide exact tag rename; supports opt-in ASCII case-insensitive matching |
+| `delete_tag` | Preview or apply cortex-wide tag removal; supports opt-in ASCII case-insensitive matching |
 | `search_traces` | Search traces. `mode`: `lexical` (FTS5, default), `semantic` (embedding similarity), or `hybrid` (RRF fusion); semantic/hybrid need a configured `search:` block and fall back to lexical otherwise |
 | `find_similar_traces` | Surface traces related to one you hold. Default ranks by BM25 vocabulary overlap; `mode=semantic`/`hybrid` ranks by embedding similarity to the source trace's vector |
 | `archive_trace` / `unarchive_trace` | Archive a trace or restore it |
@@ -695,7 +710,7 @@ consolidation:
     require_unmodified: true
 ```
 
-Explicit curation is always available: `noema memory promote <id>` advances a trace one tier (short→mid or mid→long), and `noema memory demote <id>` steps mid→short. Long-term demotion goes through `noema memory purge` because undoing a base truth deserves the same ceremony as destroying it.
+Explicit curation is always available: `noema memory promote <id>` advances a trace one tier (short→mid or mid→long), and `noema memory demote <id>` steps mid→short. Long-term demotion goes through `noema memory purge` because undoing a base truth deserves the same ceremony as destroying it. Tags remain mutable retrieval metadata on every tier; retagging a long-term trace does not change its body, identity fields, content hash, or `updated` timestamp.
 
 ### Automatic LLM distillation
 
@@ -837,8 +852,17 @@ indexing and search without putting memory data in a cloud service.
 - **Tags must contain at least one letter.** A pure-numeric tag like `2026` or `42` is stored, indexed, and searchable via `search_traces` / FTS5, but Obsidian silently drops it from the tag panel. Use `y2026`, `2026q1`, or `event-2026-04-02` instead.
 - **Avoid dots inside a tag.** Obsidian interprets `release.candidate` as a nested tag tree (`release` / `candidate`), which is rarely the intent for a flat tag. Use hyphens: `release-candidate`.
 - **No spaces.** Use hyphens or underscores: `network-troubleshooting`, not `network troubleshooting`.
+- **Prefer lowercase.** Lowercase kebab-case keeps exact matching and cross-tool display predictable: `mcp-server`, not `MCP-Server`.
 
 The Obsidian plugin's "New trace" command surfaces these as inline warnings as you type — non-blocking hints, not validation errors. The cortex still accepts the tag.
+
+Use `noema tags doctor` to audit these conventions. `doctor --fix` only applies
+deterministic repairs such as lowercasing and replacing spaces or periods with
+hyphens; numeric-only tags remain report-only because Noema cannot infer the
+intended replacement. Bulk rename and delete commands show a preflight plan and
+prompt with `y/N` by default. Pass `--dry-run` to stop after the plan or
+`--yes`/`-y` for non-interactive execution. `--ignore-case`/`-i` uses ASCII
+case-insensitive matching and reports every spelling that will converge.
 
 **Cortex layout on disk:**
 

--- a/docs/rust-rewrite-maintenance.md
+++ b/docs/rust-rewrite-maintenance.md
@@ -1,0 +1,102 @@
+# Rust cutover evidence maintenance
+
+This document is for Noema maintainers updating the evidence behind the public
+[`Why Noema switched to Rust`](why-rust.md) page. It owns benchmark
+regeneration, evidence lifecycle rules, operational cautions, and remaining
+qualification work. It is not end-user installation or usage guidance.
+
+## Evidence inventory
+
+- Curated chart data:
+  [`tests/rust-rewrite/report-data.json`](../tests/rust-rewrite/report-data.json)
+- Final comparison source state: signed `rust-cutover-baseline` tag
+- Detailed methodology and historical results:
+  [`rust-rewrite-experiment-results.md`](rust-rewrite-experiment-results.md)
+- Qualification state and handoff notes:
+  [`rust-rewrite-status.md`](rust-rewrite-status.md)
+- Acceptance criteria:
+  [`rust-rewrite-test-plan.md`](rust-rewrite-test-plan.md)
+
+The public page and its accessible tables are the interpretation layer. The
+curated JSON and signed tag are the evidence layer. Keep those roles separate.
+
+## Open qualification work
+
+These items refine Noema's guarantees; they are not missing command or protocol
+ports:
+
+1. Repeat the passing macOS APFS forced-detach qualification on a hard-powered
+   VM or disposable hardware target. The local gate covers restore placement,
+   configuration rename, journal cleanup, SQLite recovery, and acknowledged
+   standard-mode state, but cannot force a device to lose an already
+   acknowledged volatile-cache write.
+2. Decide whether corrupt-database salvage belongs in Noema. The current Rust
+   implementation fails closed and preserves the original bytes.
+3. Complete human TUI checks across the supported terminal emulators.
+4. Extend qualitative evaluation to a redacted representative corpus,
+   additional models, and multiple reviewers.
+
+## Operational caution
+
+Do not downgrade a cortex while a `strong` pending-mutation record exists.
+Complete recovery with the current Noema binary first; releases predating the
+strong journal do not understand that record.
+
+## Regenerating the published charts
+
+After updating `tests/rust-rewrite/report-data.json`, regenerate every SVG:
+
+```sh
+make historical-report
+```
+
+The selected `REPORT_PYTHON` interpreter needs Matplotlib. Matplotlib is report
+tooling, not a Noema runtime dependency. Override the interpreter when needed:
+
+```sh
+make historical-report REPORT_PYTHON=/path/to/python
+```
+
+Set `NOEMA_REPORT_PREVIEW_DIR=/tmp/noema-report-preview` to render uncommitted
+PNG copies for visual review alongside the canonical SVGs.
+
+## Adding or replacing a result
+
+1. Require the scenario's correctness gate to pass before measuring it.
+2. Use release-optimized binaries and record the candidate commit, host class,
+   operating system, architecture, and toolchain.
+3. Preserve alternating execution order, independent corpora, fresh processes,
+   run count, and exact post-write verification.
+4. Keep unlike campaigns separate. Mark superseded measurements as historical
+   instead of silently combining them.
+5. Update the curated JSON, regenerate every chart, and update the adjacent
+   accessible table and prose in `docs/why-rust.md` together.
+6. Recheck every percentage and ratio against the curated source data.
+7. Run the repository gates before treating a result as release evidence:
+
+   ```sh
+   make test
+   make release-check
+   git diff --check
+   ```
+
+8. When a claim targets a release candidate, validate the six-platform
+   archives, checksums, plugin bundles, and Homebrew metadata from that exact
+   candidate commit before publishing the claim.
+
+Historical Go/Rust reproduction requires checking out the signed
+`rust-cutover-baseline` tag. Do not imply that the current Rust-only tree can
+recreate the former Go binary without that checkout.
+
+## Public-document rules
+
+- Keep `docs/why-rust.md` focused on the decision, measured evidence,
+  limitations, and user-relevant tradeoffs.
+- Keep commands, regeneration instructions, open tasks, and release procedures
+  here.
+- Retain unfavorable results. A new campaign may supersede an older one, but it
+  must not silently remove caveats such as broad-output memory use or artifact
+  size.
+- Use qualified language: measured points are not fitted scaling curves, short
+  soaks are not stability claims, and model wall time is not runtime speed.
+- Keep chart alt text and accessible tables synchronized with visual changes.

--- a/docs/why-rust.md
+++ b/docs/why-rust.md
@@ -1,13 +1,11 @@
 # Why Noema switched to Rust
 
-Status: accepted cutover decision, last updated 2026-08-17.
-
-Noema's production implementation is now Rust. The case was not that Rust is
-universally faster, nor that a language rewrite automatically improves a
-system. The case was that this specific implementation matched Noema's tested
-behavior, improved the workloads most representative of a long-lived memory
-service, and made an enhanced recovery protocol available without imposing its
-cost on every user.
+Noema's production implementation switched to Rust in v0.20.0. The case was
+not that Rust is universally faster, nor that a language rewrite automatically
+improves a system. The case was that this specific implementation matched
+Noema's tested behavior, improved the workloads most representative of a
+long-lived memory service, and made an enhanced recovery protocol available
+without imposing its cost on every user.
 
 The final side-by-side state is preserved by the signed
 `rust-cutover-baseline` tag. The repository root, build, CI, and release paths
@@ -36,7 +34,7 @@ for that decision.
 | Enhanced durability | `strong` passes process-death and APFS detach/remount recovery, with a large write cost | Useful opt-in; hard power-cut/device-cache qualification remains |
 | Release artifact | Rust is 27.8% larger in the current local release build | Favors Go, but operational impact is small |
 | Production source | Rust uses 10.7% fewer code-only lines and 30.3% fewer physical lines | Smaller implementation; not proof of correctness or a language-wide result |
-| Release readiness | Rust-only source, CI, six-platform release packaging, checksums, plugins, and Homebrew metadata are configured | Cutover accepted; remote workflow and first-release validation remain operational gates |
+| Release delivery | v0.20.0 shipped Rust-only source, CI, six-platform archives, checksums, plugins, and Homebrew packages | Production cutover complete |
 
 ## Performance at scale
 
@@ -78,10 +76,10 @@ mixed workloads favored Rust, four-client broad output was nearly tied at
 | 100k four-client selective | 52% faster | 39% less |
 | 100k mixed read/write | 41% faster | 41% less |
 
-The 100k serial-broad result is the clearest remaining performance target. It
+The 100k serial-broad result is the clearest performance caveat. It
 does not erase the gains elsewhere, but it prevents a claim that Rust always
-uses less memory. Full-corpus MCP responses should eventually become bounded or
-streamed regardless of implementation.
+uses less memory. Users relying on repeated full-corpus MCP responses should
+budget memory accordingly; selective retrieval and mixed traffic use less.
 
 ## Long-lived federation uses fewer resources
 
@@ -182,9 +180,9 @@ the default behavior.
 
 The Rust artifact is currently 27.8% larger. Both remain single local binaries,
 so the practical distribution cost is modest, but this is a real Go advantage.
-Rust also changes the build and cross-compilation toolchain; bundled SQLite and
-platform packaging need release-matrix validation rather than assumptions from
-the Go pipeline.
+Rust also changes the build and cross-compilation toolchain. The v0.20.0
+release validated bundled SQLite and the macOS, Linux, and Windows packaging
+matrix on x86-64 and ARM64.
 
 Rust's language-level contribution is compile-time memory and thread safety for
 a server that combines SQLite access, background federation, watchers,
@@ -241,63 +239,15 @@ Only the corrected final campaigns are used in the headline scale charts.
 Earlier results remain valuable as an optimization history, not as final
 Go-versus-Rust evidence.
 
-## Operational follow-ups after cutover
+## Evidence and methodology
 
-These items refine Noema's guarantees and rollout evidence; they are no longer
-missing command or protocol ports:
+The charts and accessible tables above are generated from the curated
+[`report-data.json`](../tests/rust-rewrite/report-data.json) dataset. The signed
+`rust-cutover-baseline` tag preserves the final Go and Rust comparison state.
+Detailed methodology, campaign definitions, and historical results remain in
+the [`Rust rewrite experiment results`](rust-rewrite-experiment-results.md).
 
-1. Repeat the passing macOS APFS forced-detach qualification on a hard-powered
-   VM or disposable hardware target. The local gate covers restore placement,
-   configuration rename, journal cleanup, SQLite recovery, and acknowledged
-   standard-mode state, but cannot force a device to lose already-acknowledged
-   cache writes.
-2. Decide whether corrupt-database salvage belongs in Noema; Rust currently
-   fails closed and preserves the bytes.
-3. Do not downgrade a cortex while a `strong` pending-mutation record exists.
-   Complete recovery with the current Noema binary first; older releases do not
-   understand that journal.
-4. Complete human TUI checks across the supported terminal emulators.
-5. Extend qualitative evaluation to a redacted representative corpus,
-   additional models, and multiple reviewers.
-6. Exercise the six-platform release workflow on the first candidate tag and
-   validate the generated archives, checksums, plugin bundles, and Homebrew
-   metadata before promotion.
-7. Repeat the release qualification and key performance campaign against the
-   exact release candidate commit.
-
-## Reproduction and maintenance
-
-The curated chart data lives in
-[`tests/rust-rewrite/report-data.json`](../tests/rust-rewrite/report-data.json).
-Regenerate every SVG after updating it:
-
-```sh
-make historical-report
-```
-
-The selected `REPORT_PYTHON` interpreter needs Matplotlib. It remains a report
-tooling dependency, not a Noema runtime dependency. Override the interpreter
-when necessary, for example
-`make historical-report REPORT_PYTHON=/path/to/python`.
-Set `NOEMA_REPORT_PREVIEW_DIR=/tmp/noema-report-preview` to render uncommitted
-PNG copies for visual review alongside the canonical SVGs.
-
-When adding a new result:
-
-1. Require its correctness gate to pass first.
-2. Use release-optimized binaries and record the candidate commit and host.
-3. Preserve alternating order, independent corpora, fresh processes, run count,
-   and exact post-write verification.
-4. Update the curated JSON, regenerate the charts, and update this document's
-   date and adjacent accessible tables.
-5. Mark superseded measurements as historical rather than silently combining
-   incompatible campaigns.
-6. Run `make test`, `make release-check`, and `git diff --check` before treating
-   a new result as release evidence. Historical Go/Rust reproduction requires
-   checking out the signed `rust-cutover-baseline` tag.
-
-Detailed methodology and historical results remain in the
-[`Rust rewrite experiment results`](rust-rewrite-experiment-results.md), the
-current qualification state in [`Rust rewrite status`](rust-rewrite-status.md),
-and acceptance criteria in the
-[`Rust rewrite test plan`](rust-rewrite-test-plan.md).
+Contributor procedures, evidence-update rules, and open qualification work are
+kept separately in the
+[`Rust cutover evidence maintenance guide`](rust-rewrite-maintenance.md), so
+this page can remain a stable explanation of the public decision.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,4 +1,5 @@
 use std::{
+    fmt::Write as _,
     fs::{self, OpenOptions},
     io::{self, IsTerminal, Read, Write},
     path::{Path, PathBuf},
@@ -15,7 +16,8 @@ use crate::{
     config::Config,
     consolidation::{DistillationConfig, HeuristicConfig, run_distillation_pass},
     cortex::{
-        Cortex, EmbedBackfillOptions, ListOptions, SemanticOptions, TraceIdExists, write_manifest,
+        Cortex, EmbedBackfillOptions, ListOptions, SemanticOptions, TagStatsReport, TraceIdExists,
+        write_manifest,
     },
     embedding::HttpEmbedder,
     eventsig,
@@ -58,6 +60,7 @@ enum Command {
     #[command(alias = "rm", alias = "delete")]
     Remove {
         id: String,
+        /// Bypass source-lock protection; the trace still moves to recoverable trash
         #[arg(short = 'f', long)]
         force: bool,
     },
@@ -66,7 +69,12 @@ enum Command {
     /// Restore an archived Trace
     Unarchive { id: String },
     /// Restore a trashed Trace
-    Recover { id: String },
+    Recover {
+        id: String,
+        /// Bypass source-lock protection
+        #[arg(short = 'f', long)]
+        force: bool,
+    },
     /// Permanently delete expired trashed Traces
     Purge {
         #[arg(long, default_value_t = 30)]
@@ -123,6 +131,12 @@ enum Command {
     Memory {
         #[command(subcommand)]
         command: MemoryCommand,
+    },
+    /// Inspect and maintain trace tags
+    #[command(alias = "tag")]
+    Tags {
+        #[command(subcommand)]
+        command: TagCommand,
     },
     /// Run a consolidation pass
     Consolidate(ConsolidateArgs),
@@ -319,6 +333,60 @@ enum MemoryCommand {
         confirm: bool,
         #[arg(long)]
         hard: bool,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+enum TagCommand {
+    /// Show tag counts, visibility, tier, and engagement statistics
+    Stats {
+        /// Maximum tag rows to show (0 means all)
+        #[arg(long, default_value_t = 50)]
+        limit: usize,
+        #[arg(long, default_value = "text", value_parser = ["text", "json"])]
+        output: String,
+    },
+    /// Rename a tag across active and archived traces
+    Rename {
+        old: String,
+        new: String,
+        /// Match ASCII case variants of the source tag
+        #[arg(short = 'i', long)]
+        ignore_case: bool,
+        /// Print the complete plan without changing traces
+        #[arg(long)]
+        dry_run: bool,
+        /// Apply without an interactive confirmation prompt
+        #[arg(short = 'y', long)]
+        yes: bool,
+        #[arg(long, default_value = "text", value_parser = ["text", "json"])]
+        output: String,
+    },
+    /// Delete a tag from active and archived traces
+    Delete {
+        tag: String,
+        /// Match ASCII case variants of the tag
+        #[arg(short = 'i', long)]
+        ignore_case: bool,
+        /// Print the complete plan without changing traces
+        #[arg(long)]
+        dry_run: bool,
+        /// Apply without an interactive confirmation prompt
+        #[arg(short = 'y', long)]
+        yes: bool,
+        #[arg(long, default_value = "text", value_parser = ["text", "json"])]
+        output: String,
+    },
+    /// Diagnose tags that are noncanonical or problematic in Obsidian
+    Doctor {
+        /// Apply deterministic fixes; ambiguous findings remain unchanged
+        #[arg(long)]
+        fix: bool,
+        /// Apply fixes without an interactive confirmation prompt
+        #[arg(short = 'y', long, requires = "fix")]
+        yes: bool,
+        #[arg(long, default_value = "text", value_parser = ["text", "json"])]
+        output: String,
     },
 }
 
@@ -604,13 +672,8 @@ async fn execute_cortex_command(cx: &mut Cortex, command: Command) -> Result<()>
         }
         Command::Remove { id, force } => {
             cx.set_force_source_lock(force);
-            if force {
-                cx.remove_hard(&id)?;
-                println!("Trace {id} permanently deleted.");
-            } else {
-                cx.trash(&id)?;
-                println!("Trace moved to trash: {id}");
-            }
+            cx.trash(&id)?;
+            println!("Trace moved to trash: {id}");
         }
         Command::Archive { id } => {
             cx.archive(&id)?;
@@ -620,11 +683,13 @@ async fn execute_cortex_command(cx: &mut Cortex, command: Command) -> Result<()>
             cx.unarchive(&id)?;
             println!("Trace unarchived: {id}");
         }
-        Command::Recover { id } => {
+        Command::Recover { id, force } => {
+            cx.set_force_source_lock(force);
             cx.recover(&id)?;
             println!("Trace recovered: {id}");
         }
         Command::Purge { days } => println!("Purged {} trace(s).", cx.purge_expired(days)?),
+        Command::Tags { command } => tag_command(cx, command)?,
         Command::Search {
             query,
             semantic,
@@ -723,14 +788,20 @@ async fn execute_cortex_command(cx: &mut Cortex, command: Command) -> Result<()>
                 if recover {
                     println!("      The local event log had no usable snapshot for these IDs.");
                     println!(
-                        "      Use `noema list` + `noema remove --force <id>` to clean them up."
+                        "      Use `noema list` to inspect the tier, then explicitly purge each orphan:"
+                    );
+                    println!(
+                        "      `noema memory purge <id> --tier <tier> --reason \"orphan cleanup\" --confirm --hard`."
                     );
                 } else {
                     println!(
                         "      Try `noema sync --recover` to rebuild them from the local event log,"
                     );
                     println!(
-                        "      or use `noema list` + `noema remove --force <id>` to clean them up."
+                        "      or use `noema list` to inspect the tier and explicitly purge each orphan:"
+                    );
+                    println!(
+                        "      `noema memory purge <id> --tier <tier> --reason \"orphan cleanup\" --confirm --hard`."
                     );
                 }
             }
@@ -1375,6 +1446,329 @@ fn remove_cortex(name: &str, purge: bool, force: bool) -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn tag_command(cx: &Cortex, command: TagCommand) -> Result<()> {
+    match command {
+        TagCommand::Stats { limit, output } => {
+            let report = cx.tag_stats(limit)?;
+            if output == "json" {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(
+                        &serde_json::json!({"schema_version":1,"report":report})
+                    )?
+                );
+                return Ok(());
+            }
+            print!("{}", format_tag_stats_report(&report));
+        }
+        TagCommand::Rename {
+            old,
+            new,
+            ignore_case,
+            dry_run,
+            yes,
+            output,
+        } => {
+            if old.is_empty() || new.is_empty() {
+                bail!("tag names must not be empty");
+            }
+            if old == new {
+                bail!("source and destination tags are identical");
+            }
+            let rows = tag_rows(cx)?;
+            let plan = crate::tag::rename_plan(&rows, &cx.name, &old, &new, ignore_case);
+            execute_tag_plan(cx, "rename", &plan, dry_run, yes, &output, None)?;
+        }
+        TagCommand::Delete {
+            tag,
+            ignore_case,
+            dry_run,
+            yes,
+            output,
+        } => {
+            if tag.is_empty() {
+                bail!("tag name must not be empty");
+            }
+            let rows = tag_rows(cx)?;
+            let plan = crate::tag::delete_plan(&rows, &cx.name, &tag, ignore_case);
+            execute_tag_plan(cx, "delete", &plan, dry_run, yes, &output, None)?;
+        }
+        TagCommand::Doctor { fix, yes, output } => {
+            let rows = tag_rows(cx)?;
+            let report = crate::tag::doctor(&rows);
+            if output == "json" && !fix {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(
+                        &serde_json::json!({"schema_version":1,"report":report})
+                    )?
+                );
+                return Ok(());
+            }
+            if output == "text" {
+                print!("{}", format_tag_doctor_report(&report));
+            }
+            if !fix {
+                return Ok(());
+            }
+            let plan = crate::tag::doctor_fix_plan(&rows, &cx.name, &report);
+            execute_tag_plan(cx, "doctor_fix", &plan, false, yes, &output, Some(&report))?;
+        }
+    }
+    Ok(())
+}
+
+fn format_tag_stats_report(report: &TagStatsReport) -> String {
+    let mut output = format!(
+        "Distinct tags: {}\nAssignments:   {}\n",
+        report.distinct_tags, report.assignments
+    );
+    if report.tags.is_empty() {
+        output.push_str("\n(no tags)\n");
+        return output;
+    }
+
+    let tag_width = report
+        .tags
+        .iter()
+        .map(|entry| entry.tag.chars().count())
+        .max()
+        .unwrap_or_default()
+        .max("Tag".len());
+    let traces_width =
+        numeric_column_width("Traces", report.tags.iter().map(|entry| entry.trace_count));
+    let active_width =
+        numeric_column_width("Active", report.tags.iter().map(|entry| entry.active_count));
+    let archived_width = numeric_column_width(
+        "Archived",
+        report.tags.iter().map(|entry| entry.archived_count),
+    );
+    let long_width = numeric_column_width("Long", report.tags.iter().map(|entry| entry.long_count));
+    let hits_width =
+        numeric_column_width("Hits", report.tags.iter().map(|entry| entry.search_hits));
+    let reads_width =
+        numeric_column_width("Reads", report.tags.iter().map(|entry| entry.read_count));
+    let modifies_width = numeric_column_width(
+        "Modifies",
+        report.tags.iter().map(|entry| entry.modify_count),
+    );
+
+    let _ = writeln!(
+        output,
+        "\n{:<tag_width$}  {:>traces_width$}  {:>active_width$}  {:>archived_width$}  {:>long_width$}  {:>hits_width$}  {:>reads_width$}  {:>modifies_width$}",
+        "Tag", "Traces", "Active", "Archived", "Long", "Hits", "Reads", "Modifies"
+    );
+    for entry in &report.tags {
+        let _ = writeln!(
+            output,
+            "{:<tag_width$}  {:>traces_width$}  {:>active_width$}  {:>archived_width$}  {:>long_width$}  {:>hits_width$}  {:>reads_width$}  {:>modifies_width$}",
+            entry.tag,
+            entry.trace_count,
+            entry.active_count,
+            entry.archived_count,
+            entry.long_count,
+            entry.search_hits,
+            entry.read_count,
+            entry.modify_count
+        );
+    }
+    output
+}
+
+fn numeric_column_width(header: &str, values: impl Iterator<Item = i64>) -> usize {
+    values
+        .map(|value| value.to_string().len())
+        .max()
+        .unwrap_or_default()
+        .max(header.len())
+}
+
+fn tag_rows(cx: &Cortex) -> Result<Vec<crate::cortex::Row>> {
+    cx.tag_rows()
+}
+
+fn execute_tag_plan(
+    cx: &Cortex,
+    action: &str,
+    plan: &crate::tag::TagMutationPlan,
+    dry_run: bool,
+    assume_yes: bool,
+    output: &str,
+    report: Option<&crate::tag::TagDoctorReport>,
+) -> Result<()> {
+    if output == "text" {
+        println!("Tag {action} plan");
+        if plan.matched_spellings.is_empty() {
+            println!("  matched spellings: (none)");
+        } else {
+            println!("  matched spellings:");
+            for (spelling, count) in &plan.matched_spellings {
+                println!("    {spelling}: {count} assignment(s)");
+            }
+        }
+        println!("  affected traces:  {}", plan.changes.len());
+        if !plan.blocked_source_locked.is_empty() {
+            println!(
+                "  source-locked:    {}",
+                plan.blocked_source_locked.join(", ")
+            );
+        }
+    }
+
+    if !plan.blocked_source_locked.is_empty() {
+        if output == "json" {
+            print_tag_plan_json(action, plan, dry_run, false, 0, report)?;
+        }
+        bail!(
+            "{} source-locked trace(s) block this operation",
+            plan.blocked_source_locked.len()
+        );
+    }
+    if plan.changes.is_empty() {
+        if output == "json" {
+            print_tag_plan_json(action, plan, dry_run, false, 0, report)?;
+        } else {
+            println!("No changes required.");
+        }
+        return Ok(());
+    }
+    if dry_run {
+        if output == "json" {
+            print_tag_plan_json(action, plan, true, false, 0, report)?;
+        } else {
+            println!("Dry run only; no traces changed.");
+        }
+        return Ok(());
+    }
+    if !assume_yes {
+        if output == "json" || !io::stdin().is_terminal() {
+            bail!("--yes is required for non-interactive tag mutations");
+        }
+        print!("Proceed? [y/N]: ");
+        io::stdout().flush()?;
+        if !tag_mutation_confirmed(&read_line()?) {
+            println!("Aborted; no traces changed.");
+            return Ok(());
+        }
+    }
+
+    let mut changed = 0;
+    for change in &plan.changes {
+        cx.set_tags(&change.id, change.after.clone(), false)
+            .with_context(|| {
+                format!(
+                    "tag {action} stopped after {changed} successful trace mutation(s); rerun is safe"
+                )
+            })?;
+        changed += 1;
+    }
+    if output == "json" {
+        print_tag_plan_json(action, plan, false, true, changed, report)?;
+    } else {
+        println!("Changed {changed} trace(s).");
+    }
+    Ok(())
+}
+
+fn tag_mutation_confirmed(answer: &str) -> bool {
+    answer.eq_ignore_ascii_case("y") || answer.eq_ignore_ascii_case("yes")
+}
+
+fn print_tag_plan_json(
+    action: &str,
+    plan: &crate::tag::TagMutationPlan,
+    dry_run: bool,
+    applied: bool,
+    changed: usize,
+    report: Option<&crate::tag::TagDoctorReport>,
+) -> Result<()> {
+    let mut output = serde_json::json!({
+        "schema_version": 1,
+        "action": action,
+        "dry_run": dry_run,
+        "matched_spellings": &plan.matched_spellings,
+        "matched_assignments": plan.matched_assignments(),
+        "affected_traces": plan.changes.len(),
+        "changes": &plan.changes,
+        "blocked_source_locked": &plan.blocked_source_locked,
+        "applied": applied,
+        "changed_traces": changed,
+    });
+    if let Some(report) = report {
+        output["report"] = serde_json::to_value(report)?;
+    }
+    println!("{}", serde_json::to_string_pretty(&output)?);
+    Ok(())
+}
+
+fn format_tag_doctor_report(report: &crate::tag::TagDoctorReport) -> String {
+    let mut output = format!("Checked {} distinct tag(s).\n", report.checked_tags);
+    if report.findings.is_empty() {
+        output.push_str("No tag hygiene findings.\n");
+        return output;
+    }
+
+    let rows = report
+        .findings
+        .iter()
+        .map(|finding| {
+            let issues = finding
+                .issues
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(",");
+            (
+                finding.tag.as_str(),
+                finding.trace_count,
+                issues,
+                finding.suggestion.as_deref().unwrap_or("manual review"),
+            )
+        })
+        .collect::<Vec<_>>();
+    let tag_width = rows
+        .iter()
+        .map(|row| row.0.chars().count())
+        .max()
+        .unwrap_or_default()
+        .max("Tag".len());
+    let traces_width = rows
+        .iter()
+        .map(|row| row.1.to_string().len())
+        .max()
+        .unwrap_or_default()
+        .max("Traces".len());
+    let issues_width = rows
+        .iter()
+        .map(|row| row.2.chars().count())
+        .max()
+        .unwrap_or_default()
+        .max("Issues".len());
+    let _ = writeln!(
+        output,
+        "\n{:<tag_width$}  {:>traces_width$}  {:<issues_width$}  Suggested fix",
+        "Tag", "Traces", "Issues"
+    );
+    for (tag, traces, issues, suggestion) in rows {
+        let _ = writeln!(
+            output,
+            "{tag:<tag_width$}  {traces:>traces_width$}  {issues:<issues_width$}  {suggestion}"
+        );
+    }
+    if !report.collisions.is_empty() {
+        output.push_str("\nNormalization collisions:\n");
+        for collision in &report.collisions {
+            let _ = writeln!(
+                output,
+                "  {} <- {}",
+                collision.destination,
+                collision.sources.join(", ")
+            );
+        }
+    }
+    output
 }
 
 fn memory_command(cx: &Cortex, command: MemoryCommand) -> Result<()> {
@@ -3714,6 +4108,120 @@ mod tests {
             Command::Serve(ServeArgs { ref allowed_host, .. })
                 if allowed_host == &["memory.example.com", "memory.example.com:3000"]
         ));
+    }
+
+    #[test]
+    fn tag_commands_parse_aliases_and_automation_flags() {
+        let cli = Cli::try_parse_from(["noema", "tags", "rename", "AI", "ai", "-i", "-y"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Tags {
+                command: TagCommand::Rename {
+                    ignore_case: true,
+                    yes: true,
+                    ..
+                }
+            }
+        ));
+
+        let cli = Cli::try_parse_from(["noema", "tag", "delete", "legacy", "--dry-run"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Command::Tags {
+                command: TagCommand::Delete { dry_run: true, .. }
+            }
+        ));
+
+        assert!(Cli::try_parse_from(["noema", "tags", "doctor", "--yes"]).is_err());
+        assert!(tag_mutation_confirmed("y"));
+        assert!(tag_mutation_confirmed("YES"));
+        assert!(!tag_mutation_confirmed("n"));
+        assert!(!tag_mutation_confirmed(""));
+    }
+
+    #[test]
+    fn tag_stats_text_aligns_variable_width_columns_without_tabs() {
+        let report = TagStatsReport {
+            distinct_tags: 1,
+            assignments: 1111,
+            tags: vec![crate::cortex::TagStatsEntry {
+                tag: "a-variable-width-tag".into(),
+                trace_count: 1111,
+                active_count: 222,
+                archived_count: 33,
+                long_count: 44,
+                search_hits: 5555,
+                read_count: 666,
+                modify_count: 77,
+            }],
+        };
+        let output = format_tag_stats_report(&report);
+        assert!(!output.contains('\t'));
+        let mut lines = output.lines();
+        assert_eq!(lines.next(), Some("Distinct tags: 1"));
+        assert_eq!(lines.next(), Some("Assignments:   1111"));
+        assert_eq!(lines.next(), Some(""));
+        let header = lines.next().unwrap();
+        let row = lines.next().unwrap();
+        for (heading, value) in [
+            ("Traces", "1111"),
+            ("Active", "222"),
+            ("Archived", "33"),
+            ("Long", "44"),
+            ("Hits", "5555"),
+            ("Reads", "666"),
+            ("Modifies", "77"),
+        ] {
+            assert_eq!(
+                header.find(heading).unwrap() + heading.len(),
+                row.find(value).unwrap() + value.len()
+            );
+        }
+    }
+
+    #[test]
+    fn tag_doctor_text_aligns_variable_width_columns_without_tabs() {
+        let report = crate::tag::TagDoctorReport {
+            checked_tags: 2,
+            findings: vec![
+                crate::tag::TagDiagnostic {
+                    tag: "a-variable-width-tag".into(),
+                    trace_count: 65,
+                    issues: vec![
+                        crate::tag::TagIssue::Period,
+                        crate::tag::TagIssue::Uppercase,
+                    ],
+                    suggestion: Some("normalized-tag".into()),
+                },
+                crate::tag::TagDiagnostic {
+                    tag: "2026-08-18".into(),
+                    trace_count: 1,
+                    issues: vec![crate::tag::TagIssue::NumericOnly],
+                    suggestion: None,
+                },
+            ],
+            collisions: vec![crate::tag::TagCollision {
+                destination: "normalized-tag".into(),
+                sources: vec!["Normalized.Tag".into(), "normalized-tag".into()],
+            }],
+        };
+        let output = format_tag_doctor_report(&report);
+        assert!(!output.contains('\t'));
+        let mut lines = output.lines();
+        assert_eq!(lines.next(), Some("Checked 2 distinct tag(s)."));
+        assert_eq!(lines.next(), Some(""));
+        let header = lines.next().unwrap();
+        let first = lines.next().unwrap();
+        let second = lines.next().unwrap();
+        assert_eq!(header.find("Issues"), first.find("period,uppercase"));
+        assert_eq!(header.find("Issues"), second.find("numeric_only"));
+        assert_eq!(header.find("Suggested fix"), first.find("normalized-tag"));
+        assert_eq!(header.find("Suggested fix"), second.find("manual review"));
+        assert_eq!(
+            header.find("Traces").unwrap() + "Traces".len(),
+            first.find("65").unwrap() + "65".len()
+        );
+        assert!(output.contains("  normalized-tag <- Normalized.Tag, normalized-tag"));
     }
 
     #[test]

--- a/src/cortex.rs
+++ b/src/cortex.rs
@@ -556,6 +556,25 @@ pub struct TagSummary {
 }
 
 #[derive(Debug, Clone, Default, Serialize)]
+pub struct TagStatsEntry {
+    pub tag: String,
+    pub trace_count: i64,
+    pub active_count: i64,
+    pub archived_count: i64,
+    pub long_count: i64,
+    pub search_hits: i64,
+    pub read_count: i64,
+    pub modify_count: i64,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct TagStatsReport {
+    pub distinct_tags: usize,
+    pub assignments: i64,
+    pub tags: Vec<TagStatsEntry>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct TierStats {
     pub short: i64,
@@ -1855,6 +1874,61 @@ impl Cortex {
             .collect::<rusqlite::Result<Vec<_>>>()?)
     }
 
+    pub fn tag_stats(&self, limit: usize) -> Result<TagStatsReport> {
+        let mut statement = self.connection.prepare(
+            "SELECT tt.tag,
+                    COUNT(DISTINCT t.id) AS trace_count,
+                    COUNT(DISTINCT CASE WHEN t.archived_at IS NULL THEN t.id END) AS active_count,
+                    COUNT(DISTINCT CASE WHEN t.archived_at IS NOT NULL THEN t.id END) AS archived_count,
+                    COUNT(DISTINCT CASE WHEN t.tier='long' THEN t.id END) AS long_count,
+                    COALESCE(SUM(u.search_hit_count),0) AS hits,
+                    COALESCE(SUM(u.read_count),0) AS reads,
+                    COALESCE(SUM(u.modify_count),0) AS mods
+             FROM trace_tags tt
+             JOIN traces t ON t.id=tt.trace_id
+             LEFT JOIN trace_usage u ON u.trace_id=t.id
+             WHERE t.trashed_at IS NULL AND t.purged_at IS NULL
+             GROUP BY tt.tag
+             ORDER BY trace_count DESC,tt.tag ASC",
+        )?;
+        let mut tags = statement
+            .query_map([], |row| {
+                Ok(TagStatsEntry {
+                    tag: row.get(0)?,
+                    trace_count: row.get(1)?,
+                    active_count: row.get(2)?,
+                    archived_count: row.get(3)?,
+                    long_count: row.get(4)?,
+                    search_hits: row.get(5)?,
+                    read_count: row.get(6)?,
+                    modify_count: row.get(7)?,
+                })
+            })?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        let distinct_tags = tags.len();
+        let assignments = tags.iter().map(|tag| tag.trace_count).sum();
+        if limit > 0 {
+            tags.truncate(limit);
+        }
+        Ok(TagStatsReport {
+            distinct_tags,
+            assignments,
+            tags,
+        })
+    }
+
+    pub fn tag_rows(&self) -> Result<Vec<Row>> {
+        let mut rows = self.list(&ListOptions {
+            all: true,
+            ..Default::default()
+        })?;
+        for row in &mut rows {
+            let trace = Trace::parse_file(&self.file_path(row))?;
+            row.tags = trace.frontmatter.tags;
+        }
+        Ok(rows)
+    }
+
     pub fn tier_stats(&self) -> Result<TierStats> {
         let mut stats = TierStats::default();
         let mut statement = self.connection.prepare(
@@ -2800,9 +2874,7 @@ impl Cortex {
     }
 
     pub fn set_tags(&self, id: &str, tags: Vec<String>, actor_agent: bool) -> Result<()> {
-        let (_, mut trace) = self.get_trace(id)?;
-        trace.frontmatter.tags = dedupe(tags);
-        self.update_trace(id, &mut trace, actor_agent)
+        self.replace_trace_tags(id, dedupe(tags), actor_agent)
     }
 
     pub fn append_tags(
@@ -2815,8 +2887,40 @@ impl Cortex {
         trace.frontmatter.tags.extend(tags);
         trace.frontmatter.tags = dedupe(trace.frontmatter.tags);
         let result = trace.frontmatter.tags.clone();
-        self.update_trace(id, &mut trace, actor_agent)?;
+        self.replace_trace_tags(id, result.clone(), actor_agent)?;
         Ok(result)
+    }
+
+    fn replace_trace_tags(&self, id: &str, tags: Vec<String>, actor_agent: bool) -> Result<()> {
+        let row = self.get(id)?;
+        self.check_source_lock(&row)?;
+        let (_, mut trace) = self.get_trace(id)?;
+        if trace.frontmatter.tags == tags {
+            return Ok(());
+        }
+        trace.frontmatter.tags = tags;
+        trace.frontmatter.updated = row.updated_at.clone();
+        trace.validate()?;
+        let path = self.file_path(&row);
+        self.replace_trace_transactionally(&path, &trace, |pending_key| {
+            let tx = self.connection.unchecked_transaction()?;
+            replace_tags(&tx, id, &trace.frontmatter.tags)?;
+            upsert_fts(&tx, id, &row.title, &trace.body, &trace.frontmatter.tags)?;
+            self.emit_event(
+                &tx,
+                "tag_update",
+                id,
+                &trace::now_rfc3339(),
+                json!({"tags":&trace.frontmatter.tags}),
+            )?;
+            Self::clear_pending_in_transaction(&tx, pending_key)?;
+            tx.commit()?;
+            Ok(())
+        })?;
+        if actor_agent {
+            self.bump_usage(id, false, true)?;
+        }
+        Ok(())
     }
 
     pub fn archive(&self, id: &str) -> Result<()> {
@@ -5708,6 +5812,79 @@ mod tests {
         assert_eq!(after.content_hash, before.content_hash);
         assert_eq!(after.updated_at, before.updated_at);
         assert_eq!(Trace::parse_file(&path).unwrap().body, "out-of-band edit");
+    }
+
+    #[test]
+    fn tag_only_mutation_preserves_long_term_content_immutability() {
+        let (_temp, cx) = cortex();
+        let mut trace = Trace::new(
+            "Retaggable immutable memory",
+            "fact",
+            "",
+            vec!["Old.Tag".into(), "stable".into()],
+            "committed body",
+        );
+        cx.add(&mut trace).unwrap();
+        let id = trace.frontmatter.id.clone();
+        cx.promote(&id, "mid").unwrap();
+        cx.promote(&id, "long").unwrap();
+        let before = cx.get(&id).unwrap();
+
+        cx.set_tags(&id, vec!["new-tag".into(), "stable".into()], false)
+            .unwrap();
+
+        let after = cx.get(&id).unwrap();
+        let (_, stored) = cx.get_trace(&id).unwrap();
+        assert_eq!(after.tier, "long");
+        assert_eq!(after.tags, vec!["new-tag", "stable"]);
+        assert_eq!(stored.frontmatter.tags, vec!["new-tag", "stable"]);
+        assert_eq!(stored.body, "committed body");
+        assert_eq!(after.content_hash, before.content_hash);
+        assert_eq!(after.updated_at, before.updated_at);
+        assert!(cx.update_trace(&id, &mut trace, false).is_err());
+        assert_eq!(
+            cx.history(&id).unwrap().last().unwrap().action,
+            "tag_update"
+        );
+        assert_eq!(
+            cx.search(
+                "new-tag",
+                &ListOptions {
+                    all: true,
+                    ..Default::default()
+                }
+            )
+            .unwrap()
+            .len(),
+            1
+        );
+    }
+
+    #[test]
+    fn tag_stats_include_active_archived_and_long_counts() {
+        let (_temp, cx) = cortex();
+        let mut active = Trace::new("Active tags", "note", "", vec!["shared".into()], "body");
+        cx.add(&mut active).unwrap();
+        let mut archived = Trace::new(
+            "Archived tags",
+            "note",
+            "",
+            vec!["shared".into(), "archive-only".into()],
+            "body",
+        );
+        cx.add(&mut archived).unwrap();
+        cx.promote(&archived.frontmatter.id, "mid").unwrap();
+        cx.promote(&archived.frontmatter.id, "long").unwrap();
+        cx.archive(&archived.frontmatter.id).unwrap();
+
+        let report = cx.tag_stats(0).unwrap();
+        assert_eq!(report.distinct_tags, 2);
+        assert_eq!(report.assignments, 3);
+        let shared = report.tags.iter().find(|tag| tag.tag == "shared").unwrap();
+        assert_eq!(shared.trace_count, 2);
+        assert_eq!(shared.active_count, 1);
+        assert_eq!(shared.archived_count, 1);
+        assert_eq!(shared.long_count, 1);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod mcp;
 pub mod migration;
 pub mod plugin;
 pub mod restore;
+pub mod tag;
 pub mod tlsutil;
 pub mod trace;
 pub mod tui;

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -246,6 +246,48 @@ struct TagsParam {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+struct TagStatsParams {
+    /// Maximum tag rows to return (default 50, maximum 1000; 0 returns all)
+    limit: Option<usize>,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct RenameTagParams {
+    /// Exact source tag spelling
+    old_tag: String,
+    /// Destination tag spelling
+    new_tag: String,
+    /// Match ASCII case variants of old_tag
+    #[serde(default)]
+    ignore_case: bool,
+    /// Apply the plan. Defaults to false and returns a read-only preview.
+    #[serde(default)]
+    apply: bool,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct DeleteTagParams {
+    /// Exact tag spelling to remove
+    tag: String,
+    /// Match ASCII case variants of tag
+    #[serde(default)]
+    ignore_case: bool,
+    /// Apply the plan. Defaults to false and returns a read-only preview.
+    #[serde(default)]
+    apply: bool,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct TagDoctorParams {
+    /// Build a deterministic repair plan. Ambiguous findings remain report-only.
+    #[serde(default)]
+    fix: bool,
+    /// Apply the deterministic repair plan. Requires fix=true.
+    #[serde(default)]
+    apply: bool,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 struct VoteParam {
     /// Trace ID to vote on
     id: String,
@@ -637,6 +679,127 @@ impl NoemaServer {
             action: TagMutationAction::Append,
             tags,
         }))
+    }
+    #[tool(
+        description = "Tag taxonomy statistics across active and archived traces, including assignment, tier, visibility, and engagement counts."
+    )]
+    async fn tag_stats(
+        &self,
+        Parameters(p): Parameters<TagStatsParams>,
+    ) -> Result<String, ErrorData> {
+        let requested = p.limit.unwrap_or(50);
+        let limit = if requested == 0 {
+            0
+        } else {
+            requested.min(1000)
+        };
+        let report = self.open().await?.tag_stats(limit).map_err(mcp_error)?;
+        Ok(json_text(json!({"schema_version":1,"report":report})))
+    }
+    #[tool(
+        description = "Diagnose noncanonical or Obsidian-problematic tags. Read-only by default. Set fix=true to include a deterministic repair plan, then apply=true to execute it; numeric-only and other ambiguous findings are never auto-fixed."
+    )]
+    async fn tag_doctor(
+        &self,
+        Parameters(p): Parameters<TagDoctorParams>,
+    ) -> Result<String, ErrorData> {
+        if p.apply && !p.fix {
+            return Err(ErrorData::invalid_params(
+                "apply=true requires fix=true",
+                None,
+            ));
+        }
+        if p.apply {
+            self.ensure_writable()?;
+        }
+        let cx = self.open().await?;
+        let rows = cx.tag_rows().map_err(mcp_error)?;
+        let report = crate::tag::doctor(&rows);
+        let plan = p
+            .fix
+            .then(|| crate::tag::doctor_fix_plan(&rows, &cx.name, &report));
+        let applied = if p.apply {
+            apply_mcp_tag_plan(&cx, plan.as_ref().unwrap()).map_err(mcp_error)?
+        } else {
+            0
+        };
+        Ok(json_text(json!({
+            "schema_version":1,
+            "report":report,
+            "plan":plan.as_ref().map(tag_plan_value),
+            "applied":p.apply,
+            "changed_traces":applied,
+        })))
+    }
+    #[tool(
+        description = "Preview or apply a cortex-wide exact tag rename across active and archived traces. ASCII case-insensitive matching is opt-in. apply defaults to false."
+    )]
+    async fn rename_tag(
+        &self,
+        Parameters(p): Parameters<RenameTagParams>,
+    ) -> Result<String, ErrorData> {
+        if p.old_tag.is_empty() || p.new_tag.is_empty() {
+            return Err(ErrorData::invalid_params(
+                "tag names must not be empty",
+                None,
+            ));
+        }
+        if p.old_tag == p.new_tag {
+            return Err(ErrorData::invalid_params(
+                "source and destination tags are identical",
+                None,
+            ));
+        }
+        if p.apply {
+            self.ensure_writable()?;
+        }
+        let cx = self.open().await?;
+        let rows = cx.tag_rows().map_err(mcp_error)?;
+        let plan = crate::tag::rename_plan(&rows, &cx.name, &p.old_tag, &p.new_tag, p.ignore_case);
+        let applied = if p.apply {
+            apply_mcp_tag_plan(&cx, &plan).map_err(mcp_error)?
+        } else {
+            0
+        };
+        Ok(json_text(json!({
+            "schema_version":1,
+            "action":"rename",
+            "plan":tag_plan_value(&plan),
+            "applied":p.apply,
+            "changed_traces":applied,
+        })))
+    }
+    #[tool(
+        description = "Preview or apply cortex-wide removal of an exact tag from active and archived traces. ASCII case-insensitive matching is opt-in. apply defaults to false."
+    )]
+    async fn delete_tag(
+        &self,
+        Parameters(p): Parameters<DeleteTagParams>,
+    ) -> Result<String, ErrorData> {
+        if p.tag.is_empty() {
+            return Err(ErrorData::invalid_params(
+                "tag name must not be empty",
+                None,
+            ));
+        }
+        if p.apply {
+            self.ensure_writable()?;
+        }
+        let cx = self.open().await?;
+        let rows = cx.tag_rows().map_err(mcp_error)?;
+        let plan = crate::tag::delete_plan(&rows, &cx.name, &p.tag, p.ignore_case);
+        let applied = if p.apply {
+            apply_mcp_tag_plan(&cx, &plan).map_err(mcp_error)?
+        } else {
+            0
+        };
+        Ok(json_text(json!({
+            "schema_version":1,
+            "action":"delete",
+            "plan":tag_plan_value(&plan),
+            "applied":p.apply,
+            "changed_traces":applied,
+        })))
     }
     #[tool(
         description = "Cast a tier-preference vote on a trace. Use sparingly: only when the user has clearly indicated preference. Votes accumulate across calls and are preferences, not overrides."
@@ -1619,8 +1782,10 @@ derived_from when synthesizing conclusions from existing traces.
 append_trace is useful for running logs and fire-and-forget writes because it
 appends content without reading the full trace first.
 
-Use set_trace_tags or append_trace_tags for retrieval metadata hygiene. Do not
-use vote_trace to compensate for missing or excessive tags; voting is only a
+Use set_trace_tags or append_trace_tags for per-trace retrieval metadata
+hygiene. Use tag_stats and tag_doctor to inspect the cortex-wide taxonomy.
+rename_tag and delete_tag return a read-only plan unless apply=true. Do not use
+vote_trace to compensate for missing or excessive tags; voting is only a
 tier-preference signal.
 
 ## Guardrails
@@ -1753,6 +1918,7 @@ fn build_cortex_usage(cortex: &Cortex) -> Result<CortexUsageOutput> {
                 "append_trace appends content without reading the full trace first.",
                 "set_trace_tags replaces retrieval tags without touching title, body, type, or lineage.",
                 "append_trace_tags adds retrieval tags idempotently without touching title, body, type, or lineage.",
+                "rename_tag and delete_tag preview cortex-wide changes by default and require apply=true to mutate.",
                 "archive_trace hides without deleting; delete_trace moves to trash; recover_trace restores from trash."
             ],
             "audit_federation":[
@@ -1768,13 +1934,15 @@ fn build_cortex_usage(cortex: &Cortex) -> Result<CortexUsageOutput> {
             "durability_profile":cortex.durability_profile(),
             "filesystem_watch_enabled":watch_enabled,
             "long_tier_content_mutable":false,
+            "long_tier_tags_mutable":true,
             "trash_visible_through_mcp":false,
             "source_locking_description":"Source-locked foreign traces refuse update, delete, and remove outside their origin; archive and unarchive remain local visibility choices."
         })),
         authoring_tips: vec![
             "Prefer specific types over note.".into(),
             "Use tags for cross-cutting retrieval.".into(),
-            "Use set_trace_tags or append_trace_tags for tag cleanup; vote_trace is only a tier-preference signal.".into(),
+            "Use tag_stats and tag_doctor before cortex-wide tag cleanup; bulk tag tools preview unless apply=true.".into(),
+            "Use set_trace_tags or append_trace_tags for per-trace tag cleanup; vote_trace is only a tier-preference signal.".into(),
             "Set author to the human or agent responsible for the memory.".into(),
             "Keep public-facing content free of private hostnames, personal identifiers, cortex names, and secret-bearing output unless explicitly approved.".into(),
         ],
@@ -1831,6 +1999,37 @@ fn resolve_search_mode(
         return Ok((mode, None, String::new(), weight));
     };
     Ok((mode, Some(embedder), search.embedding_model.clone(), weight))
+}
+
+fn tag_plan_value(plan: &crate::tag::TagMutationPlan) -> serde_json::Value {
+    json!({
+        "matched_spellings":&plan.matched_spellings,
+        "matched_assignments":plan.matched_assignments(),
+        "affected_traces":plan.changes.len(),
+        "changes":&plan.changes,
+        "blocked_source_locked":&plan.blocked_source_locked,
+    })
+}
+
+fn apply_mcp_tag_plan(cx: &Cortex, plan: &crate::tag::TagMutationPlan) -> Result<usize> {
+    if !plan.blocked_source_locked.is_empty() {
+        bail!(
+            "{} source-locked trace(s) block this operation: {}",
+            plan.blocked_source_locked.len(),
+            plan.blocked_source_locked.join(", ")
+        );
+    }
+    let mut changed = 0;
+    for change in &plan.changes {
+        cx.set_tags(&change.id, change.after.clone(), true)
+            .with_context(|| {
+                format!(
+                    "bulk tag mutation stopped after {changed} successful trace mutation(s); rerun is safe"
+                )
+            })?;
+        changed += 1;
+    }
+    Ok(changed)
 }
 
 fn csv(value: &str) -> Vec<String> {
@@ -2003,6 +2202,73 @@ fn mcp_error(error: impl std::fmt::Display) -> ErrorData {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn bulk_tag_tools_preview_before_applying() {
+        let temp = tempfile::tempdir().unwrap();
+        Cortex::create("test", temp.path()).unwrap();
+        let root = temp.path().join("test");
+        let cx = Cortex::open("test", &root).unwrap();
+        let mut upper = Trace::new("Upper", "note", "", vec!["AI".into()], "alpha");
+        let upper_id = upper.frontmatter.id.clone();
+        cx.add(&mut upper).unwrap();
+        let mut lower = Trace::new("Lower", "note", "", vec!["ai".into()], "beta");
+        let lower_id = lower.frontmatter.id.clone();
+        cx.add(&mut lower).unwrap();
+        drop(cx);
+
+        let server = NoemaServer::new("test", &root, false).unwrap();
+        let preview = server
+            .rename_tag(Parameters(RenameTagParams {
+                old_tag: "AI".into(),
+                new_tag: "artificial-intelligence".into(),
+                ignore_case: true,
+                apply: false,
+            }))
+            .await
+            .unwrap();
+        let preview: serde_json::Value = serde_json::from_str(&preview).unwrap();
+        assert_eq!(preview["applied"], false);
+        assert_eq!(preview["plan"]["affected_traces"], 2);
+        let changes = preview["plan"]["changes"].as_array().unwrap();
+        assert!(
+            changes
+                .iter()
+                .any(|change| change["before"] == json!(["AI"]))
+        );
+        assert!(
+            changes
+                .iter()
+                .all(|change| { change["after"] == json!(["artificial-intelligence"]) })
+        );
+        {
+            let cx = server.open().await.unwrap();
+            assert_eq!(cx.get(&upper_id).unwrap().tags, vec!["AI"]);
+            assert_eq!(cx.get(&lower_id).unwrap().tags, vec!["ai"]);
+        }
+
+        let applied = server
+            .rename_tag(Parameters(RenameTagParams {
+                old_tag: "AI".into(),
+                new_tag: "artificial-intelligence".into(),
+                ignore_case: true,
+                apply: true,
+            }))
+            .await
+            .unwrap();
+        let applied: serde_json::Value = serde_json::from_str(&applied).unwrap();
+        assert_eq!(applied["applied"], true);
+        assert_eq!(applied["changed_traces"], 2);
+        let cx = server.open().await.unwrap();
+        assert_eq!(
+            cx.get(&upper_id).unwrap().tags,
+            vec!["artificial-intelligence"]
+        );
+        assert_eq!(
+            cx.get(&lower_id).unwrap().tags,
+            vec!["artificial-intelligence"]
+        );
+    }
 
     #[test]
     fn formats_compact_public_rows() {

--- a/src/tag.rs
+++ b/src/tag.rs
@@ -1,0 +1,350 @@
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt,
+};
+
+use serde::Serialize;
+
+use crate::cortex::Row;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TagIssue {
+    Whitespace,
+    Period,
+    Uppercase,
+    NumericOnly,
+    RepeatedHyphen,
+    EdgeHyphen,
+}
+
+impl fmt::Display for TagIssue {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Whitespace => "whitespace",
+            Self::Period => "period",
+            Self::Uppercase => "uppercase",
+            Self::NumericOnly => "numeric_only",
+            Self::RepeatedHyphen => "repeated_hyphen",
+            Self::EdgeHyphen => "edge_hyphen",
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TagDiagnostic {
+    pub tag: String,
+    pub trace_count: usize,
+    pub issues: Vec<TagIssue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub suggestion: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TagCollision {
+    pub destination: String,
+    pub sources: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct TagDoctorReport {
+    pub checked_tags: usize,
+    pub findings: Vec<TagDiagnostic>,
+    pub collisions: Vec<TagCollision>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct TagChange {
+    pub id: String,
+    pub before: Vec<String>,
+    pub after: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct TagMutationPlan {
+    pub matched_spellings: BTreeMap<String, usize>,
+    pub changes: Vec<TagChange>,
+    pub blocked_source_locked: Vec<String>,
+}
+
+impl TagMutationPlan {
+    pub fn matched_assignments(&self) -> usize {
+        self.matched_spellings.values().sum()
+    }
+}
+
+pub fn inspect(tag: &str) -> Vec<TagIssue> {
+    let mut issues = Vec::new();
+    if tag.chars().any(char::is_whitespace) {
+        issues.push(TagIssue::Whitespace);
+    }
+    if tag.contains('.') {
+        issues.push(TagIssue::Period);
+    }
+    if tag.chars().any(|character| character.is_ascii_uppercase()) {
+        issues.push(TagIssue::Uppercase);
+    }
+    if !tag.is_empty()
+        && tag
+            .chars()
+            .all(|character| character.is_ascii_digit() || matches!(character, '-' | '_'))
+    {
+        issues.push(TagIssue::NumericOnly);
+    }
+    if tag.contains("--") {
+        issues.push(TagIssue::RepeatedHyphen);
+    }
+    if tag.starts_with('-') || tag.ends_with('-') {
+        issues.push(TagIssue::EdgeHyphen);
+    }
+    issues
+}
+
+pub fn suggested_fix(tag: &str) -> Option<String> {
+    let issues = inspect(tag);
+    if issues.is_empty() || issues.contains(&TagIssue::NumericOnly) {
+        return None;
+    }
+
+    let mut output = String::new();
+    let mut pending_hyphen = false;
+    for character in tag.trim().chars() {
+        if character.is_whitespace() || matches!(character, '.' | '-') {
+            if !output.is_empty() {
+                pending_hyphen = true;
+            }
+            continue;
+        }
+        if pending_hyphen {
+            output.push('-');
+            pending_hyphen = false;
+        }
+        output.push(character.to_ascii_lowercase());
+    }
+    while output.ends_with('-') {
+        output.pop();
+    }
+    (!output.is_empty() && output != tag).then_some(output)
+}
+
+pub fn doctor(rows: &[Row]) -> TagDoctorReport {
+    let mut counts = BTreeMap::<String, usize>::new();
+    for row in rows {
+        for tag in &row.tags {
+            *counts.entry(tag.clone()).or_default() += 1;
+        }
+    }
+
+    let mut findings = Vec::new();
+    let mut destinations = BTreeMap::<String, BTreeSet<String>>::new();
+    for (tag, trace_count) in &counts {
+        let issues = inspect(tag);
+        if issues.is_empty() {
+            continue;
+        }
+        let suggestion = suggested_fix(tag);
+        if let Some(destination) = &suggestion {
+            destinations
+                .entry(destination.clone())
+                .or_default()
+                .insert(tag.clone());
+            if counts.contains_key(destination) {
+                destinations
+                    .entry(destination.clone())
+                    .or_default()
+                    .insert(destination.clone());
+            }
+        }
+        findings.push(TagDiagnostic {
+            tag: tag.clone(),
+            trace_count: *trace_count,
+            issues,
+            suggestion,
+        });
+    }
+
+    let collisions = destinations
+        .into_iter()
+        .filter_map(|(destination, sources)| {
+            (sources.len() > 1).then(|| TagCollision {
+                destination,
+                sources: sources.into_iter().collect(),
+            })
+        })
+        .collect();
+
+    TagDoctorReport {
+        checked_tags: counts.len(),
+        findings,
+        collisions,
+    }
+}
+
+pub fn rename_plan(
+    rows: &[Row],
+    cortex_name: &str,
+    old: &str,
+    new: &str,
+    ignore_case: bool,
+) -> TagMutationPlan {
+    mapping_plan(rows, cortex_name, |tag| {
+        matches_tag(tag, old, ignore_case).then(|| new.to_owned())
+    })
+}
+
+pub fn delete_plan(
+    rows: &[Row],
+    cortex_name: &str,
+    target: &str,
+    ignore_case: bool,
+) -> TagMutationPlan {
+    mapping_plan(rows, cortex_name, |tag| {
+        matches_tag(tag, target, ignore_case).then(String::new)
+    })
+}
+
+pub fn doctor_fix_plan(
+    rows: &[Row],
+    cortex_name: &str,
+    report: &TagDoctorReport,
+) -> TagMutationPlan {
+    let fixes: BTreeMap<_, _> = report
+        .findings
+        .iter()
+        .filter_map(|finding| {
+            finding
+                .suggestion
+                .as_ref()
+                .map(|suggestion| (finding.tag.clone(), suggestion.clone()))
+        })
+        .collect();
+    mapping_plan(rows, cortex_name, |tag| fixes.get(tag).cloned())
+}
+
+fn mapping_plan<F>(rows: &[Row], cortex_name: &str, mut replacement: F) -> TagMutationPlan
+where
+    F: FnMut(&str) -> Option<String>,
+{
+    let mut plan = TagMutationPlan::default();
+    for row in rows {
+        let mut matched = false;
+        let mut after = Vec::new();
+        let mut seen = BTreeSet::new();
+        for tag in &row.tags {
+            let next = match replacement(tag) {
+                Some(value) => {
+                    matched = true;
+                    *plan.matched_spellings.entry(tag.clone()).or_default() += 1;
+                    value
+                }
+                None => tag.clone(),
+            };
+            if !next.is_empty() && seen.insert(next.clone()) {
+                after.push(next);
+            }
+        }
+        if !matched || after == row.tags {
+            continue;
+        }
+        if row.source_locked && row.origin != cortex_name {
+            plan.blocked_source_locked.push(row.id.clone());
+            continue;
+        }
+        plan.changes.push(TagChange {
+            id: row.id.clone(),
+            before: row.tags.clone(),
+            after,
+        });
+    }
+    plan
+}
+
+fn matches_tag(candidate: &str, target: &str, ignore_case: bool) -> bool {
+    if ignore_case {
+        candidate.eq_ignore_ascii_case(target)
+    } else {
+        candidate == target
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(id: &str, tags: &[&str]) -> Row {
+        Row {
+            id: id.into(),
+            tags: tags.iter().map(|tag| (*tag).to_owned()).collect(),
+            origin: "local".into(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn doctor_reports_only_deterministic_fixes() {
+        let rows = vec![row(
+            "one",
+            &["Release.Candidate", "2026", "already-valid", "two  words"],
+        )];
+        let report = doctor(&rows);
+        assert_eq!(report.checked_tags, 4);
+        assert_eq!(report.findings.len(), 3);
+        assert_eq!(
+            report
+                .findings
+                .iter()
+                .find(|finding| finding.tag == "Release.Candidate")
+                .unwrap()
+                .suggestion,
+            Some("release-candidate".into())
+        );
+        assert_eq!(
+            report
+                .findings
+                .iter()
+                .find(|finding| finding.tag == "2026")
+                .unwrap()
+                .suggestion,
+            None
+        );
+        assert_eq!(
+            report
+                .findings
+                .iter()
+                .find(|finding| finding.tag == "two  words")
+                .unwrap()
+                .suggestion,
+            Some("two-words".into())
+        );
+    }
+
+    #[test]
+    fn ignore_case_rename_converges_variants_and_deduplicates() {
+        let rows = vec![row("one", &["AI", "ai", "other"]), row("two", &["Ai"])];
+        let plan = rename_plan(&rows, "local", "ai", "artificial-intelligence", true);
+        assert_eq!(plan.changes.len(), 2);
+        assert_eq!(plan.matched_spellings.len(), 3);
+        assert_eq!(
+            plan.changes[0].after,
+            vec!["artificial-intelligence", "other"]
+        );
+    }
+
+    #[test]
+    fn exact_delete_leaves_case_variants_untouched() {
+        let rows = vec![row("one", &["legacy", "Legacy", "current"])];
+        let plan = delete_plan(&rows, "local", "legacy", false);
+        assert_eq!(plan.changes[0].after, vec!["Legacy", "current"]);
+        assert_eq!(plan.matched_spellings.len(), 1);
+    }
+
+    #[test]
+    fn source_locked_foreign_rows_are_preflight_blocked() {
+        let mut locked = row("one", &["old"]);
+        locked.source_locked = true;
+        locked.origin = "publisher".into();
+        let plan = rename_plan(&[locked], "subscriber", "old", "new", false);
+        assert!(plan.changes.is_empty());
+        assert_eq!(plan.blocked_source_locked, ["one"]);
+    }
+}

--- a/tests/remove_semantics.rs
+++ b/tests/remove_semantics.rs
@@ -1,0 +1,95 @@
+use std::process::Command;
+
+use noema::{cortex::Cortex, trace::Trace};
+
+#[test]
+fn remove_force_overrides_source_lock_but_remains_recoverable() {
+    let temp = tempfile::tempdir().unwrap();
+    let config_home = temp.path().join("config");
+    let cortex_parent = temp.path().join("cortexes");
+    let binary = env!("CARGO_BIN_EXE_noema");
+
+    let init = Command::new(binary)
+        .env("XDG_CONFIG_HOME", &config_home)
+        .args([
+            "init",
+            "--name",
+            "remove-test",
+            "--path",
+            cortex_parent.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        init.status.success(),
+        "{}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let root = cortex_parent.join("remove-test");
+    let id = {
+        let cortex = Cortex::open("remove-test", &root).unwrap();
+        let mut trace = Trace::new("Forced trash", "fact", "", vec![], "recoverable");
+        trace.frontmatter.origin = "upstream".into();
+        trace.frontmatter.source_locked = true;
+        cortex.add(&mut trace).unwrap();
+        trace.frontmatter.id
+    };
+
+    let refused = Command::new(binary)
+        .env("XDG_CONFIG_HOME", &config_home)
+        .args(["--cortex", "remove-test", "remove", &id])
+        .output()
+        .unwrap();
+    assert!(!refused.status.success());
+
+    let removed = Command::new(binary)
+        .env("XDG_CONFIG_HOME", &config_home)
+        .args(["--cortex", "remove-test", "remove", &id, "--force"])
+        .output()
+        .unwrap();
+    assert!(
+        removed.status.success(),
+        "{}",
+        String::from_utf8_lossy(&removed.stderr)
+    );
+    let stdout = String::from_utf8(removed.stdout).unwrap();
+    assert!(stdout.contains("moved to trash"));
+    assert!(!stdout.contains("permanently"));
+
+    {
+        let cortex = Cortex::open("remove-test", &root).unwrap();
+        let row = cortex.get(&id).unwrap();
+        assert!(!row.trashed_at.is_empty());
+        assert!(cortex.trash_dir().join(format!("{id}.md")).is_file());
+        assert!(
+            cortex
+                .history(&id)
+                .unwrap()
+                .iter()
+                .any(|event| event.action == "trash")
+        );
+    }
+
+    let refused_recovery = Command::new(binary)
+        .env("XDG_CONFIG_HOME", &config_home)
+        .args(["--cortex", "remove-test", "recover", &id])
+        .output()
+        .unwrap();
+    assert!(!refused_recovery.status.success());
+
+    let recovered = Command::new(binary)
+        .env("XDG_CONFIG_HOME", &config_home)
+        .args(["--cortex", "remove-test", "recover", &id, "--force"])
+        .output()
+        .unwrap();
+    assert!(
+        recovered.status.success(),
+        "{}",
+        String::from_utf8_lossy(&recovered.stderr)
+    );
+
+    let cortex = Cortex::open("remove-test", &root).unwrap();
+    assert!(cortex.get(&id).unwrap().trashed_at.is_empty());
+    assert!(cortex.trace_file(&id, false).is_file());
+}

--- a/tests/rust-rewrite/compare.sh
+++ b/tests/rust-rewrite/compare.sh
@@ -208,14 +208,16 @@ test "$(sqlite3 "$cortex_parent/shared/db/noema.db" "SELECT count(*) FROM traces
 printf 'ok - Rust ceremonial soft and hard purge stays readable by Go\n'
 
 force_id=$(go_noema add \
-    --title "Rust force remove trace" \
+    --title "Rust forced trash trace" \
     --type note \
     --author go \
     --tag remove \
-    --body "force remove interoperability" | sed -n 's/^Trace added: //p')
+    --body "forced trash interoperability" | sed -n 's/^Trace added: //p')
 rust_noema remove --force "$force_id" >/dev/null
-test "$(sqlite3 "$cortex_parent/shared/db/noema.db" "SELECT count(*) FROM traces WHERE id='$force_id';")" -eq 0
-printf 'ok - Rust remove --force performs Go-compatible hard deletion\n'
+test "$(sqlite3 "$cortex_parent/shared/db/noema.db" "SELECT count(*) FROM traces WHERE id='$force_id' AND trashed_at IS NOT NULL;")" -eq 1
+rust_noema recover --force "$force_id" >/dev/null
+test "$(sqlite3 "$cortex_parent/shared/db/noema.db" "SELECT count(*) FROM traces WHERE id='$force_id' AND trashed_at IS NULL;")" -eq 1
+printf 'ok - Rust remove --force remains recoverable\n'
 
 collision_id=$(rust_noema add \
     --title "Rust collision trace" \


### PR DESCRIPTION
## What changed

- add `noema tags stats`, `rename`, `delete`, and `doctor` with aligned text and stable JSON output
- add matching MCP tools with explicit preview/apply semantics
- support opt-in ASCII case-insensitive bulk mutation and non-interactive `--yes`
- preserve long-tier bodies, identity fields, content hashes, and timestamps during tag-only mutations
- make `remove --force` override source locking without bypassing recoverable trash
- add `recover --force` for source-locked recovery and reserve hard deletion for explicit purge workflows
- carry the current Homebrew authentication fix and public Rust rationale from `main` back onto `next`

## Why

Noema had trace-level tag editing but no safe cortex-wide maintenance surface. Operators needed statistics, deterministic hygiene checks, and bulk changes that preview their full impact before mutation. During release qualification, `remove --force` was also found to contradict its recoverable-trash contract by hard-deleting immediately.

## Impact

Tag maintenance is available from both the CLI and MCP. Mutating CLI commands prompt with `y/N` unless `--dry-run` or `--yes` is supplied; MCP mutations require an explicit apply request. Existing trace content remains unchanged by tag-only operations. `remove --force` is now recoverable and consistently means only “override source-lock protection.”

## Validation

- `make test`
- `make release-check`
- `cd plugins/obsidian && npm ci --silent && npm run build && npx tsc --noEmit`
- `git diff --check`
- end-to-end forced trash/recovery regression in `tests/remove_semantics.rs`
- manual CLI validation of tag statistics, doctor plans/fixes, confirmation prompts, and deletion
