### PR TITLE
release: v0.21.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1843,7 +1843,7 @@ dependencies = [
 
 [[package]]
 name = "noema"
-version = "0.21.5"
+version = "0.21.6"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noema"
-version = "0.21.5"
+version = "0.21.6"
 edition = "2024"
 rust-version = "1.88"
 description = "The intentional memory layer for your AI agents"


### PR DESCRIPTION
## Summary

- bump the Noema package version to 0.21.6
- publish the merged Obsidian plugin v0.4.0 in the release plugin archive
- retain the established six-platform binaries, checksums, and Homebrew update flow

## Validation

- `make test`
- `make release-check`
- `cd plugins/obsidian && npm ci && npm run build && npx tsc --noEmit`
- `cd plugins/obsidian && npm test`
- generated `dist/noema-obsidian-plugin.tar.gz` locally and verified its embedded manifest reports `0.4.0`
- `git diff --exit-code -- plugins/obsidian/main.js`

## Dependency audit

`npm audit` reports the existing moderate esbuild development-server advisory (GHSA-67mh-4wv8-2f99); npm reports no available fix. It does not affect the packaged runtime plugin.