### PR TITLE
release: v0.21.4 — safe sync reconciliation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "noema"
-version = "0.21.3"
+version = "0.21.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noema"
-version = "0.21.3"
+version = "0.21.4"
 edition = "2024"
 rust-version = "1.88"
 description = "The intentional memory layer for your AI agents"

--- a/README.md
+++ b/README.md
@@ -774,6 +774,21 @@ consolidation:
 
 Explicit curation is always available: `noema memory promote <id>` advances a trace one tier (short→mid or mid→long), and `noema memory demote <id>` steps mid→short. Long-term demotion goes through `noema memory purge` because undoing a base truth deserves the same ceremony as destroying it. Tags remain mutable retrieval metadata on every tier; retagging a long-term trace does not change its body, identity fields, content hash, or `updated` timestamp.
 
+If `noema sync` reports that a long-tier file has drifted from its immutable
+database/event history, preview the exact differences before repairing it:
+
+```bash
+noema memory reconcile <id>
+noema memory reconcile <id> --apply       # prompts for confirmation
+noema memory reconcile <id> --apply --yes # non-interactive
+```
+
+Reconciliation restores the canonical content-bearing event snapshot without
+changing the long-tier row. Before replacement, Noema retains the exact drifted
+bytes under the private `db/reconciliations/` directory and records an audited
+long-term divergence resolution. Substantive revisions should remain separate
+traces linked through `derived_from`; reconciliation is not an edit bypass.
+
 ### Automatic LLM distillation
 
 By default, `consolidation.llm_enabled: true` wires up the `noema consolidate` CLI but leaves the in-process agent on cheap heuristic-only work — you'd run the CLI from a separate system cron to get clusters distilled. Set `auto_distillation_enabled: true` to fold the LLM pipeline into every scheduled trigger instead, so each cron/idle/threshold fire runs **distillation → heuristic → graduation** in sequence on the elected peer.

--- a/migrations/020_normalize_legacy_reference_type.sql
+++ b/migrations/020_normalize_legacy_reference_type.sql
@@ -1,0 +1,27 @@
+-- `reference` was advertised by an older client but was never part of the
+-- canonical trace-type vocabulary. Some of those rows reached the immutable
+-- long tier before validation was enforced. Normalize only that exact legacy
+-- value; all other unknown types remain operator-visible validation failures.
+
+DROP TRIGGER IF EXISTS trg_long_term_immutable;
+
+UPDATE traces
+SET type = 'note'
+WHERE type = 'reference';
+
+CREATE TRIGGER trg_long_term_immutable
+BEFORE UPDATE ON traces
+WHEN OLD.tier = 'long' AND NEW.tier = 'long'
+  AND (OLD.title IS NOT NEW.title
+   OR OLD.type IS NOT NEW.type
+   OR OLD.author IS NOT NEW.author
+   OR OLD.origin IS NOT NEW.origin
+   OR OLD.cortex_id IS NOT NEW.cortex_id
+   OR OLD.content_hash IS NOT NEW.content_hash
+   OR OLD.source_locked IS NOT NEW.source_locked
+   OR OLD.source_hash IS NOT NEW.source_hash
+   OR OLD.created_at IS NOT NEW.created_at
+   OR OLD.updated_at IS NOT NEW.updated_at)
+BEGIN
+    SELECT RAISE(ABORT, 'long-term trace is immutable');
+END;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -329,6 +329,16 @@ enum MemoryCommand {
     Demote {
         trace_id: String,
     },
+    /// Preview or repair an on-disk file that drifted from immutable long-term history
+    Reconcile {
+        trace_id: String,
+        /// Restore the canonical event-backed file
+        #[arg(long)]
+        apply: bool,
+        /// Apply without an interactive confirmation prompt
+        #[arg(short = 'y', long, requires = "apply")]
+        yes: bool,
+    },
     Purge {
         trace_id: String,
         #[arg(long)]
@@ -879,17 +889,18 @@ async fn execute_cortex_command(cx: &mut Cortex, command: Command) -> Result<()>
         }
         Command::Sync { recover } => {
             let result = cx.sync_with_recovery(recover)?;
-            if recover {
-                println!(
-                    "Added: {}  Updated: {}  Drifted: {}  Recovered: {}  Orphaned: {}",
-                    result.added, result.updated, result.drifted, result.recovered, result.orphaned
-                );
-            } else {
-                println!(
-                    "Added: {}  Updated: {}  Drifted: {}  Orphaned: {}",
-                    result.added, result.updated, result.drifted, result.orphaned
-                );
+            for invalid in &result.invalid_files {
+                println!("INVALID {}", invalid.path);
+                println!("        {}", invalid.error);
             }
+            println!(
+                "Scanned: {}  Added: {}  Changed: {}  Unchanged: {}",
+                result.scanned, result.added, result.changed, result.unchanged
+            );
+            println!(
+                "Drifted: {}  Invalid: {}  Recovered: {}  Orphaned: {}",
+                result.drifted, result.invalid, result.recovered, result.orphaned
+            );
             if result.recovered > 0 {
                 println!(
                     "Note: recovered entries had missing files that were rebuilt from the local event log."
@@ -903,7 +914,7 @@ async fn execute_cortex_command(cx: &mut Cortex, command: Command) -> Result<()>
                     "      The DB row is left untouched (long-tier is immutable). Visibility was still reconciled."
                 );
                 println!(
-                    "      Use `noema get <id>` to inspect each trace's current file body. Drifted IDs:"
+                    "      Use `noema memory reconcile <id>` to preview a safe repair. Drifted IDs:"
                 );
                 for id in &result.drifted_ids {
                     println!("        {id}");
@@ -917,6 +928,10 @@ async fn execute_cortex_command(cx: &mut Cortex, command: Command) -> Result<()>
             }
             if result.orphaned > 0 {
                 println!("Note: orphaned entries are in the database but have no file on disk.");
+                println!("      Orphaned IDs:");
+                for id in &result.orphaned_ids {
+                    println!("        {id}");
+                }
                 if recover {
                     println!("      The local event log had no usable snapshot for these IDs.");
                     println!(
@@ -936,6 +951,12 @@ async fn execute_cortex_command(cx: &mut Cortex, command: Command) -> Result<()>
                         "      `noema memory purge <id> --tier <tier> --reason \"orphan cleanup\" --confirm --hard`."
                     );
                 }
+            }
+            if result.invalid > 0 {
+                bail!(
+                    "sync completed with {} invalid trace file(s); invalid files were not changed",
+                    result.invalid
+                );
             }
         }
         Command::Events {
@@ -2045,6 +2066,57 @@ fn memory_command(cx: &Cortex, command: MemoryCommand) -> Result<()> {
         MemoryCommand::Demote { trace_id } => {
             cx.demote(&trace_id)?;
             println!("Demoted {trace_id} to short");
+        }
+        MemoryCommand::Reconcile {
+            trace_id,
+            apply,
+            yes,
+        } => {
+            let plan = cx.long_term_reconciliation_plan(&trace_id)?;
+            println!("Long-tier reconciliation — {}", plan.id);
+            println!("  File: {}", plan.path);
+            println!("  Classification: {}", plan.classification);
+            if plan.drift_fields.is_empty() {
+                println!("  Drifted fields: none");
+                println!("  No repair is needed.");
+                return Ok(());
+            }
+            println!("  Drifted fields: {}", plan.drift_fields.join(", "));
+            println!("  Canonical event: {}", plan.canonical_event_id);
+            println!("  Canonical content: {}", plan.canonical_content_hash);
+            println!("  On-disk content: {}", plan.file_content_hash);
+            if plan.successors.is_empty() {
+                println!("  Derived successors: none");
+                println!(
+                    "  Warning: the drifted bytes will be retained in a private recovery artifact."
+                );
+            } else {
+                println!("  Derived successors:");
+                for successor in &plan.successors {
+                    println!("    {successor}");
+                }
+            }
+            println!("  Proposed action: restore the canonical event-backed long-tier file.");
+            if !apply {
+                println!(
+                    "  Preview only. Apply with `noema memory reconcile {} --apply`.",
+                    plan.id
+                );
+                return Ok(());
+            }
+            if !yes {
+                print!("Proceed? [y/N]: ");
+                io::stdout().flush()?;
+                if !matches!(read_line()?.as_str(), "y" | "Y" | "yes") {
+                    bail!("aborted by user");
+                }
+            }
+            let result = cx.reconcile_long_term(&trace_id)?;
+            println!(
+                "Reconciled {} from immutable event history.",
+                result.plan.id
+            );
+            println!("Recovery artifact: {}", result.recovery_artifact);
         }
         MemoryCommand::Purge {
             trace_id,

--- a/src/cortex.rs
+++ b/src/cortex.rs
@@ -656,12 +656,41 @@ pub struct OneSourceMidCount {
 
 #[derive(Debug, Clone, Default, Serialize)]
 pub struct SyncResult {
+    pub scanned: usize,
     pub added: usize,
-    pub updated: usize,
+    pub changed: usize,
+    pub unchanged: usize,
     pub recovered: usize,
     pub orphaned: usize,
+    pub orphaned_ids: Vec<String>,
     pub drifted: usize,
     pub drifted_ids: Vec<String>,
+    pub invalid: usize,
+    pub invalid_files: Vec<SyncInvalidFile>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SyncInvalidFile {
+    pub path: String,
+    pub error: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LongTermReconciliationPlan {
+    pub id: String,
+    pub path: String,
+    pub classification: String,
+    pub drift_fields: Vec<String>,
+    pub successors: Vec<String>,
+    pub canonical_event_id: String,
+    pub canonical_content_hash: String,
+    pub file_content_hash: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct LongTermReconciliationResult {
+    pub plan: LongTermReconciliationPlan,
+    pub recovery_artifact: String,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -1086,12 +1115,24 @@ impl Cortex {
             .read(true)
             .write(true)
             .open(&path_lock_path)?;
-        path_lock_file.try_lock_exclusive().with_context(|| {
-            format!(
-                "trace mutation is already in progress ({})",
-                path_lock_path.display()
-            )
-        })?;
+        let mut retries = 0;
+        loop {
+            match path_lock_file.try_lock_exclusive() {
+                Ok(()) => break,
+                Err(error) if error.kind() == std::io::ErrorKind::WouldBlock && retries < 5 => {
+                    retries += 1;
+                    std::thread::sleep(std::time::Duration::from_millis(5));
+                }
+                Err(error) => {
+                    return Err(error).with_context(|| {
+                        format!(
+                            "trace mutation is already in progress ({})",
+                            path_lock_path.display()
+                        )
+                    });
+                }
+            }
+        }
         Ok(path_lock_file)
     }
 
@@ -3028,7 +3069,7 @@ impl Cortex {
                 frontmatter: crate::trace::Frontmatter {
                     id: id.to_owned(),
                     title: data.title,
-                    trace_type: data.trace_type,
+                    trace_type: normalize_legacy_trace_type(&data.trace_type).into(),
                     tier: row.tier,
                     author: data.author,
                     tags: data.tags,
@@ -3039,6 +3080,7 @@ impl Cortex {
                     content_hash: data.content_hash,
                     source_hash: data.source_hash,
                     source_locked: data.source_locked,
+                    extra: Default::default(),
                 },
                 body: data.body,
             };
@@ -3236,7 +3278,12 @@ impl Cortex {
         let cutoff = (Utc::now() - Duration::days(days.into())).to_rfc3339();
         let ids: Vec<String> = {
             let mut statement = self.connection.prepare(
-                "SELECT id FROM traces WHERE trashed_at IS NOT NULL AND trashed_at < ?1",
+                "SELECT id FROM traces
+                 WHERE trashed_at IS NOT NULL
+                   AND trashed_at < ?1
+                   AND tier != 'long'
+                   AND purged_at IS NULL
+                 ORDER BY id",
             )?;
             statement
                 .query_map([cutoff], |row| row.get(0))?
@@ -3975,7 +4022,7 @@ impl Cortex {
             frontmatter: trace::Frontmatter {
                 id: event.trace_id.clone(),
                 title: data.title,
-                trace_type: data.trace_type,
+                trace_type: normalize_legacy_trace_type(&data.trace_type).into(),
                 tier,
                 author: data.author,
                 tags: dedupe(data.tags),
@@ -3990,6 +4037,7 @@ impl Cortex {
                 content_hash,
                 source_hash: data.source_hash,
                 source_locked: data.source_locked && event.cortex_id != self.id,
+                extra: Default::default(),
             },
             body: data.body,
         };
@@ -4135,6 +4183,178 @@ impl Cortex {
         Ok((parents, children))
     }
 
+    pub fn long_term_reconciliation_plan(&self, id: &str) -> Result<LongTermReconciliationPlan> {
+        let row = self.get(id)?;
+        if row.tier != "long" {
+            bail!(
+                "trace {id:?} is tier {:?}; reconciliation is only for long-tier drift",
+                row.tier
+            );
+        }
+        let path = self.file_path(&row);
+        let file_trace =
+            Trace::parse_file(&path).with_context(|| format!("reading drifted trace {id:?}"))?;
+        file_trace.validate()?;
+        let file_content_hash = trace::content_hash(&file_trace.body);
+        let (canonical_event_id, canonical) = self.canonical_long_term_trace(&row)?;
+        let mut drift_fields = Vec::new();
+        let file = &file_trace.frontmatter;
+        let expected = &canonical.frontmatter;
+        for (field, differs) in [
+            ("id", file.id != expected.id),
+            ("title", file.title != expected.title),
+            ("type", file.trace_type != expected.trace_type),
+            ("tier", file_trace.effective_tier() != expected.tier),
+            ("author", file.author != expected.author),
+            ("origin", file.origin != expected.origin),
+            ("created", file.created != expected.created),
+            ("updated", file.updated != expected.updated),
+            ("body", file_content_hash != expected.content_hash),
+            (
+                "content_hash",
+                file.content_hash != file_content_hash
+                    || file.content_hash != expected.content_hash,
+            ),
+            (
+                "source_locked",
+                file.source_locked != expected.source_locked,
+            ),
+            ("source_hash", file.source_hash != expected.source_hash),
+        ] {
+            if differs {
+                drift_fields.push(field.to_owned());
+            }
+        }
+        let (_, successors) = self.lineage(id)?;
+        Ok(LongTermReconciliationPlan {
+            id: id.to_owned(),
+            path: self.relative_trace_path(&path)?,
+            classification: if drift_fields.is_empty() {
+                "clean".into()
+            } else {
+                "restore-canonical".into()
+            },
+            drift_fields,
+            successors,
+            canonical_event_id,
+            canonical_content_hash: canonical.frontmatter.content_hash,
+            file_content_hash,
+        })
+    }
+
+    pub fn reconcile_long_term(&self, id: &str) -> Result<LongTermReconciliationResult> {
+        let plan = self.long_term_reconciliation_plan(id)?;
+        if plan.drift_fields.is_empty() {
+            bail!("trace {id:?} has no long-tier drift");
+        }
+        let row = self.get(id)?;
+        let path = self.file_path(&row);
+        let original_bytes = fs::read(&path)
+            .with_context(|| format!("reading drifted trace {id:?} for recovery artifact"))?;
+        let artifact_directory = self.dir.join("db/reconciliations");
+        fs::create_dir_all(&artifact_directory)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&artifact_directory, fs::Permissions::from_mode(0o700))?;
+        }
+        let artifact_name = format!("{id}-{}.md", ulid::Ulid::new());
+        let artifact_path = artifact_directory.join(&artifact_name);
+        trace::write_bytes_atomic_with_mode(&artifact_path, &original_bytes, 0o600)?;
+        let recovery_artifact = format!("db/reconciliations/{artifact_name}");
+        let (_, mut canonical) = self.canonical_long_term_trace(&row)?;
+        canonical.frontmatter.extra = Trace::parse(&original_bytes)?.frontmatter.extra;
+        let now = trace::now_rfc3339();
+        let event_data = json!({
+            "kind": "local_file_reconciliation",
+            "resolution": "restore_canonical",
+            "canonical_event_id": plan.canonical_event_id,
+            "canonical_content_hash": plan.canonical_content_hash,
+            "drifted_content_hash": plan.file_content_hash,
+            "drift_fields": plan.drift_fields,
+            "recovery_artifact": recovery_artifact,
+        });
+        self.replace_trace_transactionally(&path, &canonical, |pending_key| {
+            let tx = self.connection.unchecked_transaction()?;
+            self.emit_event(&tx, "divergence_long_term", id, &now, event_data)?;
+            Self::clear_pending_in_transaction(&tx, pending_key)?;
+            tx.commit()?;
+            Ok(())
+        })?;
+        Ok(LongTermReconciliationResult {
+            plan,
+            recovery_artifact,
+        })
+    }
+
+    fn canonical_long_term_trace(&self, row: &Row) -> Result<(String, Trace)> {
+        let event = self
+            .history(&row.id)?
+            .into_iter()
+            .rev()
+            .find(|event| matches!(event.action.as_str(), "create" | "update"))
+            .ok_or_else(|| anyhow::anyhow!("trace {:?} has no content-bearing event", row.id))?;
+        let data: TraceEventData = serde_json::from_value(event.data.clone())?;
+        let content_hash = trace::content_hash(&data.body);
+        if !data.content_hash.is_empty() && data.content_hash != content_hash {
+            bail!(
+                "trace {:?} event {} has an invalid content hash",
+                row.id,
+                event.id
+            );
+        }
+        let event_type = normalize_legacy_trace_type(&data.trace_type);
+        let event_origin = if data.origin.is_empty() {
+            row.origin.as_str()
+        } else {
+            data.origin.as_str()
+        };
+        let mut mismatches = Vec::new();
+        for (field, differs) in [
+            ("title", data.title != row.title),
+            ("type", event_type != row.trace_type),
+            ("author", data.author != row.author),
+            ("origin", event_origin != row.origin),
+            ("updated", event.timestamp != row.updated_at),
+            ("content_hash", content_hash != row.content_hash),
+            ("source_locked", data.source_locked != row.source_locked),
+            ("source_hash", data.source_hash != row.source_hash),
+        ] {
+            if differs {
+                mismatches.push(field);
+            }
+        }
+        if !mismatches.is_empty() {
+            bail!(
+                "trace {:?} DB row does not match latest content event {} in: {}",
+                row.id,
+                event.id,
+                mismatches.join(", ")
+            );
+        }
+        let trace = Trace {
+            frontmatter: trace::Frontmatter {
+                id: row.id.clone(),
+                title: row.title.clone(),
+                trace_type: row.trace_type.clone(),
+                tier: row.tier.clone(),
+                author: row.author.clone(),
+                tags: row.tags.clone(),
+                derived_from: row.derived_from.clone(),
+                origin: row.origin.clone(),
+                created: row.created_at.clone(),
+                updated: row.updated_at.clone(),
+                content_hash,
+                source_hash: row.source_hash.clone(),
+                source_locked: row.source_locked,
+                extra: Default::default(),
+            },
+            body: data.body,
+        };
+        trace.validate()?;
+        Ok((event.id, trace))
+    }
+
     pub fn sync(&self) -> Result<SyncResult> {
         self.sync_with_recovery(false)
     }
@@ -4158,22 +4378,58 @@ impl Cortex {
                 if path.extension().and_then(|ext| ext.to_str()) != Some("md") {
                     continue;
                 }
+                let relative_path = path
+                    .strip_prefix(&self.dir)
+                    .unwrap_or(&path)
+                    .to_string_lossy()
+                    .into_owned();
+                if let Some(id) = path
+                    .file_stem()
+                    .and_then(|stem| stem.to_str())
+                    .filter(|id| trace::is_valid_id(id))
+                {
+                    found.insert(id.to_owned());
+                }
                 let mut trace = match Trace::parse_file(&path) {
                     Ok(trace) => trace,
-                    Err(_) => continue,
+                    Err(error) => {
+                        result.invalid += 1;
+                        result.invalid_files.push(SyncInvalidFile {
+                            path: relative_path,
+                            error: error.to_string(),
+                        });
+                        continue;
+                    }
                 };
                 let id = trace.frontmatter.id.clone();
-                found.insert(id.clone());
-                let existing = self.get(&id).ok();
+                if trace::is_valid_id(&id) {
+                    found.insert(id.clone());
+                }
+                let existing = trace::is_valid_id(&id)
+                    .then(|| self.get(&id).ok())
+                    .flatten();
+                let repair_tier = existing
+                    .as_ref()
+                    .is_some_and(|row| trace.effective_tier() != row.tier);
                 if let Some(row) = &existing
-                    && trace.effective_tier() != row.tier
+                    && repair_tier
                 {
                     trace.frontmatter.tier = row.tier.clone();
+                }
+                if let Err(error) = trace.validate() {
+                    result.invalid += 1;
+                    result.invalid_files.push(SyncInvalidFile {
+                        path: relative_path,
+                        error: error.to_string(),
+                    });
+                    continue;
+                }
+                result.scanned += 1;
+                if repair_tier {
                     trace
                         .write_preserving_updated(&path)
                         .with_context(|| format!("repairing tier for {id}"))?;
                 }
-                trace.validate()?;
 
                 let archived_at = if archived {
                     Some(
@@ -4216,6 +4472,9 @@ impl Cortex {
                 let content_hash = trace::content_hash(&trace.body);
 
                 if let Some(row) = existing {
+                    let visibility_changed = row.archived_at
+                        != archived_at.as_deref().unwrap_or_default()
+                        || row.trashed_at != trashed_at.as_deref().unwrap_or_default();
                     if row.tier == "long" {
                         let drifted = row.title != trace.frontmatter.title
                             || row.trace_type != trace.frontmatter.trace_type
@@ -4236,8 +4495,10 @@ impl Cortex {
                             if result.drifted_ids.len() < 10 {
                                 result.drifted_ids.push(id);
                             }
+                        } else if visibility_changed {
+                            result.changed += 1;
                         } else {
-                            result.updated += 1;
+                            result.unchanged += 1;
                         }
                         continue;
                     }
@@ -4247,6 +4508,20 @@ impl Cortex {
                         trace.frontmatter.content_hash = content_hash.clone();
                         trace.frontmatter.updated = trace::now_rfc3339();
                     }
+                    let changed = repair_tier
+                        || needs_file_repair
+                        || row.title != trace.frontmatter.title
+                        || row.trace_type != trace.frontmatter.trace_type
+                        || row.author != trace.frontmatter.author
+                        || row.origin != trace.frontmatter.origin
+                        || row.cortex_id != cortex_id
+                        || row.updated_at != trace.frontmatter.updated
+                        || visibility_changed
+                        || row.content_hash != content_hash
+                        || row.source_locked != trace.frontmatter.source_locked
+                        || row.source_hash != trace.frontmatter.source_hash
+                        || !same_string_members(&row.tags, &trace.frontmatter.tags)
+                        || !same_string_members(&row.derived_from, &trace.frontmatter.derived_from);
                     let update_db = |pending_key: Option<&str>| -> Result<()> {
                         let tx = self.connection.unchecked_transaction()?;
                         let f = &trace.frontmatter;
@@ -4270,7 +4545,11 @@ impl Cortex {
                     } else {
                         update_db(None)?;
                     }
-                    result.updated += 1;
+                    if changed {
+                        result.changed += 1;
+                    } else {
+                        result.unchanged += 1;
+                    }
                 } else {
                     let needs_file_repair = trace.frontmatter.content_hash != content_hash;
                     if needs_file_repair {
@@ -4305,7 +4584,12 @@ impl Cortex {
             }
         }
         let db_ids: Vec<String> = {
-            let mut statement = self.connection.prepare("SELECT id FROM traces")?;
+            let query = if recover {
+                "SELECT id FROM traces WHERE purged_at IS NULL ORDER BY id"
+            } else {
+                "SELECT id FROM traces WHERE purged_at IS NULL AND trashed_at IS NULL ORDER BY id"
+            };
+            let mut statement = self.connection.prepare(query)?;
             statement
                 .query_map([], |row| row.get(0))?
                 .collect::<rusqlite::Result<_>>()?
@@ -4313,6 +4597,7 @@ impl Cortex {
         for id in db_ids.into_iter().filter(|id| !found.contains(id)) {
             if !recover {
                 result.orphaned += 1;
+                result.orphaned_ids.push(id);
                 continue;
             }
             if self
@@ -4322,6 +4607,7 @@ impl Cortex {
                 result.recovered += 1;
             } else {
                 result.orphaned += 1;
+                result.orphaned_ids.push(id);
             }
         }
         Ok(result)
@@ -4353,7 +4639,7 @@ impl Cortex {
             frontmatter: trace::Frontmatter {
                 id: id.to_owned(),
                 title: data.title,
-                trace_type: data.trace_type,
+                trace_type: normalize_legacy_trace_type(&data.trace_type).into(),
                 tier: row.tier,
                 author: data.author,
                 tags: data.tags,
@@ -4364,6 +4650,7 @@ impl Cortex {
                 content_hash: data.content_hash,
                 source_hash: data.source_hash,
                 source_locked: data.source_locked,
+                extra: Default::default(),
             },
             body: data.body,
         };
@@ -4760,6 +5047,13 @@ struct TraceEventData {
     source_hash: String,
     #[serde(default)]
     source_locked: bool,
+}
+
+fn normalize_legacy_trace_type(value: &str) -> &str {
+    match value {
+        "reference" => "note",
+        _ => value,
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -5333,6 +5627,16 @@ fn dedupe(values: Vec<String>) -> Vec<String> {
         .collect()
 }
 
+fn same_string_members(left: &[String], right: &[String]) -> bool {
+    left.iter()
+        .filter(|value| !value.is_empty())
+        .collect::<BTreeSet<_>>()
+        == right
+            .iter()
+            .filter(|value| !value.is_empty())
+            .collect::<BTreeSet<_>>()
+}
+
 pub fn sanitize_fts5_query(query: &str) -> String {
     let mut out = Vec::new();
     for token in query.split_whitespace() {
@@ -5778,8 +6082,10 @@ mod tests {
 
         let ordinary = cx.sync().unwrap();
         assert_eq!((ordinary.recovered, ordinary.orphaned), (0, 1));
+        assert_eq!(ordinary.orphaned_ids, vec![id.clone()]);
         let recovered = cx.sync_with_recovery(true).unwrap();
         assert_eq!((recovered.recovered, recovered.orphaned), (1, 0));
+        assert!(recovered.orphaned_ids.is_empty());
 
         let rebuilt = Trace::parse_file(&path).unwrap();
         let row = cx.get(&id).unwrap();
@@ -5812,6 +6118,138 @@ mod tests {
         assert_eq!(after.content_hash, before.content_hash);
         assert_eq!(after.updated_at, before.updated_at);
         assert_eq!(Trace::parse_file(&path).unwrap().body, "out-of-band edit");
+    }
+
+    #[test]
+    fn long_term_reconciliation_restores_event_snapshot_and_keeps_recovery_artifact() {
+        let (_temp, cx) = cortex();
+        let mut original = Trace::new(
+            "Immutable policy",
+            "preference",
+            "tester",
+            vec!["policy".into()],
+            "canonical body",
+        );
+        cx.add(&mut original).unwrap();
+        let id = original.frontmatter.id.clone();
+        cx.promote(&id, "mid").unwrap();
+        cx.promote(&id, "long").unwrap();
+        let before = cx.get(&id).unwrap();
+
+        let mut successor = Trace::new(
+            "Revised policy",
+            "preference",
+            "tester",
+            vec!["policy".into()],
+            "replacement policy",
+        );
+        successor.frontmatter.derived_from = vec![id.clone()];
+        let successor_id = successor.frontmatter.id.clone();
+        cx.add(&mut successor).unwrap();
+
+        let path = cx.file_path(&before);
+        let mut drifted = Trace::parse_file(&path).unwrap();
+        drifted.frontmatter.title = "Out-of-band title".into();
+        drifted.body = "out-of-band body".into();
+        drifted.frontmatter.content_hash = trace::content_hash(&drifted.body);
+        drifted
+            .frontmatter
+            .extra
+            .insert("access".into(), serde_yaml::Value::Null);
+        drifted.write_preserving_updated(&path).unwrap();
+        let drifted_bytes = fs::read(&path).unwrap();
+
+        let preview = cx.long_term_reconciliation_plan(&id).unwrap();
+        assert_eq!(preview.classification, "restore-canonical");
+        assert!(preview.drift_fields.contains(&"title".into()));
+        assert!(preview.drift_fields.contains(&"body".into()));
+        assert_eq!(preview.successors, vec![successor_id]);
+        assert_eq!(fs::read(&path).unwrap(), drifted_bytes);
+
+        let result = cx.reconcile_long_term(&id).unwrap();
+        let artifact = cx.dir.join(&result.recovery_artifact);
+        assert_eq!(fs::read(artifact).unwrap(), drifted_bytes);
+        let restored = Trace::parse_file(&path).unwrap();
+        assert_eq!(restored.frontmatter.title, before.title);
+        assert_eq!(restored.frontmatter.updated, before.updated_at);
+        assert_eq!(restored.frontmatter.content_hash, before.content_hash);
+        assert_eq!(
+            restored.frontmatter.extra.get("access"),
+            Some(&serde_yaml::Value::Null)
+        );
+        assert_eq!(restored.body, "canonical body");
+        assert_eq!(cx.get(&id).unwrap().content_hash, before.content_hash);
+        assert_eq!(cx.sync().unwrap().drifted, 0);
+        let audit = cx.history(&id).unwrap().pop().unwrap();
+        assert_eq!(audit.action, "divergence_long_term");
+        assert_eq!(audit.data["resolution"].as_str(), Some("restore_canonical"));
+    }
+
+    #[test]
+    fn reconciliation_rejects_non_long_trace_without_writing_artifact() {
+        let (_temp, cx) = cortex();
+        let mut trace = Trace::new("Mutable note", "note", "", vec![], "body");
+        cx.add(&mut trace).unwrap();
+        let id = trace.frontmatter.id.clone();
+
+        let error = cx.long_term_reconciliation_plan(&id).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("reconciliation is only for long-tier drift")
+        );
+        assert!(!cx.dir.join("db/reconciliations").exists());
+    }
+
+    #[test]
+    fn reconciliation_rejects_tampered_canonical_event_without_writing_artifact() {
+        let (_temp, cx) = cortex();
+        let mut trace = Trace::new("Immutable note", "note", "", vec![], "canonical body");
+        cx.add(&mut trace).unwrap();
+        let id = trace.frontmatter.id.clone();
+        cx.promote(&id, "mid").unwrap();
+        cx.promote(&id, "long").unwrap();
+        let path = cx.trace_file(&id, false);
+        let original_bytes = fs::read(&path).unwrap();
+        cx.connection
+            .execute(
+                "UPDATE events SET data=json_set(data,'$.body','tampered event body') WHERE trace_id=?1 AND action='create'",
+                [&id],
+            )
+            .unwrap();
+
+        let error = cx.long_term_reconciliation_plan(&id).unwrap_err();
+
+        assert!(error.to_string().contains("invalid content hash"));
+        assert_eq!(fs::read(path).unwrap(), original_bytes);
+        assert!(!cx.dir.join("db/reconciliations").exists());
+    }
+
+    #[test]
+    fn recovery_normalizes_legacy_reference_event_to_current_note_type() {
+        let (_temp, cx) = cortex();
+        let mut trace = Trace::new("Legacy reference", "note", "", vec![], "body");
+        cx.add(&mut trace).unwrap();
+        let id = trace.frontmatter.id.clone();
+        cx.promote(&id, "mid").unwrap();
+        cx.promote(&id, "long").unwrap();
+        cx.connection
+            .execute(
+                "UPDATE events SET data=json_set(data,'$.type','reference') WHERE trace_id=?1 AND action='create'",
+                [&id],
+            )
+            .unwrap();
+        let path = cx.trace_file(&id, false);
+        fs::remove_file(&path).unwrap();
+
+        let result = cx.sync_with_recovery(true).unwrap();
+
+        assert_eq!((result.recovered, result.orphaned), (1, 0));
+        assert_eq!(
+            Trace::parse_file(&path).unwrap().frontmatter.trace_type,
+            "note"
+        );
     }
 
     #[test]
@@ -5899,10 +6337,116 @@ mod tests {
 
         let result = cx.sync().unwrap();
         assert_eq!(result.added, 1);
+        assert_eq!(
+            (result.scanned, result.changed, result.unchanged),
+            (1, 0, 0)
+        );
         let repaired = Trace::parse_file(&path).unwrap();
         let expected = trace::content_hash("on disk");
         assert_eq!(repaired.frontmatter.content_hash, expected);
         assert_eq!(cx.get(&id).unwrap().content_hash, expected);
+    }
+
+    #[test]
+    fn sync_reports_invalid_files_and_continues_with_valid_files() {
+        let (_temp, cx) = cortex();
+        let mut valid = Trace::new("Valid drop-in", "note", "", vec![], "valid body");
+        valid.frontmatter.origin = cx.name.clone();
+        let valid_id = valid.frontmatter.id.clone();
+        valid
+            .write_preserving_updated(&cx.trace_file(&valid_id, false))
+            .unwrap();
+
+        let mut invalid = Trace::new("Legacy incident", "incident", "", vec![], "invalid body");
+        invalid.frontmatter.origin = cx.name.clone();
+        let invalid_id = invalid.frontmatter.id.clone();
+        let invalid_path = cx.trace_file(&invalid_id, false);
+        invalid.write_preserving_updated(&invalid_path).unwrap();
+        let invalid_bytes = fs::read(&invalid_path).unwrap();
+
+        let result = cx.sync().unwrap();
+
+        assert_eq!((result.added, result.invalid, result.orphaned), (1, 1, 0));
+        assert_eq!(
+            (result.scanned, result.changed, result.unchanged),
+            (1, 0, 0)
+        );
+        assert_eq!(result.invalid_files.len(), 1);
+        assert_eq!(
+            result.invalid_files[0].path,
+            format!("traces/{invalid_id}.md")
+        );
+        assert!(result.invalid_files[0].error.contains("incident"));
+        assert!(result.invalid_files[0].error.contains("expected one of"));
+        assert!(cx.get(&valid_id).is_ok());
+        assert!(cx.get(&invalid_id).is_err());
+        assert_eq!(fs::read(invalid_path).unwrap(), invalid_bytes);
+    }
+
+    #[test]
+    fn sync_recovery_does_not_overwrite_a_present_malformed_trace() {
+        let (_temp, cx) = cortex();
+        let mut trace = Trace::new("Malformed but present", "fact", "", vec![], "original");
+        cx.add(&mut trace).unwrap();
+        let id = trace.frontmatter.id.clone();
+        let path = cx.trace_file(&id, false);
+        let malformed = b"frontmatter is temporarily malformed\n";
+        fs::write(&path, malformed).unwrap();
+
+        let result = cx.sync_with_recovery(true).unwrap();
+
+        assert_eq!(
+            (result.invalid, result.recovered, result.orphaned),
+            (1, 0, 0)
+        );
+        assert_eq!(result.invalid_files[0].path, format!("traces/{id}.md"));
+        assert_eq!(fs::read(path).unwrap(), malformed);
+        assert!(cx.get(&id).is_ok());
+    }
+
+    #[test]
+    fn sync_distinguishes_changed_and_unchanged_existing_traces() {
+        let (_temp, cx) = cortex();
+        let mut trace = Trace::new("Accurate sync counts", "fact", "", vec![], "original");
+        cx.add(&mut trace).unwrap();
+        let id = trace.frontmatter.id.clone();
+        let path = cx.trace_file(&id, false);
+
+        let unchanged = cx.sync().unwrap();
+        assert_eq!(
+            (
+                unchanged.scanned,
+                unchanged.added,
+                unchanged.changed,
+                unchanged.unchanged,
+            ),
+            (1, 0, 0, 1)
+        );
+
+        let mut edited = Trace::parse_file(&path).unwrap();
+        edited.body = "edited on disk".into();
+        edited.write_preserving_updated(&path).unwrap();
+        let changed = cx.sync().unwrap();
+        assert_eq!(
+            (
+                changed.scanned,
+                changed.added,
+                changed.changed,
+                changed.unchanged,
+            ),
+            (1, 0, 1, 0)
+        );
+
+        let stable = cx.sync().unwrap();
+        assert_eq!(
+            (
+                stable.scanned,
+                stable.added,
+                stable.changed,
+                stable.unchanged,
+            ),
+            (1, 0, 0, 1)
+        );
     }
 
     #[test]
@@ -6261,6 +6805,76 @@ mod tests {
         assert!(cx.get(&id).is_err());
         assert_eq!(cx.history(&id).unwrap().last().unwrap().action, "purge");
         assert!(!cx.trash_dir().join(format!("{id}.md")).exists());
+    }
+
+    #[test]
+    fn expired_long_term_recovery_survives_reopen_and_repeated_sync() {
+        let (_temp, mut cx) = cortex();
+        let mut trace = Trace::new("Expired long trash", "preference", "", vec![], "body");
+        trace.frontmatter.tier = "long".into();
+        cx.add(&mut trace).unwrap();
+        let id = trace.frontmatter.id.clone();
+        cx.trash(&id).unwrap();
+        cx.connection
+            .execute(
+                "UPDATE traces SET trashed_at='2000-01-01T00:00:00Z' WHERE id=?1",
+                [&id],
+            )
+            .unwrap();
+        let path = cx.trash_dir().join(format!("{id}.md"));
+
+        assert_eq!(cx.purge_expired(30).unwrap(), 0);
+        assert!(path.exists());
+        assert_eq!(cx.history(&id).unwrap().last().unwrap().action, "trash");
+
+        fs::remove_file(&path).unwrap();
+        let root = cx.dir.clone();
+        drop(cx);
+
+        let recovered = Cortex::open("test", &root).unwrap();
+        let result = recovered.sync_with_recovery(true).unwrap();
+        assert_eq!((result.recovered, result.orphaned), (1, 0));
+        assert!(path.exists());
+        drop(recovered);
+
+        let stable = Cortex::open("test", &root).unwrap();
+        let result = stable.sync().unwrap();
+        assert_eq!((result.recovered, result.orphaned), (0, 0));
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn sync_does_not_recover_intentionally_fileless_long_term_tombstones() {
+        let (_temp, cx) = cortex();
+        let mut trace = Trace::new("Purged tombstone", "fact", "", vec![], "body");
+        trace.frontmatter.tier = "long".into();
+        cx.add(&mut trace).unwrap();
+        let id = trace.frontmatter.id.clone();
+        let path = cx.trace_file(&id, false);
+
+        cx.admin_purge(&id, "retention request", "long", false)
+            .unwrap();
+        assert!(!path.exists());
+
+        let result = cx.sync_with_recovery(true).unwrap();
+        assert_eq!((result.recovered, result.orphaned), (0, 0));
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn ordinary_sync_does_not_report_trashed_trace_as_orphaned() {
+        let (_temp, cx) = cortex();
+        let mut trace = Trace::new("Trashed trace", "preference", "", vec![], "body");
+        trace.frontmatter.tier = "long".into();
+        cx.add(&mut trace).unwrap();
+        let id = trace.frontmatter.id.clone();
+
+        cx.trash(&id).unwrap();
+        assert!(cx.trash_dir().join(format!("{id}.md")).exists());
+
+        let result = cx.sync().unwrap();
+        assert_eq!((result.recovered, result.orphaned), (0, 0));
+        assert!(result.orphaned_ids.is_empty());
     }
 
     #[test]

--- a/src/db.rs
+++ b/src/db.rs
@@ -103,7 +103,7 @@ mod tests {
                 row.get(0)
             })
             .unwrap();
-        assert_eq!(version, 19);
+        assert_eq!(version, 20);
         let fts: String = connection
             .query_row(
                 "SELECT sql FROM sqlite_master WHERE name='traces_fts'",
@@ -112,5 +112,40 @@ mod tests {
             )
             .unwrap();
         assert!(fts.contains("fts5"));
+    }
+
+    #[test]
+    fn normalizes_legacy_reference_rows_without_weakening_long_term_trigger() {
+        let temp = tempfile::tempdir().unwrap();
+        let connection = open(temp.path()).unwrap();
+        connection
+            .execute("DELETE FROM schema_migrations WHERE version=20", [])
+            .unwrap();
+        connection
+            .execute(
+                "INSERT INTO traces(id,title,type,tier,author,origin,cortex_id,created_at,updated_at,content_hash,source_locked)
+                 VALUES ('20260101-legacy-reference','Legacy reference','reference','long','','local','cortex','2026-01-01T00:00:00Z','2026-01-01T00:00:00Z','sha256:test',0)",
+                [],
+            )
+            .unwrap();
+
+        migrate(&connection).unwrap();
+
+        let trace_type: String = connection
+            .query_row(
+                "SELECT type FROM traces WHERE id='20260101-legacy-reference'",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(trace_type, "note");
+        assert!(
+            connection
+                .execute(
+                    "UPDATE traces SET title='Changed' WHERE id='20260101-legacy-reference'",
+                    [],
+                )
+                .is_err()
+        );
     }
 }

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::BTreeMap,
     fs::{self, OpenOptions},
     io::Write,
     path::Path,
@@ -52,6 +53,8 @@ pub struct Frontmatter {
     pub source_hash: String,
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub source_locked: bool,
+    #[serde(default, flatten)]
+    pub extra: BTreeMap<String, serde_yaml::Value>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -85,6 +88,7 @@ impl Trace {
                 content_hash: String::new(),
                 source_hash: String::new(),
                 source_locked: false,
+                extra: BTreeMap::new(),
             },
             body: body.into(),
         }
@@ -125,8 +129,9 @@ impl Trace {
         }
         if !VALID_TYPES.contains(&f.trace_type.as_str()) {
             bail!(
-                "invalid trace frontmatter: unrecognized type {:?}",
-                f.trace_type
+                "invalid trace frontmatter: unrecognized type {:?}; expected one of: {}",
+                f.trace_type,
+                VALID_TYPES.join(", ")
             );
         }
         if f.created.is_empty() || f.updated.is_empty() {
@@ -169,6 +174,10 @@ impl Trace {
 }
 
 pub(crate) fn write_bytes_atomic(path: &Path, data: &[u8]) -> Result<()> {
+    write_bytes_atomic_with_mode(path, data, 0o640)
+}
+
+pub(crate) fn write_bytes_atomic_with_mode(path: &Path, data: &[u8], mode: u32) -> Result<()> {
     let directory = path
         .parent()
         .ok_or_else(|| anyhow::anyhow!("trace path has no parent directory"))?;
@@ -181,7 +190,7 @@ pub(crate) fn write_bytes_atomic(path: &Path, data: &[u8]) -> Result<()> {
             .write(true)
             .create_new(true)
             .open(&temporary)?;
-        set_private_permissions(&temporary)?;
+        set_permissions(&temporary, mode)?;
         file.write_all(data)?;
         file.sync_all()?;
         drop(file);
@@ -203,7 +212,7 @@ fn write_bytes_compatible(path: &Path, data: &[u8]) -> Result<()> {
         .truncate(true)
         .open(path)?;
     if !existed {
-        set_private_permissions(path)?;
+        set_permissions(path, 0o640)?;
     }
     file.write_all(data)?;
     Ok(())
@@ -278,14 +287,14 @@ fn strip_leading_date_prefix(value: &str) -> &str {
 }
 
 #[cfg(unix)]
-fn set_private_permissions(path: &Path) -> Result<()> {
+fn set_permissions(path: &Path, mode: u32) -> Result<()> {
     use std::os::unix::fs::PermissionsExt;
-    fs::set_permissions(path, fs::Permissions::from_mode(0o640))?;
+    fs::set_permissions(path, fs::Permissions::from_mode(mode))?;
     Ok(())
 }
 
 #[cfg(not(unix))]
-fn set_private_permissions(_path: &Path) -> Result<()> {
+fn set_permissions(_path: &Path, _mode: u32) -> Result<()> {
     Ok(())
 }
 

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -476,6 +476,7 @@ impl Reconciler {
                 content_hash: trace::content_hash(&body),
                 source_hash: row.source_hash.clone(),
                 source_locked: row.source_locked,
+                extra: Default::default(),
             },
             body,
         };

--- a/tests/long_term_reconcile.rs
+++ b/tests/long_term_reconcile.rs
@@ -1,0 +1,179 @@
+use std::{fs, process::Command};
+
+use noema::{cortex::Cortex, trace::Trace};
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+#[test]
+fn reconcile_cli_previews_then_restores_long_term_file() {
+    let temp = tempfile::tempdir().unwrap();
+    let config_home = temp.path().join("config");
+    let cortex_parent = temp.path().join("cortexes");
+    let binary = env!("CARGO_BIN_EXE_noema");
+    let init = Command::new(binary)
+        .env("XDG_CONFIG_HOME", &config_home)
+        .args([
+            "init",
+            "--name",
+            "reconcile-test",
+            "--path",
+            cortex_parent.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        init.status.success(),
+        "{}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let root = cortex_parent.join("reconcile-test");
+    let cortex = Cortex::open("reconcile-test", &root).unwrap();
+    let mut original = Trace::new("Historical policy", "preference", "", vec![], "canonical");
+    cortex.add(&mut original).unwrap();
+    let id = original.frontmatter.id.clone();
+    cortex.promote(&id, "mid").unwrap();
+    cortex.promote(&id, "long").unwrap();
+    cortex.archive(&id).unwrap();
+    let path = cortex.trace_file(&id, true);
+
+    let mut successor = Trace::new("Current policy", "preference", "", vec![], "current");
+    successor.frontmatter.derived_from = vec![id.clone()];
+    let successor_id = successor.frontmatter.id.clone();
+    cortex.add(&mut successor).unwrap();
+
+    let mut drifted = Trace::parse_file(&path).unwrap();
+    drifted.body = "edited outside Noema".into();
+    drifted.frontmatter.content_hash = noema::trace::content_hash(&drifted.body);
+    drifted.write_preserving_updated(&path).unwrap();
+    let drifted_bytes = fs::read(&path).unwrap();
+    drop(cortex);
+
+    let preview = Command::new(binary)
+        .env("XDG_CONFIG_HOME", &config_home)
+        .args(["--cortex", "reconcile-test", "memory", "reconcile", &id])
+        .output()
+        .unwrap();
+    assert!(
+        preview.status.success(),
+        "{}",
+        String::from_utf8_lossy(&preview.stderr)
+    );
+    let preview_text = String::from_utf8(preview.stdout).unwrap();
+    assert!(preview_text.contains("Classification: restore-canonical"));
+    assert!(preview_text.contains(&format!("File: archive/traces/{id}.md")));
+    assert!(preview_text.contains("Drifted fields: body"));
+    assert!(preview_text.contains(&successor_id));
+    assert!(preview_text.contains("Preview only"));
+    assert_eq!(fs::read(&path).unwrap(), drifted_bytes);
+
+    let apply = Command::new(binary)
+        .env("XDG_CONFIG_HOME", &config_home)
+        .args([
+            "--cortex",
+            "reconcile-test",
+            "memory",
+            "reconcile",
+            &id,
+            "--apply",
+            "--yes",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        apply.status.success(),
+        "{}",
+        String::from_utf8_lossy(&apply.stderr)
+    );
+    let apply_text = String::from_utf8(apply.stdout).unwrap();
+    assert!(apply_text.contains("Reconciled"));
+    assert!(apply_text.contains("Recovery artifact: db/reconciliations/"));
+    assert_eq!(Trace::parse_file(&path).unwrap().body, "canonical");
+
+    let cortex = Cortex::open("reconcile-test", &root).unwrap();
+    assert_eq!(cortex.sync().unwrap().drifted, 0);
+    assert!(!cortex.get(&id).unwrap().archived_at.is_empty());
+    assert_eq!(cortex.lineage(&id).unwrap().1, vec![successor_id]);
+
+    let artifact_directory = root.join("db/reconciliations");
+    let artifacts: Vec<_> = fs::read_dir(&artifact_directory)
+        .unwrap()
+        .map(|entry| entry.unwrap().path())
+        .collect();
+    assert_eq!(artifacts.len(), 1);
+    assert_eq!(fs::read(&artifacts[0]).unwrap(), drifted_bytes);
+    #[cfg(unix)]
+    {
+        assert_eq!(
+            fs::metadata(&artifact_directory)
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o700
+        );
+        assert_eq!(
+            fs::metadata(&artifacts[0]).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+    }
+
+    let history = cortex.history(&id).unwrap();
+    let audit = history.last().unwrap();
+    assert_eq!(audit.action, "divergence_long_term");
+    assert_eq!(
+        audit.data["kind"].as_str(),
+        Some("local_file_reconciliation")
+    );
+    assert_eq!(audit.data["resolution"].as_str(), Some("restore_canonical"));
+    assert_eq!(
+        audit.data["recovery_artifact"].as_str(),
+        Some(artifacts[0].strip_prefix(&root).unwrap().to_str().unwrap())
+    );
+    let audit_count = history
+        .iter()
+        .filter(|event| event.action == "divergence_long_term")
+        .count();
+    drop(cortex);
+
+    let clean_preview = Command::new(binary)
+        .env("XDG_CONFIG_HOME", &config_home)
+        .args(["--cortex", "reconcile-test", "memory", "reconcile", &id])
+        .output()
+        .unwrap();
+    assert!(clean_preview.status.success());
+    let clean_preview_text = String::from_utf8(clean_preview.stdout).unwrap();
+    assert!(clean_preview_text.contains("Classification: clean"));
+    assert!(clean_preview_text.contains("No repair is needed"));
+
+    let second_apply = Command::new(binary)
+        .env("XDG_CONFIG_HOME", &config_home)
+        .args([
+            "--cortex",
+            "reconcile-test",
+            "memory",
+            "reconcile",
+            &id,
+            "--apply",
+            "--yes",
+        ])
+        .output()
+        .unwrap();
+    assert!(second_apply.status.success());
+    let second_apply_text = String::from_utf8(second_apply.stdout).unwrap();
+    assert!(second_apply_text.contains("Classification: clean"));
+    assert!(second_apply_text.contains("No repair is needed"));
+    assert_eq!(fs::read_dir(&artifact_directory).unwrap().count(), 1);
+
+    let cortex = Cortex::open("reconcile-test", &root).unwrap();
+    assert_eq!(
+        cortex
+            .history(&id)
+            .unwrap()
+            .iter()
+            .filter(|event| event.action == "divergence_long_term")
+            .count(),
+        audit_count
+    );
+}

--- a/tests/sync_diagnostics.rs
+++ b/tests/sync_diagnostics.rs
@@ -1,0 +1,87 @@
+use std::{fs, process::Command};
+
+use noema::{cortex::Cortex, trace::Trace};
+
+#[test]
+fn sync_reports_all_invalid_files_without_overwriting_them() {
+    let temp = tempfile::tempdir().unwrap();
+    let config_home = temp.path().join("config");
+    let cortex_parent = temp.path().join("cortexes");
+    let binary = env!("CARGO_BIN_EXE_noema");
+
+    let init = Command::new(binary)
+        .env("XDG_CONFIG_HOME", &config_home)
+        .args([
+            "init",
+            "--name",
+            "sync-test",
+            "--path",
+            cortex_parent.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        init.status.success(),
+        "{}",
+        String::from_utf8_lossy(&init.stderr)
+    );
+
+    let root = cortex_parent.join("sync-test");
+    let cortex = Cortex::open("sync-test", &root).unwrap();
+
+    let mut malformed = Trace::new("Malformed existing", "fact", "", vec![], "original");
+    cortex.add(&mut malformed).unwrap();
+    let malformed_id = malformed.frontmatter.id.clone();
+    let malformed_path = cortex.trace_file(&malformed_id, false);
+    let malformed_bytes = b"frontmatter is temporarily malformed\n";
+    fs::write(&malformed_path, malformed_bytes).unwrap();
+
+    let mut invalid = Trace::new("Legacy incident", "incident", "", vec![], "invalid");
+    invalid.frontmatter.origin = "sync-test".into();
+    let invalid_id = invalid.frontmatter.id.clone();
+    let invalid_path = cortex.trace_file(&invalid_id, false);
+    invalid.write_preserving_updated(&invalid_path).unwrap();
+    let invalid_bytes = fs::read(&invalid_path).unwrap();
+
+    let mut valid = Trace::new("Valid drop-in", "note", "", vec![], "valid");
+    valid.frontmatter.origin = "sync-test".into();
+    let valid_id = valid.frontmatter.id.clone();
+    valid
+        .write_preserving_updated(&cortex.trace_file(&valid_id, false))
+        .unwrap();
+
+    let mut orphan = Trace::new("Missing file", "note", "", vec![], "orphaned");
+    cortex.add(&mut orphan).unwrap();
+    let orphan_id = orphan.frontmatter.id.clone();
+    fs::remove_file(cortex.trace_file(&orphan_id, false)).unwrap();
+    drop(cortex);
+
+    let output = Command::new(binary)
+        .env("XDG_CONFIG_HOME", &config_home)
+        .args(["--cortex", "sync-test", "sync"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stderr = String::from_utf8(output.stderr).unwrap();
+    assert!(stdout.contains(&format!("INVALID traces/{malformed_id}.md")));
+    assert!(stdout.contains(&format!("INVALID traces/{invalid_id}.md")));
+    assert!(stdout.contains("unrecognized type \"incident\""));
+    assert!(stdout.contains("expected one of: fact, decision, preference"));
+    assert!(stdout.contains("Scanned: 1  Added: 1  Changed: 0  Unchanged: 0"));
+    assert!(stdout.contains("Drifted: 0  Invalid: 2  Recovered: 0  Orphaned: 1"));
+    assert!(stdout.contains("Orphaned IDs:"));
+    assert!(stdout.contains(&format!("        {orphan_id}")));
+    assert!(stderr.contains(
+        "Error: sync completed with 2 invalid trace file(s); invalid files were not changed"
+    ));
+
+    assert_eq!(fs::read(malformed_path).unwrap(), malformed_bytes);
+    assert_eq!(fs::read(invalid_path).unwrap(), invalid_bytes);
+    let cortex = Cortex::open("sync-test", &root).unwrap();
+    assert!(cortex.get(&malformed_id).is_ok());
+    assert!(cortex.get(&invalid_id).is_err());
+    assert!(cortex.get(&valid_id).is_ok());
+    assert!(cortex.get(&orphan_id).is_ok());
+}


### PR DESCRIPTION
## Summary

- continue sync past invalid trace files and report every invalid path with accepted trace types
- add preview-first long-tier reconciliation backed by immutable event history, private recovery artifacts, and audit events
- normalize legacy reference frontmatter to note through schema migration 20 without weakening long-tier immutability
- correct sync counts, orphan diagnostics, soft-trash handling, and long-tier retention safety
- bump the Rust package to v0.21.4

## User-visible behavior

- noema sync now processes valid files even when other files are invalid and reports a complete actionable summary
- noema memory reconcile ID previews drift fields, canonical history, and successors before any repair
- applying reconciliation preserves the exact displaced bytes in a private mode-0600 artifact
- ordinary sync no longer reports intentionally trashed traces as orphaned; sync --recover still restores genuinely missing files

## Validation

- git diff --check
- make test: 173 unit tests plus all integration and crash-recovery tests
- focused archived-trace reconciliation, idempotence, artifact mode, audit-event, lineage, tampered-history, legacy-migration, and trash-recovery regressions
- make release-check: optimized noema v0.21.4 artifact
- two consecutive live syncs before the version bump: Drifted 0, Invalid 0, Orphaned 0
- live cortex verification: 12 ok, 0 warn, 0 fail