### PR TITLE
fix(federation): ignore retired clock keys during causal replay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "noema"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noema"
-version = "0.21.1"
+version = "0.21.2"
 edition = "2024"
 rust-version = "1.88"
 description = "The intentional memory layer for your AI agents"

--- a/src/cortex.rs
+++ b/src/cortex.rs
@@ -3637,7 +3637,7 @@ impl Cortex {
             && !local.vclock.is_empty()
             && !event.vclock.is_empty()
         {
-            match federation::compare(&local.vclock, &event.vclock) {
+            match federation::compare_for_replay(&local.vclock, &event.vclock) {
                 Relation::Concurrent => return self.create_divergence(&row, event),
                 Relation::After | Relation::Equal => return self.store_remote_event(event),
                 Relation::Before => {}
@@ -5937,6 +5937,49 @@ mod tests {
             .unwrap();
         assert_eq!(event.pubkey, public);
         eventsig::verify(&event.pubkey, &event, &event.signature).unwrap();
+    }
+
+    #[test]
+    fn replay_materializes_causal_update_after_legacy_clock_migration() {
+        let temp = tempfile::tempdir().unwrap();
+        Cortex::create("legacy-alpha", temp.path()).unwrap();
+        Cortex::create("legacy-beta", temp.path()).unwrap();
+        let alpha = Cortex::open("legacy-alpha", temp.path().join("legacy-alpha")).unwrap();
+        let beta = Cortex::open("legacy-beta", temp.path().join("legacy-beta")).unwrap();
+
+        let mut trace = Trace::new("Legacy replay", "fact", "", vec![], "historical body");
+        alpha.add(&mut trace).unwrap();
+        let trace_id = trace.frontmatter.id.clone();
+        let mut historical = event_for(&alpha, &trace_id, "create", &alpha.id);
+        historical.vclock.insert("legacy-alpha".into(), 19);
+        beta.replay_event(&historical).unwrap();
+
+        trace.body = "current body".into();
+        alpha.update_trace(&trace_id, &mut trace, false).unwrap();
+        let current = event_for(&alpha, &trace_id, "update", &alpha.id);
+        assert_eq!(
+            federation::compare(&historical.vclock, &current.vclock),
+            Relation::Concurrent
+        );
+
+        beta.replay_event(&current).unwrap();
+
+        assert_eq!(beta.get_trace(&trace_id).unwrap().1.body, "current body");
+        assert!(
+            beta.list(&ListOptions {
+                trace_type: "divergence".into(),
+                ..Default::default()
+            })
+            .unwrap()
+            .is_empty()
+        );
+        let stored_historical = beta
+            .history(&trace_id)
+            .unwrap()
+            .into_iter()
+            .find(|event| event.id == historical.id)
+            .unwrap();
+        assert_eq!(stored_historical.vclock, historical.vclock);
     }
 
     #[test]

--- a/src/federation.rs
+++ b/src/federation.rs
@@ -54,6 +54,38 @@ pub fn compare(left: &VectorClock, right: &VectorClock) -> Relation {
     }
 }
 
+pub fn compare_for_replay(left: &VectorClock, right: &VectorClock) -> Relation {
+    let relation = compare(left, right);
+    if relation != Relation::Concurrent
+        || !left
+            .keys()
+            .chain(right.keys())
+            .any(|key| ulid::Ulid::from_string(key).is_err())
+    {
+        return relation;
+    }
+
+    let stable_left: VectorClock = left
+        .iter()
+        .filter(|(key, _)| ulid::Ulid::from_string(key).is_ok())
+        .map(|(key, value)| (key.clone(), *value))
+        .collect();
+    let stable_right: VectorClock = right
+        .iter()
+        .filter(|(key, _)| ulid::Ulid::from_string(key).is_ok())
+        .map(|(key, value)| (key.clone(), *value))
+        .collect();
+    if stable_left.is_empty() || stable_right.is_empty() {
+        return relation;
+    }
+
+    match compare(&stable_left, &stable_right) {
+        Relation::Before => Relation::Before,
+        Relation::After => Relation::After,
+        Relation::Equal | Relation::Concurrent => relation,
+    }
+}
+
 pub fn merge(left: &mut VectorClock, right: &VectorClock) {
     for (key, value) in right {
         left.entry(key.clone())
@@ -778,11 +810,47 @@ fn public_keys_equal(left: &str, right: &str) -> bool {
 mod tests {
     use super::*;
 
+    const CORTEX_A: &str = "01KNJX4991ASW6NNKS9BQHNCGB";
+    const CORTEX_B: &str = "01KPAA8VQNG3TKMCY1XJ0JJG0Z";
+
     #[test]
     fn detects_concurrency() {
         let a = BTreeMap::from([("a".into(), 2), ("b".into(), 1)]);
         let b = BTreeMap::from([("a".into(), 1), ("b".into(), 2)]);
         assert_eq!(compare(&a, &b), Relation::Concurrent);
+    }
+
+    #[test]
+    fn replay_ignores_retired_name_key_when_stable_clocks_are_ordered() {
+        let historical = BTreeMap::from([
+            (CORTEX_A.into(), 10),
+            (CORTEX_B.into(), 20),
+            ("legacy-name".into(), 3),
+        ]);
+        let current = BTreeMap::from([(CORTEX_A.into(), 11), (CORTEX_B.into(), 21)]);
+
+        assert_eq!(compare(&historical, &current), Relation::Concurrent);
+        assert_eq!(compare_for_replay(&historical, &current), Relation::Before);
+    }
+
+    #[test]
+    fn replay_preserves_stable_id_concurrency() {
+        let left = BTreeMap::from([
+            (CORTEX_A.into(), 11),
+            (CORTEX_B.into(), 20),
+            ("legacy-name".into(), 3),
+        ]);
+        let right = BTreeMap::from([(CORTEX_A.into(), 10), (CORTEX_B.into(), 21)]);
+
+        assert_eq!(compare_for_replay(&left, &right), Relation::Concurrent);
+    }
+
+    #[test]
+    fn replay_preserves_ambiguous_legacy_only_concurrency() {
+        let legacy = BTreeMap::from([("legacy-name".into(), 3)]);
+        let current = BTreeMap::from([(CORTEX_A.into(), 11)]);
+
+        assert_eq!(compare_for_replay(&legacy, &current), Relation::Concurrent);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- prevent false divergence detection when a post-migration event is causally newer on every stable Cortex ID but an older event retains a retired name-key clock component
- preserve genuine stable-ID concurrency and ambiguous legacy-clock cases
- leave historical event clocks and signatures unchanged
- bump the patch version to 0.21.2

## Validation

- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test --all-targets --locked
- make release-check

The regression suite covers ordered stable clocks with a retired key, genuine stable-ID concurrency, legacy-only ambiguity, end-to-end replay materialization, and preservation of the stored historical clock.