### PR TITLE
fix(release): eliminate Windows build warning

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,8 @@ jobs:
           test "$tag_version" = "$package_version"
 
       - name: Build release binary
+        env:
+          RUSTFLAGS: -D warnings
         run: cargo build --release --locked
 
       - name: Smoke-test version output

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3380,13 +3380,13 @@ fn setup_serve_logging(
         if unsafe { libc::dup2(file.as_raw_fd(), libc::STDERR_FILENO) } < 0 {
             return Err(std::io::Error::last_os_error()).context("redirecting stderr");
         }
+        Ok(())
     }
     #[cfg(not(unix))]
     {
         let _ = file;
         bail!("serve log redirection is not implemented on this platform");
     }
-    Ok(())
 }
 
 async fn serve(selected: Option<&str>, args: ServeArgs) -> Result<()> {


### PR DESCRIPTION
## Summary
- return directly from each platform-specific serve logging branch
- fail every release-matrix build on compiler warnings
- preserve the existing non-Unix behavior while removing unreachable code

## Validation
- `make test`
- `RUSTFLAGS="-D warnings" make release-check`
- `cargo fmt --check`
- `git diff --check`

The unpublished v0.21.0 workflow was cancelled and its tag removed before this correction.