### PR TITLE
fix(mcp): emit portable schema version metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "noema"
-version = "0.21.0"
+version = "0.21.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noema"
-version = "0.21.0"
+version = "0.21.1"
 edition = "2024"
 rust-version = "1.88"
 description = "The intentional memory layer for your AI agents"

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -381,8 +381,16 @@ enum TagMutationAction {
     Append,
 }
 
+fn schema_version_schema(_: &mut schemars::SchemaGenerator) -> schemars::Schema {
+    schemars::json_schema!({
+        "type": "integer",
+        "minimum": 0
+    })
+}
+
 #[derive(Debug, Serialize, JsonSchema)]
 struct CortexUsageOutput {
+    #[schemars(schema_with = "schema_version_schema")]
     schema_version: u32,
     cortex: BTreeMap<String, serde_json::Value>,
     contract: CortexContractOutput,
@@ -2202,6 +2210,16 @@ fn mcp_error(error: impl std::fmt::Display) -> ErrorData {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cortex_usage_schema_uses_portable_schema_version() {
+        let schema = serde_json::to_value(schemars::schema_for!(CortexUsageOutput)).unwrap();
+
+        assert_eq!(
+            schema["properties"]["schema_version"],
+            json!({"type": "integer", "minimum": 0})
+        );
+    }
 
     #[tokio::test]
     async fn bulk_tag_tools_preview_before_applying() {


### PR DESCRIPTION
## Summary

- emit schema_version as a portable non-negative integer schema without a client-specific uint32 format
- preserve the runtime u32 type and add regression coverage for the generated schema
- bump the package version to 0.21.1

## Validation

- make test
- make release-check
- isolated OpenCode 1.18.19 MCP discovery against the optimized v0.21.1 binary; connected without schema warnings